### PR TITLE
Update to the space data source, to search by unique name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=octopus.com
 NAMESPACE=com
 NAME=octopusdeploy
 BINARY=terraform-provider-${NAME}
-VERSION=0.7.64
+VERSION=0.7.65
 
 ifeq ($(OS), Windows_NT)
 OS_ARCH?=windows_amd64

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=octopus.com
 NAMESPACE=com
 NAME=octopusdeploy
 BINARY=terraform-provider-${NAME}
-VERSION=0.7.65
+VERSION=0.7.66
 
 ifeq ($(OS), Windows_NT)
 OS_ARCH?=windows_amd64

--- a/octopusdeploy/config.go
+++ b/octopusdeploy/config.go
@@ -9,10 +9,9 @@ import (
 
 // Config holds Address and the APIKey of the Octopus Deploy server
 type Config struct {
-	Address   string
-	APIKey    string
-	SpaceID   string
-	SpaceName string
+	Address string
+	APIKey  string
+	SpaceID string
 }
 
 // Client returns a new Octopus Deploy client
@@ -34,20 +33,6 @@ func (c *Config) Client() (*octopusdeploy.Client, diag.Diagnostics) {
 		}
 
 		client, err = octopusdeploy.NewClient(nil, apiURL, c.APIKey, space.GetID())
-		if err != nil {
-			return nil, diag.FromErr(err)
-		}
-	}
-
-	if len(c.SpaceName) > 0 {
-		spaces, err := client.Spaces.Get(octopusdeploy.SpacesQuery{
-			Name: c.SpaceName,
-		})
-		if err != nil {
-			return nil, diag.FromErr(err)
-		}
-
-		client, err = octopusdeploy.NewClient(nil, apiURL, c.APIKey, spaces.Items[0].GetID())
 		if err != nil {
 			return nil, diag.FromErr(err)
 		}

--- a/octopusdeploy/data_source_space.go
+++ b/octopusdeploy/data_source_space.go
@@ -29,6 +29,11 @@ func dataSourceSpaceRead(ctx context.Context, d *schema.ResourceData, m interfac
 	log.Printf("[INFO] Found space with name '%s', with ID '%s'", space.Name, space.ID)
 
 	d.Set("id", space.ID)
+	d.Set("description", space.Description)
+	d.Set("is_default", space.IsDefault)
+	d.Set("is_task_queue_stopped", space.TaskQueueStopped)
+	d.Set("space_managers_team_members", space.SpaceManagersTeamMembers)
+	d.Set("space_managers_teams", space.SpaceManagersTeams)
 	d.SetId(space.GetID())
 
 	return nil

--- a/octopusdeploy/data_source_space.go
+++ b/octopusdeploy/data_source_space.go
@@ -1,0 +1,35 @@
+package octopusdeploy
+
+import (
+	"context"
+	"log"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/octopusdeploy"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceSpace() *schema.Resource {
+	return &schema.Resource{
+		Description: "Provides information about an exist space.",
+		ReadContext: dataSourceSpaceRead,
+		Schema:      getSpaceDataSourceSchema(),
+	}
+}
+
+func dataSourceSpaceRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+
+	client := m.(*octopusdeploy.Client)
+
+	space_name := d.Get("name").(string)
+	space, err := client.Spaces.GetByName(space_name)
+	if err != nil {
+		return diag.Errorf("Unable to find space with name '%s'", space_name)
+	}
+	log.Printf("[INFO] Found space with name '%s', with ID '%s'", space.Name, space.ID)
+
+	d.Set("id", space.ID)
+	d.SetId(space.GetID())
+
+	return nil
+}

--- a/octopusdeploy/data_source_space.go
+++ b/octopusdeploy/data_source_space.go
@@ -11,7 +11,7 @@ import (
 
 func dataSourceSpace() *schema.Resource {
 	return &schema.Resource{
-		Description: "Provides information about an exist space.",
+		Description: "Provides information about an existing space.",
 		ReadContext: dataSourceSpaceRead,
 		Schema:      getSpaceDataSourceSchema(),
 	}
@@ -24,7 +24,7 @@ func dataSourceSpaceRead(ctx context.Context, d *schema.ResourceData, m interfac
 	spaceName := d.Get("name").(string)
 	space, err := client.Spaces.GetByName(spaceName)
 	if err != nil {
-		return diag.Errorf("Unable to find space with name '%s'", spaceName)
+		return diag.Errorf("unable to find space with name '%s'", spaceName)
 	}
 	log.Printf("[INFO] Found space with name '%s', with ID '%s'", space.Name, space.ID)
 

--- a/octopusdeploy/data_source_space.go
+++ b/octopusdeploy/data_source_space.go
@@ -21,10 +21,10 @@ func dataSourceSpaceRead(ctx context.Context, d *schema.ResourceData, m interfac
 
 	client := m.(*octopusdeploy.Client)
 
-	space_name := d.Get("name").(string)
-	space, err := client.Spaces.GetByName(space_name)
+	spaceName := d.Get("name").(string)
+	space, err := client.Spaces.GetByName(spaceName)
 	if err != nil {
-		return diag.Errorf("Unable to find space with name '%s'", space_name)
+		return diag.Errorf("Unable to find space with name '%s'", spaceName)
 	}
 	log.Printf("[INFO] Found space with name '%s', with ID '%s'", space.Name, space.ID)
 

--- a/octopusdeploy/data_source_spaces.go
+++ b/octopusdeploy/data_source_spaces.go
@@ -2,6 +2,7 @@ package octopusdeploy
 
 import (
 	"context"
+	"log"
 	"time"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/octopusdeploy"
@@ -18,22 +19,36 @@ func dataSourceSpaces() *schema.Resource {
 }
 
 func dataSourceSpacesRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	query := octopusdeploy.SpacesQuery{
-		IDs:         expandArray(d.Get("ids").([]interface{})),
-		PartialName: d.Get("name").(string),
-		Skip:        d.Get("skip").(int),
-		Take:        d.Get("take").(int),
-	}
 
 	client := m.(*octopusdeploy.Client)
-	spaces, err := client.Spaces.Get(query)
-	if err != nil {
-		return diag.FromErr(err)
-	}
 
 	flattenedSpaces := []interface{}{}
-	for _, space := range spaces.Items {
+
+	space_name := d.Get("name").(string)
+	if space_name != "" {
+		space, err := client.Spaces.GetByName(space_name)
+		if err != nil {
+			return diag.Errorf("Unable to find space with name '%s'", space_name)
+		}
+		log.Printf("[INFO] Found space with name '%s', with ID '%s'", space.Name, space.ID)
+
 		flattenedSpaces = append(flattenedSpaces, flattenSpace(space))
+	} else {
+		query := octopusdeploy.SpacesQuery{
+			IDs:         expandArray(d.Get("ids").([]interface{})),
+			PartialName: d.Get("partial_name").(string),
+			Skip:        d.Get("skip").(int),
+			Take:        d.Get("take").(int),
+		}
+
+		spaces, err := client.Spaces.Get(query)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		for _, space := range spaces.Items {
+			flattenedSpaces = append(flattenedSpaces, flattenSpace(space))
+		}
 	}
 
 	d.Set("spaces", flattenedSpaces)

--- a/octopusdeploy/data_source_spaces.go
+++ b/octopusdeploy/data_source_spaces.go
@@ -2,7 +2,6 @@ package octopusdeploy
 
 import (
 	"context"
-	"log"
 	"time"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/octopusdeploy"
@@ -14,7 +13,7 @@ func dataSourceSpaces() *schema.Resource {
 	return &schema.Resource{
 		Description: "Provides information about existing spaces.",
 		ReadContext: dataSourceSpacesRead,
-		Schema:      getSpaceDataSchema(),
+		Schema:      getSpacesDataSourceSchema(),
 	}
 }
 
@@ -24,31 +23,20 @@ func dataSourceSpacesRead(ctx context.Context, d *schema.ResourceData, m interfa
 
 	flattenedSpaces := []interface{}{}
 
-	space_name := d.Get("name").(string)
-	if space_name != "" {
-		space, err := client.Spaces.GetByName(space_name)
-		if err != nil {
-			return diag.Errorf("Unable to find space with name '%s'", space_name)
-		}
-		log.Printf("[INFO] Found space with name '%s', with ID '%s'", space.Name, space.ID)
+	query := octopusdeploy.SpacesQuery{
+		IDs:         expandArray(d.Get("ids").([]interface{})),
+		PartialName: d.Get("partial_name").(string),
+		Skip:        d.Get("skip").(int),
+		Take:        d.Get("take").(int),
+	}
 
+	spaces, err := client.Spaces.Get(query)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	for _, space := range spaces.Items {
 		flattenedSpaces = append(flattenedSpaces, flattenSpace(space))
-	} else {
-		query := octopusdeploy.SpacesQuery{
-			IDs:         expandArray(d.Get("ids").([]interface{})),
-			PartialName: d.Get("partial_name").(string),
-			Skip:        d.Get("skip").(int),
-			Take:        d.Get("take").(int),
-		}
-
-		spaces, err := client.Spaces.Get(query)
-		if err != nil {
-			return diag.FromErr(err)
-		}
-
-		for _, space := range spaces.Items {
-			flattenedSpaces = append(flattenedSpaces, flattenSpace(space))
-		}
 	}
 
 	d.Set("spaces", flattenedSpaces)

--- a/octopusdeploy/provider.go
+++ b/octopusdeploy/provider.go
@@ -107,16 +107,9 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeString,
 			},
 			"space_id": {
-				ConflictsWith: []string{"space_name"},
-				Description:   "The space ID to target",
-				Optional:      true,
-				Type:          schema.TypeString,
-			},
-			"space_name": {
-				ConflictsWith: []string{"space_id"},
-				Description:   "The space name to target",
-				Optional:      true,
-				Type:          schema.TypeString,
+				Description: "The space ID to target",
+				Optional:    true,
+				Type:        schema.TypeString,
 			},
 		},
 
@@ -130,9 +123,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		APIKey:  d.Get("api_key").(string),
 	}
 
-	if spaceName, ok := d.GetOk("space_name"); ok {
-		config.SpaceName = spaceName.(string)
-	} else if spaceID, ok := d.GetOk("space_id"); ok {
+	if spaceID, ok := d.GetOk("space_id"); ok {
 		config.SpaceID = spaceID.(string)
 	}
 

--- a/octopusdeploy/provider.go
+++ b/octopusdeploy/provider.go
@@ -33,6 +33,7 @@ func Provider() *schema.Provider {
 			"octopusdeploy_project_groups":                                  dataSourceProjectGroups(),
 			"octopusdeploy_projects":                                        dataSourceProjects(),
 			"octopusdeploy_script_modules":                                  dataSourceScriptModules(),
+			"octopusdeploy_space":                                           dataSourceSpace(),
 			"octopusdeploy_spaces":                                          dataSourceSpaces(),
 			"octopusdeploy_ssh_connection_deployment_targets":               dataSourceSSHConnectionDeploymentTargets(),
 			"octopusdeploy_tag_sets":                                        dataSourceTagSets(),

--- a/octopusdeploy/schema_queries.go
+++ b/octopusdeploy/schema_queries.go
@@ -213,7 +213,7 @@ func getQueryOrderBy() *schema.Schema {
 	}
 }
 
-func WithConflictsWith(m *schema.Schema, conflictsWith []string) *schema.Schema {
+func withConflictsWith(m *schema.Schema, conflictsWith []string) *schema.Schema {
 	m.ConflictsWith = conflictsWith
 	return m
 }

--- a/octopusdeploy/schema_queries.go
+++ b/octopusdeploy/schema_queries.go
@@ -213,11 +213,6 @@ func getQueryOrderBy() *schema.Schema {
 	}
 }
 
-func withConflictsWith(m *schema.Schema, conflictsWith []string) *schema.Schema {
-	m.ConflictsWith = conflictsWith
-	return m
-}
-
 func getQueryPartialName() *schema.Schema {
 	return &schema.Schema{
 		Description: "A filter to search by the partial match of a name.",

--- a/octopusdeploy/schema_queries.go
+++ b/octopusdeploy/schema_queries.go
@@ -213,6 +213,11 @@ func getQueryOrderBy() *schema.Schema {
 	}
 }
 
+func WithConflictsWith(m *schema.Schema, conflictsWith []string) *schema.Schema {
+	m.ConflictsWith = conflictsWith
+	return m
+}
+
 func getQueryPartialName() *schema.Schema {
 	return &schema.Schema{
 		Description: "A filter to search by the partial match of a name.",

--- a/octopusdeploy/schema_space.go
+++ b/octopusdeploy/schema_space.go
@@ -68,10 +68,12 @@ func flattenSpace(space *octopusdeploy.Space) map[string]interface{} {
 }
 
 func getSpaceDataSourceSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"id":   getDataSchemaID(),
-		"name": getNameSchema(true),
-	}
+	dataSchema := getSpaceSchema()
+	setDataSchema(&dataSchema)
+
+	dataSchema["name"] = getNameSchema(true)
+
+	return dataSchema
 }
 
 func getSpacesDataSourceSchema() map[string]*schema.Schema {

--- a/octopusdeploy/schema_space.go
+++ b/octopusdeploy/schema_space.go
@@ -68,9 +68,6 @@ func flattenSpace(space *octopusdeploy.Space) map[string]interface{} {
 }
 
 func getSpaceDataSourceSchema() map[string]*schema.Schema {
-	dataSchema := getSpaceSchema()
-	setDataSchema(&dataSchema)
-
 	return map[string]*schema.Schema{
 		"id":   getDataSchemaID(),
 		"name": getNameSchema(true),

--- a/octopusdeploy/schema_space.go
+++ b/octopusdeploy/schema_space.go
@@ -67,24 +67,32 @@ func flattenSpace(space *octopusdeploy.Space) map[string]interface{} {
 	}
 }
 
-func getSpaceDataSchema() map[string]*schema.Schema {
+func getSpaceDataSourceSchema() map[string]*schema.Schema {
+	dataSchema := getSpaceSchema()
+	setDataSchema(&dataSchema)
+
+	return map[string]*schema.Schema{
+		"id":   getDataSchemaID(),
+		"name": getNameSchema(true),
+	}
+}
+
+func getSpacesDataSourceSchema() map[string]*schema.Schema {
 	dataSchema := getSpaceSchema()
 	setDataSchema(&dataSchema)
 
 	return map[string]*schema.Schema{
 		"id":           getDataSchemaID(),
-		"name":         withConflictsWith(getQueryName(), []string{"id", "ids", "partial_name", "skip", "take"}),
-		"ids":          withConflictsWith(getQueryIDs(), []string{"name"}),
-		"partial_name": withConflictsWith(getQueryPartialName(), []string{"name"}),
-		"skip":         withConflictsWith(getQuerySkip(), []string{"name"}),
-		"take":         withConflictsWith(getQueryTake(), []string{"name"}),
+		"ids":          getQueryIDs(),
+		"partial_name": getQueryPartialName(),
+		"skip":         getQuerySkip(),
+		"take":         getQueryTake(),
 		"spaces": {
-			Computed:      true,
-			Description:   "A list of spaces that match the filter(s).",
-			Elem:          &schema.Resource{Schema: dataSchema},
-			Optional:      true,
-			Type:          schema.TypeList,
-			ConflictsWith: []string{"name"},
+			Computed:    true,
+			Description: "A list of spaces that match the filter(s).",
+			Elem:        &schema.Resource{Schema: dataSchema},
+			Optional:    true,
+			Type:        schema.TypeList,
 		},
 	}
 }

--- a/octopusdeploy/schema_space.go
+++ b/octopusdeploy/schema_space.go
@@ -73,18 +73,19 @@ func getSpaceDataSchema() map[string]*schema.Schema {
 
 	return map[string]*schema.Schema{
 		"id":           getDataSchemaID(),
-		"ids":          getQueryIDs(),
-		"name":         getQueryName(),
-		"partial_name": getQueryPartialName(),
-		"skip":         getQuerySkip(),
+		"name":         withConflictsWith(getQueryName(), []string{"id", "ids", "partial_name", "skip", "take"}),
+		"ids":          withConflictsWith(getQueryIDs(), []string{"name"}),
+		"partial_name": withConflictsWith(getQueryPartialName(), []string{"name"}),
+		"skip":         withConflictsWith(getQuerySkip(), []string{"name"}),
+		"take":         withConflictsWith(getQueryTake(), []string{"name"}),
 		"spaces": {
-			Computed:    true,
-			Description: "A list of spaces that match the filter(s).",
-			Elem:        &schema.Resource{Schema: dataSchema},
-			Optional:    true,
-			Type:        schema.TypeList,
+			Computed:      true,
+			Description:   "A list of spaces that match the filter(s).",
+			Elem:          &schema.Resource{Schema: dataSchema},
+			Optional:      true,
+			Type:          schema.TypeList,
+			ConflictsWith: []string{"name"},
 		},
-		"take": getQueryTake(),
 	}
 }
 


### PR DESCRIPTION
This is an alternate solution to #311 that works on the idea of the provider only supporting `space_id`, and making the data source support search for a unique name.

You'd use a config something like

```
provider "octopusdeploy" {
  alias   = "unscoped"
  address = "http://localhost:8065"
}

data "octopusdeploy_space" "s" {
  provider = octopusdeploy.unscoped
  name     = "TerraForm test space"
}

provider "octopusdeploy" {
  address  = "http://localhost:8065"
  space_id = data.octopusdeploy_space.s.id
}
```

Fixes #259