### PR TITLE
fix: Fix bad state for primary package references

### DIFF
--- a/docs/resources/deployment_process.md
+++ b/docs/resources/deployment_process.md
@@ -192,6 +192,10 @@ Optional:
 - **name** (String) The name of this resource.
 - **properties** (Map of String) A list of properties associated with this package.
 
+Read-Only:
+
+- **extract_during_deployment** (Boolean) Whether to extract the package during deployment
+
 
 
 <a id="nestedblock--step--apply_terraform_template_action"></a>
@@ -305,6 +309,10 @@ Optional:
 - **name** (String) The name of this resource.
 - **properties** (Map of String) A list of properties associated with this package.
 
+Read-Only:
+
+- **extract_during_deployment** (Boolean) Whether to extract the package during deployment
+
 
 <a id="nestedblock--step--apply_terraform_template_action--primary_package"></a>
 ### Nested Schema for `step.apply_terraform_template_action.primary_package`
@@ -320,6 +328,10 @@ Optional:
 - **id** (String) The unique ID for this resource.
 - **name** (String) The name of this resource.
 - **properties** (Map of String) A list of properties associated with this package.
+
+Read-Only:
+
+- **extract_during_deployment** (Boolean) Whether to extract the package during deployment
 
 
 <a id="nestedblock--step--apply_terraform_template_action--template"></a>
@@ -399,6 +411,10 @@ Optional:
 - **name** (String) The name of this resource.
 - **properties** (Map of String) A list of properties associated with this package.
 
+Read-Only:
+
+- **extract_during_deployment** (Boolean) Whether to extract the package during deployment
+
 
 
 <a id="nestedblock--step--deploy_package_action"></a>
@@ -443,6 +459,10 @@ Optional:
 - **name** (String) The name of this resource.
 - **properties** (Map of String) A list of properties associated with this package.
 
+Read-Only:
+
+- **extract_during_deployment** (Boolean) Whether to extract the package during deployment
+
 
 <a id="nestedblock--step--deploy_package_action--action_template"></a>
 ### Nested Schema for `step.deploy_package_action.action_template`
@@ -480,6 +500,10 @@ Optional:
 - **id** (String) The unique ID for this resource.
 - **name** (String) The name of this resource.
 - **properties** (Map of String) A list of properties associated with this package.
+
+Read-Only:
+
+- **extract_during_deployment** (Boolean) Whether to extract the package during deployment
 
 
 <a id="nestedblock--step--deploy_package_action--windows_service"></a>
@@ -556,6 +580,10 @@ Optional:
 - **name** (String) The name of this resource.
 - **properties** (Map of String) A list of properties associated with this package.
 
+Read-Only:
+
+- **extract_during_deployment** (Boolean) Whether to extract the package during deployment
+
 
 <a id="nestedblock--step--deploy_windows_service_action--action_template"></a>
 ### Nested Schema for `step.deploy_windows_service_action.action_template`
@@ -593,6 +621,10 @@ Optional:
 - **id** (String) The unique ID for this resource.
 - **name** (String) The name of this resource.
 - **properties** (Map of String) A list of properties associated with this package.
+
+Read-Only:
+
+- **extract_during_deployment** (Boolean) Whether to extract the package during deployment
 
 
 
@@ -659,6 +691,10 @@ Optional:
 - **id** (String) The unique ID for this resource.
 - **name** (String) The name of this resource.
 - **properties** (Map of String) A list of properties associated with this package.
+
+Read-Only:
+
+- **extract_during_deployment** (Boolean) Whether to extract the package during deployment
 
 
 
@@ -745,6 +781,10 @@ Optional:
 - **id** (String) The unique ID for this resource.
 - **name** (String) The name of this resource.
 - **properties** (Map of String) A list of properties associated with this package.
+
+Read-Only:
+
+- **extract_during_deployment** (Boolean) Whether to extract the package during deployment
 
 
 
@@ -834,6 +874,10 @@ Optional:
 - **id** (String) The unique ID for this resource.
 - **name** (String) The name of this resource.
 - **properties** (Map of String) A list of properties associated with this package.
+
+Read-Only:
+
+- **extract_during_deployment** (Boolean) Whether to extract the package during deployment
 
 ## Import
 

--- a/octopusdeploy/schema_package_reference.go
+++ b/octopusdeploy/schema_package_reference.go
@@ -33,12 +33,8 @@ func addPackagesSchema(element *schema.Resource, primaryIsRequired bool) {
 		Type:        schema.TypeString,
 	}
 
-	packageElementSchema["extract_during_deployment"] = &schema.Schema{
-		Computed:    true,
-		Description: "Whether to extract the package during deployment",
-		Optional:    true,
-		Type:        schema.TypeBool,
-	}
+	// Set the standard packages as optional so user can define.
+	packageElementSchema["extract_during_deployment"].Optional = true
 }
 
 func flattenPackageReference(packageReference octopusdeploy.PackageReference) map[string]interface{} {
@@ -69,6 +65,11 @@ func getPackageSchema(required bool) *schema.Schema {
 					Description: "Whether to acquire this package on the server ('Server'), target ('ExecutionTarget') or not at all ('NotAcquired'). Can be an expression",
 					Optional:    true,
 					Type:        schema.TypeString,
+				},
+				"extract_during_deployment": {
+					Computed:    true,
+					Description: "Whether to extract the package during deployment",
+					Type:        schema.TypeBool,
 				},
 				"feed_id": {
 					Default:     "feeds-builtin",


### PR DESCRIPTION
It is possible to put primary package references into a bad state with
legacy implementations of step actions and by setting the Extract
property on a primary package. This change adds the
`extract_during_deployment` property to primary packages but keeps it
read-only.