### PR TITLE
feat: Add project trigger resource

### DIFF
--- a/octopusdeploy/provider.go
+++ b/octopusdeploy/provider.go
@@ -72,6 +72,7 @@ func Provider() *schema.Provider {
 			"octopusdeploy_project":                                        resourceProject(),
 			"octopusdeploy_project_deployment_target_trigger":              resourceProjectDeploymentTargetTrigger(),
 			"octopusdeploy_project_group":                                  resourceProjectGroup(),
+			"octopusdeploy_project_trigger":                                resourceProjectTrigger(),
 			"octopusdeploy_scoped_user_role":                               resourceScopedUserRole(),
 			"octopusdeploy_space":                                          resourceSpace(),
 			"octopusdeploy_ssh_connection_deployment_target":               resourceSSHConnectionDeploymentTarget(),

--- a/octopusdeploy/resource_project_deployment_target_trigger.go
+++ b/octopusdeploy/resource_project_deployment_target_trigger.go
@@ -18,6 +18,7 @@ func resourceProjectDeploymentTargetTrigger() *schema.Resource {
 		ReadContext:   resourceProjectDeploymentTargetTriggerRead,
 		UpdateContext: resourceProjectDeploymentTargetTriggerUpdate,
 
+		DeprecationMessage: "The octopusdeploy_project_deployment_target_trigger is deprecated. Please utilize the octopusdeploy_project_trigger.",
 		Schema: map[string]*schema.Schema{
 			"name": getNameSchema(true),
 			"project_id": {

--- a/octopusdeploy/resource_project_trigger.go
+++ b/octopusdeploy/resource_project_trigger.go
@@ -1,0 +1,98 @@
+package octopusdeploy
+
+import (
+	"context"
+	"log"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/octopusdeploy"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceProjectTrigger() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceProjectTriggerCreate,
+		DeleteContext: resourceProjectTriggerDelete,
+		Description:   "This resource manages project triggers in Octopus Deploy.",
+		Importer:      getImporter(),
+		ReadContext:   resourceProjectTriggerRead,
+		Schema:        getProjectTriggerSchema(),
+		UpdateContext: resourceProjectTriggerUpdate,
+	}
+}
+
+func resourceProjectTriggerCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	projectTrigger := expandProjectTrigger(d)
+
+	log.Printf("[INFO] creating project trigger: %#v", projectTrigger)
+
+	client := m.(*octopusdeploy.Client)
+	createdProjectTrigger, err := client.ProjectTriggers.Add(projectTrigger)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := setProjectTrigger(ctx, d, createdProjectTrigger); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(createdProjectTrigger.GetID())
+
+	log.Printf("[INFO] project trigger created (%s)", d.Id())
+	return nil
+}
+
+func resourceProjectTriggerDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	log.Printf("[INFO] deleting project trigger (%s)", d.Id())
+
+	client := m.(*octopusdeploy.Client)
+	if err := client.ProjectTriggers.DeleteByID(d.Id()); err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] project trigger deleted (%s)", d.Id())
+	d.SetId("")
+	return nil
+}
+
+func resourceProjectTriggerRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	log.Printf("[INFO] reading project trigger (%s)", d.Id())
+
+	client := m.(*octopusdeploy.Client)
+	projectTrigger, err := client.ProjectTriggers.GetByID(d.Id())
+	if err != nil {
+		if apiError, ok := err.(*octopusdeploy.APIError); ok {
+			if apiError.StatusCode == 404 {
+				log.Printf("[INFO] project trigger (%s) not found; deleting from state", d.Id())
+				d.SetId("")
+				return nil
+			}
+		}
+		return diag.FromErr(err)
+	}
+
+	if err := setProjectTrigger(ctx, d, projectTrigger); err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] project trigger read (%s)", d.Id())
+	return nil
+}
+
+func resourceProjectTriggerUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	log.Printf("[INFO] updating project trigger (%s)", d.Id())
+
+	projectTrigger := expandProjectTrigger(d)
+	client := m.(*octopusdeploy.Client)
+	updatedProjectTrigger, err := client.ProjectTriggers.Update(*projectTrigger)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := setProjectTrigger(ctx, d, updatedProjectTrigger); err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] project trigger updated (%s)", d.Id())
+	return nil
+}

--- a/octopusdeploy/schema_project_trigger.go
+++ b/octopusdeploy/schema_project_trigger.go
@@ -1,0 +1,180 @@
+package octopusdeploy
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/octopusdeploy"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func expandProjectTriggerFilter(d map[string]interface{}) *octopusdeploy.TriggerFilter {
+	var vrd map[string]interface{}
+	if v, ok := d["cron"]; ok && len(v.([]interface{})) > 0 {
+		vrd = v.([]interface{})[0].(map[string]interface{})
+		vrd["filter_type"] = "CronExpressionSchedule"
+	}
+	if v, ok := d["once_daily"]; ok && len(v.([]interface{})) > 0 {
+		vrd = v.([]interface{})[0].(map[string]interface{})
+		vrd["filter_type"] = "OnceDailySchedule"
+	}
+	if v, ok := d["days_per_month"]; ok && len(v.([]interface{})) > 0 {
+		vrd = v.([]interface{})[0].(map[string]interface{})
+		vrd["filter_type"] = "DaysPerMonthSchedule"
+	}
+	if v, ok := d["continuous_daily"]; ok && len(v.([]interface{})) > 0 {
+		vrd = v.([]interface{})[0].(map[string]interface{})
+		vrd["filter_type"] = "ContinuousDailySchedule"
+	}
+	if v, ok := d["machine"]; ok && len(v.([]interface{})) > 0 {
+		vrd = v.([]interface{})[0].(map[string]interface{})
+		vrd["filter_type"] = "MachineFilter"
+	}
+	return expandTriggerFilter(vrd)
+}
+
+func flattenProjectTriggerFilter(triggerFilter *octopusdeploy.TriggerFilter) map[string]interface{} {
+	filter_type := ""
+	switch triggerFilter.FilterType {
+	case "CronExpressionSchedule":
+		filter_type = "cron"
+	case "ContinuousDailySchedule":
+		filter_type = "continuous_daily"
+	case "DaysPerMonthSchedule":
+		filter_type = "day_per_month"
+	case "MachineFilter":
+		filter_type = "machine"
+	case "OnceDailySchedule":
+		filter_type = "once_daily"
+	}
+	return map[string]interface{}{
+		filter_type: []interface{}{flattenTriggerFilter(triggerFilter)},
+	}
+}
+
+func getProjectTriggerFilterSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		MaxItems: 1,
+		Required: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"cron":             getCronScheduledTriggerFilterSchema(),
+				"once_daily":       getOnceDailyScheduledTriggerFilterSchema(),
+				"days_per_month":   getDaysPerMonthScheduledTriggerFilterSchema(),
+				"continuous_daily": getContinuousDailyScheduledTriggerFilterSchema(),
+				"machine":          getMachineTriggerFilterSchema(),
+			},
+		},
+	}
+}
+
+func expandProjectTriggerAction(d map[string]interface{}) *octopusdeploy.TriggerAction {
+	var vrd map[string]interface{}
+	if v, ok := d["auto_deploy"]; ok && len(v.([]interface{})) > 0 {
+		vrd = v.([]interface{})[0].(map[string]interface{})
+		vrd["action_type"] = "AutoDeploy"
+	}
+	if v, ok := d["deploy_latest"]; ok && len(v.([]interface{})) > 0 {
+		vrd = v.([]interface{})[0].(map[string]interface{})
+		vrd["action_type"] = "DeployLatestRelease"
+	}
+	if v, ok := d["deploy_new"]; ok && len(v.([]interface{})) > 0 {
+		vrd = v.([]interface{})[0].(map[string]interface{})
+		vrd["action_type"] = "DeployNewRelease"
+	}
+	return expandTriggerAction(vrd)
+}
+
+func flattenProjectTriggerAction(triggerAction *octopusdeploy.TriggerAction) map[string]interface{} {
+	action_type := ""
+	switch triggerAction.ActionType {
+	case "AutoDeploy":
+		action_type = "auto_deploy"
+	case "DeployLatestRelease":
+		action_type = "deploy_latest"
+	case "DeployNewRelease":
+		action_type = "deploy_new"
+	}
+	return map[string]interface{}{
+		action_type: []interface{}{flattenTriggerAction(triggerAction)},
+	}
+}
+
+func getProjectTriggerActionSchema() *schema.Schema {
+	autoDeploy := getAutoDeployTriggerActionSchema()
+	autoDeploy.ConflictsWith = []string{"filter.0.cron", "filter.0.once_daily", "filter.0.days_per_month", "filter.0.continuous_daily"}
+	autoDeploy.RequiredWith = []string{"filter.0.machine"}
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		MaxItems: 1,
+		Required: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"auto_deploy":   autoDeploy,
+				"deploy_latest": getDeployLatestReleaseTriggerActionSchema(),
+				"deploy_new":    getDeployNewReleaseTriggerActionSchema(),
+			},
+		},
+	}
+}
+
+func getProjectTriggerSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"description": getDescriptionSchema(),
+		"id":          getIDSchema(),
+		"name":        getNameSchema(true),
+		"space_id":    getSpaceIDSchema(),
+		"is_disabled": {
+			Type:        schema.TypeBool,
+			Description: "Whether the trigger is disabled or not.",
+			Default:     false,
+			Optional:    true,
+		},
+		"project_id": {
+			Type:        schema.TypeString,
+			Description: "The ID of the project to attach the trigger.",
+			Required:    true,
+		},
+		"action": makeMutuallyExclusive(getProjectTriggerActionSchema(), "action"),
+		"filter": makeMutuallyExclusive(getProjectTriggerFilterSchema(), "filter"),
+	}
+}
+
+func expandProjectTrigger(d *schema.ResourceData) *octopusdeploy.ProjectTrigger {
+	projectTrigger := octopusdeploy.NewProjectTrigger()
+	projectTrigger.ID = d.Id()
+	projectTrigger.Name = d.Get("name").(string)
+	projectTrigger.ProjectID = d.Get("project_id").(string)
+
+	if v, ok := d.GetOk("description"); ok {
+		projectTrigger.Description = v.(string)
+	}
+	if v, ok := d.GetOk("space_id"); ok {
+		projectTrigger.SpaceID = v.(string)
+	}
+	projectTrigger.Action = expandProjectTriggerAction(d.Get("action").([]interface{})[0].(map[string]interface{}))
+	projectTrigger.Filter = expandProjectTriggerFilter(d.Get("filter").([]interface{})[0].(map[string]interface{}))
+	return projectTrigger
+}
+
+func setProjectTrigger(ctx context.Context, d *schema.ResourceData, projectTrigger *octopusdeploy.ProjectTrigger) error {
+	d.Set("description", projectTrigger.Description)
+
+	d.Set("name", projectTrigger.Name)
+	d.Set("project_id", projectTrigger.ProjectID)
+	d.Set("space_id", projectTrigger.SpaceID)
+	d.Set("is_disabled", projectTrigger.IsDisabled)
+
+	d.SetId(projectTrigger.GetID())
+
+	if err := d.Set("action", []interface{}{flattenProjectTriggerAction(projectTrigger.Action)}); err != nil {
+		return fmt.Errorf("error setting action: %s", err)
+	}
+
+	if err := d.Set("filter", []interface{}{flattenProjectTriggerFilter(projectTrigger.Filter)}); err != nil {
+		return fmt.Errorf("error setting filter: %s", err)
+	}
+
+	return nil
+}

--- a/octopusdeploy/schema_trigger_action.go
+++ b/octopusdeploy/schema_trigger_action.go
@@ -1,0 +1,266 @@
+package octopusdeploy
+
+import (
+	"github.com/OctopusDeploy/go-octopusdeploy/octopusdeploy"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func expandTriggerAction(d map[string]interface{}) *octopusdeploy.TriggerAction {
+	triggerAction := octopusdeploy.NewTriggerAction()
+
+	if v, ok := d["id"]; ok {
+		triggerAction.ID = v.(string)
+	}
+	if v, ok := d["action_type"]; ok {
+		triggerAction.ActionType = v.(string)
+	}
+
+	switch triggerAction.ActionType {
+	case "AutoDeploy":
+		expandAutoDeployTriggerAction(triggerAction, d)
+	case "DeployLatestRelease":
+		expandDeployLatestReleaseTriggerAction(triggerAction, d)
+	case "DeployNewRelease":
+		expandDeployNewReleaseTriggerAction(triggerAction, d)
+	case "RunRunbook":
+		expandRunRunbookTriggerAction(triggerAction, d)
+	}
+	return triggerAction
+}
+
+func flattenTriggerAction(triggerAction *octopusdeploy.TriggerAction) map[string]interface{} {
+	if triggerAction == nil {
+		return nil
+	}
+	flattened := make(map[string]interface{})
+
+	flattened["action_type"] = triggerAction.ActionType
+	flattened["id"] = triggerAction.ID
+
+	switch triggerAction.ActionType {
+	case "AutoDeploy":
+		flattenAutoDeployTriggerAction(triggerAction, flattened)
+	case "DeployLatestRelease":
+		flattenDeployLatestReleaseTriggerAction(triggerAction, flattened)
+	case "DeployNewRelease":
+		flattenDeployNewReleaseTriggerAction(triggerAction, flattened)
+	case "RunRunbook":
+		flattenRunRunbookTriggerAction(triggerAction, flattened)
+	}
+	return flattened
+}
+
+func getTriggerActionSchema() (*schema.Schema, *schema.Resource) {
+	element := &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": getIDSchema(),
+			"action_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+	triggerActionSchema := &schema.Schema{
+		Type:     schema.TypeList,
+		MaxItems: 1,
+		Elem:     element,
+		Optional: true,
+	}
+	return triggerActionSchema, element
+}
+
+func flattenScopedDeploymentTriggerAction(triggerAction *octopusdeploy.TriggerAction, flattened map[string]interface{}) {
+	flattened["channel_id"] = triggerAction.ChannelID
+	flattened["tenant_ids"] = triggerAction.TenantIDs
+	flattened["tenant_tags"] = triggerAction.TenantTags
+}
+func expandScopedDeploymentTriggerAction(triggerAction *octopusdeploy.TriggerAction, d map[string]interface{}) {
+	if v, ok := d["channel_id"]; ok {
+		triggerAction.ChannelID = v.(string)
+	}
+	if v, ok := d["tenant_ids"]; ok {
+		triggerAction.TenantIDs = getSliceFromTerraformTypeList(v)
+	}
+	if v, ok := d["tenant_tags"]; ok {
+		triggerAction.TenantTags = getSliceFromTerraformTypeList(v)
+	}
+}
+func getScopedDeploymentTriggerActionSchema() *schema.Schema {
+	schema, element := getTriggerActionSchema()
+	addScopedDeploymentTriggerActionSchema(element)
+	return schema
+}
+
+func addScopedDeploymentTriggerActionSchema(element *schema.Resource) {
+	element.Schema["channel_id"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+	}
+	element.Schema["tenant_ids"] = &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Elem:     &schema.Schema{Type: schema.TypeString},
+	}
+	element.Schema["tenant_tags"] = &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Elem:     &schema.Schema{Type: schema.TypeString},
+	}
+}
+
+func flattenAutoDeployTriggerAction(triggerAction *octopusdeploy.TriggerAction, flattened map[string]interface{}) {
+	flattened["should_redeploy"] = triggerAction.ShouldRedeployWhenMachineHasBeenDeployedTo
+}
+func expandAutoDeployTriggerAction(triggerAction *octopusdeploy.TriggerAction, d map[string]interface{}) {
+	if v, ok := d["should_redeploy"]; ok {
+		triggerAction.ShouldRedeployWhenMachineHasBeenDeployedTo = v.(bool)
+	}
+}
+
+func getAutoDeployTriggerActionSchema() *schema.Schema {
+	schema, element := getTriggerActionSchema()
+	addAutoDeployTriggerActionSchema(element)
+	return schema
+}
+
+func addAutoDeployTriggerActionSchema(element *schema.Resource) {
+	element.Schema["should_redeploy"] = &schema.Schema{
+		Type:        schema.TypeBool,
+		Description: "Enable to re-deploy to the deployment targets even if they are already up-to-date with the current deployment.",
+		Required:    true,
+	}
+}
+
+func flattenRunRunbookTriggerAction(triggerAction *octopusdeploy.TriggerAction, flattened map[string]interface{}) {
+	flattened["runbook_id"] = triggerAction.RunbookID
+	flattened["environment_ids"] = triggerAction.SourceEnvironmentIDs
+	flattened["tenant_ids"] = triggerAction.TenantIDs
+	flattened["tenant_tagss"] = triggerAction.TenantTags
+}
+func expandRunRunbookTriggerAction(triggerAction *octopusdeploy.TriggerAction, d map[string]interface{}) {
+	if v, ok := d["runbook_id"]; ok {
+		triggerAction.RunbookID = v.(string)
+	}
+	if v, ok := d["environment_ids"]; ok {
+		triggerAction.SourceEnvironmentIDs = getSliceFromTerraformTypeList(v)
+	}
+	if v, ok := d["tenant_ids"]; ok {
+		triggerAction.TenantIDs = getSliceFromTerraformTypeList(v)
+	}
+	if v, ok := d["tenant_tags"]; ok {
+		triggerAction.TenantTags = getSliceFromTerraformTypeList(v)
+	}
+}
+
+func getRunRunbookTriggerActionSchema() *schema.Schema {
+	schema, element := getTriggerActionSchema()
+	addRunRunbookTriggerActionSchema(element)
+	return schema
+}
+func addRunRunbookTriggerActionSchema(element *schema.Resource) {
+	element.Schema["runbook_id"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Required: true,
+	}
+	element.Schema["environment_ids"] = &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Elem:     &schema.Schema{Type: schema.TypeString},
+	}
+	element.Schema["tenant_ids"] = &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Elem:     &schema.Schema{Type: schema.TypeString},
+	}
+	element.Schema["tenant_tags"] = &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Elem:     &schema.Schema{Type: schema.TypeString},
+	}
+}
+
+func flattenDeployNewReleaseTriggerAction(triggerAction *octopusdeploy.TriggerAction, flattened map[string]interface{}) {
+	flattenScopedDeploymentTriggerAction(triggerAction, flattened)
+	flattened["variables"] = triggerAction.Variables
+	flattened["destination_environment_id"] = triggerAction.DestinationEnvironmentID
+}
+func expandDeployNewReleaseTriggerAction(triggerAction *octopusdeploy.TriggerAction, d map[string]interface{}) {
+	expandScopedDeploymentTriggerAction(triggerAction, d)
+	if v, ok := d["variables"]; ok {
+		triggerAction.Variables = v.(string)
+	}
+	if v, ok := d["destination_environment_id"]; ok {
+		triggerAction.DestinationEnvironmentID = v.(string)
+	}
+}
+
+func getDeployNewReleaseTriggerActionSchema() *schema.Schema {
+	schema, element := getTriggerActionSchema()
+	addScopedDeploymentTriggerActionSchema(element)
+	addDeployNewReleaseTriggerActionSchema(element)
+	return schema
+}
+func addDeployNewReleaseTriggerActionSchema(element *schema.Resource) {
+	element.Schema["variables"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+	}
+	element.Schema["destination_environment_id"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Required: true,
+	}
+}
+
+func flattenDeployLatestReleaseTriggerAction(triggerAction *octopusdeploy.TriggerAction, flattened map[string]interface{}) {
+	flattenScopedDeploymentTriggerAction(triggerAction, flattened)
+	flattened["variables"] = triggerAction.Variables
+	flattened["destination_environment_id"] = triggerAction.DestinationEnvironmentID
+	flattened["source_environment_ids"] = triggerAction.SourceEnvironmentIDs
+	flattened["should_redeploy"] = triggerAction.RedeployCurrent
+}
+func expandDeployLatestReleaseTriggerAction(triggerAction *octopusdeploy.TriggerAction, d map[string]interface{}) {
+	expandScopedDeploymentTriggerAction(triggerAction, d)
+	if v, ok := d["variables"]; ok {
+		triggerAction.Variables = v.(string)
+	}
+	if v, ok := d["destination_environment_id"]; ok {
+		triggerAction.DestinationEnvironmentID = v.(string)
+	}
+	if v, ok := d["source_environment_ids"]; ok {
+		triggerAction.SourceEnvironmentIDs = getSliceFromTerraformTypeList(v)
+	}
+	if v, ok := d["should_redeploy"]; ok {
+		triggerAction.RedeployCurrent = v.(bool)
+	}
+}
+
+func getDeployLatestReleaseTriggerActionSchema() *schema.Schema {
+	schema, element := getTriggerActionSchema()
+	addScopedDeploymentTriggerActionSchema(element)
+	addDeployLatestReleaseTriggerActionSchema(element)
+	return schema
+}
+
+func addDeployLatestReleaseTriggerActionSchema(element *schema.Resource) {
+	element.Schema["variables"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+	}
+	element.Schema["source_environment_ids"] = &schema.Schema{
+		Type:     schema.TypeList,
+		Required: true,
+		Elem: &schema.Schema{
+			Type: schema.TypeString,
+		},
+	}
+	element.Schema["destination_environment_id"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Required: true,
+	}
+	element.Schema["should_redeploy"] = &schema.Schema{
+		Type:        schema.TypeBool,
+		Description: "Enable to re-deploy to the deployment targets even if they are already up-to-date with the current deployment.",
+		Default:     true,
+		Optional:    true,
+	}
+}

--- a/octopusdeploy/schema_trigger_filter.go
+++ b/octopusdeploy/schema_trigger_filter.go
@@ -1,0 +1,331 @@
+package octopusdeploy
+
+import (
+	"github.com/OctopusDeploy/go-octopusdeploy/octopusdeploy"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func expandTriggerFilter(d map[string]interface{}) *octopusdeploy.TriggerFilter {
+	triggerFilter := octopusdeploy.NewTriggerFilter()
+	if v, ok := d["id"]; ok {
+		triggerFilter.ID = v.(string)
+	}
+
+	if v, ok := d["filter_type"]; ok {
+		triggerFilter.FilterType = v.(string)
+	}
+
+	switch triggerFilter.FilterType {
+	case "ContinuousDailySchedule":
+		expandContinuousDailyScheduledTriggerFilter(triggerFilter, d)
+	case "CronExpressionSchedule":
+		expandCronScheduledTriggerFilter(triggerFilter, d)
+	case "DaysPerMonthSchedule":
+		expandDaysPerMonthScheduledTriggerFilter(triggerFilter, d)
+	case "MachineFilter":
+		expandMachineTriggerFilter(triggerFilter, d)
+	case "OnceDailySchedule":
+		expandOnceDailyScheduledTriggerFilter(triggerFilter, d)
+	}
+	return triggerFilter
+}
+
+func flattenTriggerFilter(triggerFilter *octopusdeploy.TriggerFilter) map[string]interface{} {
+	if triggerFilter == nil {
+		return nil
+	}
+	flattened := make(map[string]interface{})
+
+	flattened["filter_type"] = triggerFilter.FilterType
+	flattened["id"] = triggerFilter.ID
+	switch triggerFilter.FilterType {
+	case "ContinuousDailySchedule":
+		flattenContinuousDailyScheduledTriggerFilter(triggerFilter, flattened)
+	case "CronExpressionSchedule":
+		flattenCronScheduledTriggerFilter(triggerFilter, flattened)
+	case "DaysPerMonthSchedule":
+		flattenDaysPerMonthScheduledTriggerFilter(triggerFilter, flattened)
+	case "MachineFilter":
+		flattenMachineTriggerFilter(triggerFilter, flattened)
+	case "OnceDailySchedule":
+		flattenOnceDailyScheduledTriggerFilter(triggerFilter, flattened)
+	}
+	return flattened
+}
+
+func getTriggerFilterSchema() (*schema.Schema, *schema.Resource) {
+	element := &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": getIDSchema(),
+			"filter_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+	triggerFilterSchema := &schema.Schema{
+		Type:     schema.TypeList,
+		MaxItems: 1,
+		Elem:     element,
+		Optional: true,
+	}
+	return triggerFilterSchema, element
+}
+
+func expandMachineTriggerFilter(triggerFilter *octopusdeploy.TriggerFilter, d map[string]interface{}) {
+	if v, ok := d["environment_ids"]; ok {
+		triggerFilter.EnvironmentIDs = getSliceFromTerraformTypeList(v)
+	}
+	if v, ok := d["roles"]; ok {
+		triggerFilter.Roles = getSliceFromTerraformTypeList(v)
+	}
+	if v, ok := d["event_groups"]; ok {
+		triggerFilter.EventGroups = getSliceFromTerraformTypeList(v)
+	}
+	if v, ok := d["event_categories"]; ok {
+		triggerFilter.EventCategories = getSliceFromTerraformTypeList(v)
+	}
+}
+
+func flattenMachineTriggerFilter(triggerFilter *octopusdeploy.TriggerFilter, flattened map[string]interface{}) {
+	flattened["environment_ids"] = triggerFilter.EnvironmentIDs
+	flattened["roles"] = triggerFilter.Roles
+	flattened["event_groups"] = triggerFilter.EventGroups
+	flattened["event_categories"] = triggerFilter.EventCategories
+}
+
+func getMachineTriggerFilterSchema() *schema.Schema {
+	schema, element := getTriggerFilterSchema()
+	addMachineTriggerFilterSchema(element)
+	return schema
+}
+
+func addMachineTriggerFilterSchema(element *schema.Resource) {
+	element.Schema["environment_ids"] = &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Elem:     &schema.Schema{Type: schema.TypeString},
+	}
+	element.Schema["roles"] = &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Elem:     &schema.Schema{Type: schema.TypeString},
+	}
+	element.Schema["event_groups"] = &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Elem:     &schema.Schema{Type: schema.TypeString},
+	}
+	element.Schema["event_categories"] = &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Elem:     &schema.Schema{Type: schema.TypeString},
+	}
+}
+
+func expandScheduledTriggerFilter(triggerFilter *octopusdeploy.TriggerFilter, d map[string]interface{}) {
+	if v, ok := d["timezone"]; ok {
+		triggerFilter.Timezone = v.(string)
+	}
+}
+
+func flattenScheduledTriggerFilter(triggerFilter *octopusdeploy.TriggerFilter, flattened map[string]interface{}) {
+	flattened["timezone"] = triggerFilter.Timezone
+}
+
+func addScheduledTriggerFilterSchema(element *schema.Resource) {
+	element.Schema["timezone"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Default:  "UTC",
+		Optional: true,
+	}
+}
+
+func expandCronScheduledTriggerFilter(triggerFilter *octopusdeploy.TriggerFilter, d map[string]interface{}) {
+	expandScheduledTriggerFilter(triggerFilter, d)
+	if v, ok := d["cron_expression"]; ok {
+		triggerFilter.CronExpression = v.(string)
+	}
+}
+
+func flattenCronScheduledTriggerFilter(triggerFilter *octopusdeploy.TriggerFilter, flattened map[string]interface{}) {
+	flattenScheduledTriggerFilter(triggerFilter, flattened)
+	flattened["cron_expression"] = triggerFilter.CronExpression
+}
+
+func getCronScheduledTriggerFilterSchema() *schema.Schema {
+	schema, element := getTriggerFilterSchema()
+	addScheduledTriggerFilterSchema(element)
+	addCronScheduledTriggerFilterSchema(element)
+	return schema
+}
+
+func addCronScheduledTriggerFilterSchema(element *schema.Resource) {
+	element.Schema["cron_expression"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Required: true,
+	}
+}
+
+func expandContinuousDailyScheduledTriggerFilter(triggerFilter *octopusdeploy.TriggerFilter, d map[string]interface{}) {
+	expandScheduledTriggerFilter(triggerFilter, d)
+	if v, ok := d["run_after"]; ok {
+		triggerFilter.RunAfter = v.(string)
+	}
+	if v, ok := d["run_until"]; ok {
+		triggerFilter.RunUntil = v.(string)
+	}
+	if v, ok := d["interval"]; ok {
+		triggerFilter.Interval = v.(string)
+	}
+	if v, ok := d["hour_interval"]; ok {
+		triggerFilter.HourInterval = v.(int)
+	}
+	if v, ok := d["minute_interval"]; ok {
+		triggerFilter.MinuteInterval = v.(int)
+	}
+	if v, ok := d["days_of_week"]; ok {
+		triggerFilter.DaysOfWeek = getSliceFromTerraformTypeList(v)
+	}
+}
+
+func flattenContinuousDailyScheduledTriggerFilter(triggerFilter *octopusdeploy.TriggerFilter, flattened map[string]interface{}) {
+	flattenScheduledTriggerFilter(triggerFilter, flattened)
+	flattened["run_after"] = triggerFilter.RunAfter
+	flattened["run_until"] = triggerFilter.RunUntil
+	flattened["interval"] = triggerFilter.Interval
+	flattened["hour_interval"] = triggerFilter.HourInterval
+	flattened["minute_interval"] = triggerFilter.MinuteInterval
+	flattened["days_of_week"] = triggerFilter.DaysOfWeek
+}
+
+func getContinuousDailyScheduledTriggerFilterSchema() *schema.Schema {
+	schema, element := getTriggerFilterSchema()
+	addScheduledTriggerFilterSchema(element)
+	addContinuousDailyScheduledTriggerFilterSchema(element)
+	return schema
+}
+
+func addContinuousDailyScheduledTriggerFilterSchema(element *schema.Resource) {
+	element.Schema["run_after"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Required: true,
+	}
+	element.Schema["run_util"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Required: true,
+	}
+	element.Schema["interval"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Required: true,
+	}
+	element.Schema["hour_interval"] = &schema.Schema{
+		Type:     schema.TypeInt,
+		Optional: true,
+	}
+	element.Schema["minute_internal"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+	}
+	element.Schema["days_of_week"] = &schema.Schema{
+		Type: schema.TypeList,
+		Elem: &schema.Schema{
+			Type: schema.TypeString,
+		},
+		Optional: true,
+	}
+}
+
+func expandDaysPerMonthScheduledTriggerFilter(triggerFilter *octopusdeploy.TriggerFilter, d map[string]interface{}) {
+	expandScheduledTriggerFilter(triggerFilter, d)
+	if v, ok := d["start_time"]; ok {
+		triggerFilter.StartTime = v.(string)
+	}
+	if v, ok := d["monthly_schedule_type"]; ok {
+		triggerFilter.MonthlyScheduleType = v.(string)
+	}
+	if v, ok := d["date_of_month"]; ok {
+		triggerFilter.DateOfMonth = v.(string)
+	}
+	if v, ok := d["day_number_of_month"]; ok {
+		triggerFilter.DayNumberOfMonth = v.(string)
+	}
+	if v, ok := d["day_of_week"]; ok {
+		triggerFilter.DayOfWeek = v.(string)
+	}
+}
+
+func flattenDaysPerMonthScheduledTriggerFilter(triggerFilter *octopusdeploy.TriggerFilter, flattened map[string]interface{}) {
+	flattenScheduledTriggerFilter(triggerFilter, flattened)
+	flattened["start_time"] = triggerFilter.StartTime
+	flattened["monthly_schedule_type"] = triggerFilter.MonthlyScheduleType
+	flattened["date_of_month"] = triggerFilter.DateOfMonth
+	flattened["day_number_of_month"] = triggerFilter.DayNumberOfMonth
+	flattened["day_of_week"] = triggerFilter.DayOfWeek
+}
+
+func getDaysPerMonthScheduledTriggerFilterSchema() *schema.Schema {
+	schema, element := getTriggerFilterSchema()
+	addScheduledTriggerFilterSchema(element)
+	addDaysPerMonthScheduledTriggerFilterSchema(element)
+	return schema
+}
+
+func addDaysPerMonthScheduledTriggerFilterSchema(element *schema.Resource) {
+	element.Schema["start_time"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Required: true,
+	}
+	element.Schema["monthly_schedule_type"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Required: true,
+	}
+	element.Schema["date_of_month"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Required: true,
+	}
+	element.Schema["day_number_of_month"] = &schema.Schema{
+		Type:     schema.TypeInt,
+		Required: true,
+	}
+	element.Schema["day_of_week"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+	}
+}
+
+func expandOnceDailyScheduledTriggerFilter(triggerFilter *octopusdeploy.TriggerFilter, d map[string]interface{}) {
+	expandScheduledTriggerFilter(triggerFilter, d)
+	if v, ok := d["start_time"]; ok {
+		triggerFilter.StartTime = v.(string)
+	}
+	if v, ok := d["days_of_week"]; ok {
+		triggerFilter.DaysOfWeek = getSliceFromTerraformTypeList(v)
+	}
+}
+func flattenOnceDailyScheduledTriggerFilter(triggerFilter *octopusdeploy.TriggerFilter, flattened map[string]interface{}) {
+	flattenScheduledTriggerFilter(triggerFilter, flattened)
+	flattened["start_time"] = triggerFilter.StartTime
+	flattened["days_of_week"] = triggerFilter.DaysOfWeek
+}
+
+func getOnceDailyScheduledTriggerFilterSchema() *schema.Schema {
+	schema, element := getTriggerFilterSchema()
+	addScheduledTriggerFilterSchema(element)
+	addOnceDailyScheduledTriggerFilterSchema(element)
+	return schema
+}
+
+func addOnceDailyScheduledTriggerFilterSchema(element *schema.Resource) {
+	element.Schema["start_time"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Required: true,
+	}
+	element.Schema["days_of_week"] = &schema.Schema{
+		Type: schema.TypeList,
+		Elem: &schema.Schema{
+			Type: schema.TypeString,
+		},
+		Required: true,
+	}
+}

--- a/octopusdeploy/util.go
+++ b/octopusdeploy/util.go
@@ -1,6 +1,7 @@
 package octopusdeploy
 
 import (
+	"fmt"
 	"hash/crc32"
 	"log"
 	"strings"
@@ -106,4 +107,24 @@ func stringHashCode(s string) int {
 		return -v
 	}
 	return 0
+}
+
+func makeMutuallyExclusive(schemaBlock *schema.Schema, parent string) *schema.Schema {
+	if resource, ok := schemaBlock.Elem.(*schema.Resource); ok {
+		schema := resource.Schema
+		keys := make([]string, len(schema))
+		i := 0
+		for key := range schema {
+			if parent != "" {
+				keys[i] = fmt.Sprintf("%s.0.%s", parent, key)
+			} else {
+				keys[i] = key
+			}
+			i++
+		}
+		for _, value := range schema {
+			value.ExactlyOneOf = keys
+		}
+	}
+	return schemaBlock
 }


### PR DESCRIPTION
Project Trigger
---
Adds project triggers to the octopusdeploy provider.

#### Filter Types
Type | Supported
--- | ---
CronExpressionSchedule | Yes
ContinuousDailySchedule | Yes
DaysPerMonthSchedule | Yes
MachineFilter | Yes
OnceDailySchedule | Yes

#### Action Types
Type | Supported
--- | ---
AutoDeploy | Yes
DeployLatestRelease | Yes
DeployNewRelease | Yes
RunRunbook | No *(support exists, but not exposed)*

Runbook support can be added to the project trigger resource, or a separate octopusdeploy_runbook_trigger resource could be created.

### Changes
- Adds a  new resource `octopusdeploy_project_trigger`
- Deprecates the `octopusdeploy_project_deployment_target_trigger`


### TODO

- [ ] Documentation
- [ ] Tests

Depends on:
https://github.com/OctopusDeploy/go-octopusdeploy/pull/77