### PR TITLE
Update make file to be OS agnostic for local builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,18 @@ NAMESPACE=com
 NAME=octopusdeploy
 BINARY=terraform-provider-${NAME}
 VERSION=0.7.64
-OS_ARCH?=darwin_amd64
 
 ifeq ($(OS), Windows_NT)
+OS_ARCH?=windows_amd64
 PROFILE=${APPDATA}/terraform.d
 EXT=.exe
 else
 PROFILE=~/.terraform.d
+ifeq ($(shell uname), Linux)
+OS_ARCH?=linux_amd64
+else
+OS_ARCH?=darwin_amd64
+endif
 endif
 
 default: install


### PR DESCRIPTION
I noticed I had to update the value for the `OS_ARCH` env var in the `Makefile` for the plugin when running locally as I am running linux (it was putting the built plugin in the wrong directory). 

I've updated it so it will detect what OS you're running and change the `OS_ARCH` accordingly.