### PR TITLE
fix: Fix user role creation and descriptions

### DIFF
--- a/octopusdeploy/resource_user_role_test.go
+++ b/octopusdeploy/resource_user_role_test.go
@@ -26,9 +26,33 @@ func TestAccUserRoleBasic(t *testing.T) {
 	})
 }
 
+func TestAccUserRolePermissions(t *testing.T) {
+	localName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	name := acctest.RandStringFromCharSet(16, acctest.CharSetAlpha)
+
+	resource.Test(t, resource.TestCase{
+		CheckDestroy: testAccUserRoleCheckDestroy,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testUserRolePermissions(localName, name),
+			},
+		},
+	})
+}
+
 func testUserRoleMinimum(localName string, name string) string {
 	return fmt.Sprintf(`resource "octopusdeploy_user_role" "%s" {
 		name = "%s"
+	}`, localName, name)
+}
+
+func testUserRolePermissions(localName string, name string) string {
+	return fmt.Sprintf(`resource "octopusdeploy_user_role" "%s" {
+		name                       = "%s"
+		granted_space_permissions  = ["AccountCreate"]
+		granted_system_permissions = ["SpaceView"]
 	}`, localName, name)
 }
 

--- a/octopusdeploy/schema_user_role.go
+++ b/octopusdeploy/schema_user_role.go
@@ -21,11 +21,11 @@ func expandUserRole(d *schema.ResourceData) *octopusdeploy.UserRole {
 	}
 
 	if v, ok := d.GetOk("granted_space_permissions"); ok {
-		userRole.GrantedSpacePermissions = v.([]string)
+		userRole.GrantedSpacePermissions = getSliceFromTerraformTypeList(v)
 	}
 
 	if v, ok := d.GetOk("granted_system_permissions"); ok {
-		userRole.GrantedSystemPermissions = v.([]string)
+		userRole.GrantedSystemPermissions = getSliceFromTerraformTypeList(v)
 	}
 
 	if v, ok := d.GetOk("name"); ok {
@@ -33,15 +33,15 @@ func expandUserRole(d *schema.ResourceData) *octopusdeploy.UserRole {
 	}
 
 	if v, ok := d.GetOk("space_permission_descriptions"); ok {
-		userRole.SpacePermissionDescriptions = v.([]string)
+		userRole.SpacePermissionDescriptions = getSliceFromTerraformTypeList(v)
 	}
 
 	if v, ok := d.GetOk("supported_restrictions"); ok {
-		userRole.SupportedRestrictions = v.([]string)
+		userRole.SupportedRestrictions = getSliceFromTerraformTypeList(v)
 	}
 
 	if v, ok := d.GetOk("system_permission_descriptions"); ok {
-		userRole.SystemPermissionDescriptions = v.([]string)
+		userRole.SystemPermissionDescriptions = getSliceFromTerraformTypeList(v)
 	}
 
 	return userRole
@@ -106,6 +106,7 @@ func getUserRoleSchema() map[string]*schema.Schema {
 		"id":   getIDSchema(),
 		"name": getNameSchema(true),
 		"space_permission_descriptions": {
+			Computed: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 			Optional: true,
 			Type:     schema.TypeList,
@@ -116,6 +117,7 @@ func getUserRoleSchema() map[string]*schema.Schema {
 			Type:     schema.TypeList,
 		},
 		"system_permission_descriptions": {
+			Computed: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 			Optional: true,
 			Type:     schema.TypeList,


### PR DESCRIPTION
Creating a user role with any list properties defined would cause
the provider to crash to a type conversion issue.

Specifying permissions without specify descriptions resulted in a
continuously tainted resource since they are returned by the api. 
Description attributes are now marked as computed and changes 
will not show in plan.

Fixes #149 