### PR TITLE
Project schema wasn't including SpaceID in the data to send to Octopus

### DIFF
--- a/octopusdeploy/schema_project.go
+++ b/octopusdeploy/schema_project.go
@@ -85,6 +85,10 @@ func expandProject(d *schema.ResourceData) *octopusdeploy.Project {
 		project.Slug = v.(string)
 	}
 
+	if v, ok := d.GetOk("space_id"); ok {
+		project.SpaceID = v.(string)
+	}
+
 	if v, ok := d.GetOk("template"); ok {
 		project.Templates = expandActionTemplateParameters(v.([]interface{}))
 	}


### PR DESCRIPTION
The project schema was retrieving the SpaceID, and correctly putting it into state but was forgetting to add it back into the object that was being sent to the Octopus API.

Fixes #294 