### PR TITLE
Changed octopusdeploy_team.users to TypeSet from TypeList

### DIFF
--- a/octopusdeploy/schema_deployment_action_container_test.go
+++ b/octopusdeploy/schema_deployment_action_container_test.go
@@ -20,7 +20,7 @@ func TestExpandDeploymentActionContainer(t *testing.T) {
 	actual = expandContainer(emptyInterfaceArray)
 	require.Equal(t, expected, actual)
 
-	var testMap []interface{} = make([]interface{}, 1)
+	var testMap = make([]interface{}, 1)
 	actual = expandContainer(testMap)
 	require.Equal(t, expected, actual)
 

--- a/octopusdeploy/schema_team.go
+++ b/octopusdeploy/schema_team.go
@@ -193,7 +193,7 @@ func getTeamSchema() map[string]*schema.Schema {
 			Description: "A list of user IDs designated to be members of this team.",
 			Elem:        &schema.Schema{Type: schema.TypeString},
 			Optional:    true,
-			Type:        schema.TypeList,
+			Type:        schema.TypeSet,
 		},
 		"user_role": {
 			Elem: &schema.Resource{


### PR DESCRIPTION
This change will make Terraform no longer respect the order of users in octopusdeploy_team.users. The reason for this change is to stop Terraform from showing changes on the team user list when no users have been added or removed from the list.