### PR TITLE
Update references to provider parameters in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,11 @@ Simply provide the _name_ of the space (not the space ID)
 provider "octopusdeploy" {
   address = "http://octopus.production.yolo"
   api_key  = "API-XXXXXXXXXXXXX"
-  space   = "Support" // The name of the space
+  space_name = "Support" // The name of the space
 }
 ```
+
+You may also use a `space_id` property to scope the provider to a Space.
 
 ### Multiple spaces
 
@@ -61,7 +63,7 @@ provider "octopusdeploy" {
 
   address = "http://octopus.production.yolo"
   api_key  = "API-XXXXXXXXXXXXX"
-  space   = "Support" // The name of the space
+  space_name = "Support" // The name of the space
 }
 
 provider "octopusdeploy" {
@@ -69,7 +71,7 @@ provider "octopusdeploy" {
 
   address = "http://octopus.production.yolo"
   api_key  = "API-XXXXXXXXXXXXX"
-  space   = "Product1" // The name of another space
+  space_name = "Product1" // The name of another space
 }
 
 // This resource will use the default provider and the default space

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To use it, extract the binary for your platform into the same folder as your `.t
 
 provider "octopusdeploy" {
   address = "http://octopus.production.yolo"
-  apikey  = "API-XXXXXXXXXXXXX"
+  api_key  = "API-XXXXXXXXXXXXX"
 }
 ```
 
@@ -39,7 +39,7 @@ Simply provide the _name_ of the space (not the space ID)
 
 provider "octopusdeploy" {
   address = "http://octopus.production.yolo"
-  apikey  = "API-XXXXXXXXXXXXX"
+  api_key  = "API-XXXXXXXXXXXXX"
   space   = "Support" // The name of the space
 }
 ```
@@ -53,14 +53,14 @@ To manage resources in multiple spaces you currently must use multiple instances
 
 provider "octopusdeploy" {
   address = "http://octopus.production.yolo"
-  apikey  = "API-XXXXXXXXXXXXX"
+  api_key  = "API-XXXXXXXXXXXXX"
 }
 
 provider "octopusdeploy" {
   alias   = "space_support"
 
   address = "http://octopus.production.yolo"
-  apikey  = "API-XXXXXXXXXXXXX"
+  api_key  = "API-XXXXXXXXXXXXX"
   space   = "Support" // The name of the space
 }
 
@@ -68,7 +68,7 @@ provider "octopusdeploy" {
   alias   = "space_product1"
 
   address = "http://octopus.production.yolo"
-  apikey  = "API-XXXXXXXXXXXXX"
+  api_key  = "API-XXXXXXXXXXXXX"
   space   = "Product1" // The name of another space
 }
 


### PR DESCRIPTION
Looks like these changed at some point but this README was missed. It might be useful to even just scrap the current README and use some markdown includes from the `docs` directory to avoid duplication/maintenance. Let me know what you think.