### PR TITLE
fix: Update octopusdeploy_deployment_process example to use run_script_action.

### DIFF
--- a/docs/resources/deployment_process.md
+++ b/docs/resources/deployment_process.md
@@ -20,24 +20,18 @@ resource "octopusdeploy_deployment_process" "example" {
     name                = "Hello world (using PowerShell)"
     package_requirement = "LetOctopusDecide"
     start_trigger       = "StartAfterPrevious"
-    action {
-      action_type                        = "Octopus.Script"
+    run_script_action {
       can_be_used_for_project_versioning = false
       condition                          = "Success"
       is_disabled                        = false
       is_required                        = true
       name                               = "Hello world (using PowerShell)"
-      properties = {
-        "Octopus.Action.RunOnServer"         = "true"
-        "Octopus.Action.Script.ScriptBody"   = <<-EOT
-                    Write-Host 'Hello world, using PowerShell'
-                    #TODO: Experiment with steps of your own :)
-                    Write-Host '[Learn more about the types of steps available in Octopus](https://g.octopushq.com/OnboardingAddStepsLearnMore)'
-                EOT
-        "Octopus.Action.Script.ScriptSource" = "Inline"
-        "Octopus.Action.Script.Syntax"       = "PowerShell"
-      }
-      run_on_server = false
+      script_body                        = <<-EOT
+          Write-Host 'Hello world, using PowerShell'
+          #TODO: Experiment with steps of your own :)
+          Write-Host '[Learn more about the types of steps available in Octopus](https://g.octopushq.com/OnboardingAddStepsLearnMore)'
+        EOT
+      run_on_server = true
     }
   }
   step {
@@ -45,24 +39,18 @@ resource "octopusdeploy_deployment_process" "example" {
     name                = "Hello world (using Bash)"
     package_requirement = "LetOctopusDecide"
     start_trigger       = "StartWithPrevious"
-    action {
-      action_type                        = "Octopus.Script"
+    run_script_action {
       can_be_used_for_project_versioning = false
       condition                          = "Success"
       is_disabled                        = false
       is_required                        = true
       name                               = "Hello world (using Bash)"
-      properties = {
-        "Octopus.Action.RunOnServer"         = "true"
-        "Octopus.Action.Script.ScriptBody"   = <<-EOT
-                    echo 'Hello world, using Bash'
-                    #TODO: Experiment with steps of your own :)
-                    echo '[Learn more about the types of steps available in Octopus](https://g.octopushq.com/OnboardingAddStepsLearnMore)'
-                EOT
-        "Octopus.Action.Script.ScriptSource" = "Inline"
-        "Octopus.Action.Script.Syntax"       = "Bash"
-      }
-      run_on_server = false
+      script_body                        = <<-EOT
+          echo 'Hello world, using Bash'
+          #TODO: Experiment with steps of your own :)
+          echo '[Learn more about the types of steps available in Octopus](https://g.octopushq.com/OnboardingAddStepsLearnMore)'
+        EOT
+      run_on_server = true
     }
   }
 }

--- a/examples/resources/octopusdeploy_deployment_process/resource.tf
+++ b/examples/resources/octopusdeploy_deployment_process/resource.tf
@@ -5,24 +5,18 @@ resource "octopusdeploy_deployment_process" "example" {
     name                = "Hello world (using PowerShell)"
     package_requirement = "LetOctopusDecide"
     start_trigger       = "StartAfterPrevious"
-    action {
-      action_type                        = "Octopus.Script"
+    run_script_action {
       can_be_used_for_project_versioning = false
       condition                          = "Success"
       is_disabled                        = false
       is_required                        = true
       name                               = "Hello world (using PowerShell)"
-      properties = {
-        "Octopus.Action.RunOnServer"         = "true"
-        "Octopus.Action.Script.ScriptBody"   = <<-EOT
-                    Write-Host 'Hello world, using PowerShell'
-                    #TODO: Experiment with steps of your own :)
-                    Write-Host '[Learn more about the types of steps available in Octopus](https://g.octopushq.com/OnboardingAddStepsLearnMore)'
-                EOT
-        "Octopus.Action.Script.ScriptSource" = "Inline"
-        "Octopus.Action.Script.Syntax"       = "PowerShell"
-      }
-      run_on_server = false
+      script_body                        = <<-EOT
+          Write-Host 'Hello world, using PowerShell'
+          #TODO: Experiment with steps of your own :)
+          Write-Host '[Learn more about the types of steps available in Octopus](https://g.octopushq.com/OnboardingAddStepsLearnMore)'
+        EOT
+      run_on_server                      = true
     }
   }
   step {
@@ -30,24 +24,18 @@ resource "octopusdeploy_deployment_process" "example" {
     name                = "Hello world (using Bash)"
     package_requirement = "LetOctopusDecide"
     start_trigger       = "StartWithPrevious"
-    action {
-      action_type                        = "Octopus.Script"
+    run_script_action {
       can_be_used_for_project_versioning = false
       condition                          = "Success"
       is_disabled                        = false
       is_required                        = true
       name                               = "Hello world (using Bash)"
-      properties = {
-        "Octopus.Action.RunOnServer"         = "true"
-        "Octopus.Action.Script.ScriptBody"   = <<-EOT
-                    echo 'Hello world, using Bash'
-                    #TODO: Experiment with steps of your own :)
-                    echo '[Learn more about the types of steps available in Octopus](https://g.octopushq.com/OnboardingAddStepsLearnMore)'
-                EOT
-        "Octopus.Action.Script.ScriptSource" = "Inline"
-        "Octopus.Action.Script.Syntax"       = "Bash"
-      }
-      run_on_server = false
+      script_body                        = <<-EOT
+          echo 'Hello world, using Bash'
+          #TODO: Experiment with steps of your own :)
+          echo '[Learn more about the types of steps available in Octopus](https://g.octopushq.com/OnboardingAddStepsLearnMore)'
+        EOT
+      run_on_server                      = true
     }
   }
 }


### PR DESCRIPTION
This updates the documentation and example to use the `run_script_action`. The current example throws an error due to the mismatch in `action` vs. `run_script_action`.

Fixes #246