### PR TITLE
Config was using Name search for Spaces

### DIFF
--- a/octopusdeploy/config.go
+++ b/octopusdeploy/config.go
@@ -1,7 +1,10 @@
 package octopusdeploy
 
 import (
+	"fmt"
+	"log"
 	"net/url"
+	"strings"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/octopusdeploy"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -28,6 +31,7 @@ func (c *Config) Client() (*octopusdeploy.Client, diag.Diagnostics) {
 	}
 
 	if len(c.SpaceID) > 0 {
+		log.Printf("[DEBUG] Config is locating space using ID '%s'", c.SpaceID)
 		space, err := client.Spaces.GetByID(c.SpaceID)
 		if err != nil {
 			return nil, diag.FromErr(err)
@@ -40,18 +44,37 @@ func (c *Config) Client() (*octopusdeploy.Client, diag.Diagnostics) {
 	}
 
 	if len(c.SpaceName) > 0 {
+		log.Printf("[DEBUG] Config is locating space using name '%s'", c.SpaceName)
 		spaces, err := client.Spaces.Get(octopusdeploy.SpacesQuery{
-			Name: c.SpaceName,
+			PartialName: c.SpaceName,
 		})
 		if err != nil {
 			return nil, diag.FromErr(err)
 		}
 
-		client, err = octopusdeploy.NewClient(nil, apiURL, c.APIKey, spaces.Items[0].GetID())
+		if spaces.TotalResults == 0 {
+			return nil, diag.Errorf("Unable to locate space with name '%s', found no spaces", c.SpaceName)
+		}
+		if spaces.TotalResults > 1 {
+			return nil, diag.Errorf("Unable to uniquely locate space with name '%s', found spaces %s", c.SpaceName, strings.Join(getQuotedSpaceNames(spaces.Items), ", "))
+		}
+
+		spaceID := spaces.Items[0].GetID()
+		log.Printf("[DEBUG] Config located space using name '%s', which has ID '%s'", c.SpaceName, spaceID)
+
+		client, err = octopusdeploy.NewClient(nil, apiURL, c.APIKey, spaceID)
 		if err != nil {
 			return nil, diag.FromErr(err)
 		}
 	}
 
 	return client, nil
+}
+
+func getQuotedSpaceNames(spaces []octopusdeploy.Space) []string {
+	var newSlice []string
+	for _, space := range spaces {
+		newSlice = append(newSlice, fmt.Sprintf("'%s'", space.Name))
+	}
+	return newSlice
 }


### PR DESCRIPTION
Octopus doesn't actually support Name searches on Spaces, it ignore the parameter and returns all spaces instead. The provider was doing this and then assuming it was safe to use the first result it got back, which will typically be the default space.

The provider could then create a real tangle, because the resources would all get created in whatever the first space returned was. However, if the resources in the config contained ID references to a difference space the Octopus API would accept the data but then fail on subsequent reads of that data. This would essentially render the space in operable.

This PR fixes the config code to use a PartialName search and then check that there is only a single result returned. 0 or >1 are now considered error conditions.

Additional DEBUG level logging has also been added to understand which values the config is looking for and what it found.

Fixes #259 