### PR TITLE
Fixing SSH account key file and passphrase handling

### DIFF
--- a/octopusdeploy/resource_sshkey_account_test.go
+++ b/octopusdeploy/resource_sshkey_account_test.go
@@ -29,6 +29,7 @@ func TestSSHKeyBasic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccAccountExists(prefix),
 					resource.TestCheckResourceAttr(prefix, "name", name),
+					resource.TestCheckResourceAttr(prefix, "private_key_file", privateKeyFile),
 					resource.TestCheckResourceAttr(prefix, "private_key_passphrase", passphrase),
 					resource.TestCheckResourceAttr(prefix, "tenanted_deployment_participation", string(tenantedDeploymentParticipation)),
 					resource.TestCheckResourceAttr(prefix, "username", username),

--- a/octopusdeploy/schema_account_resource.go
+++ b/octopusdeploy/schema_account_resource.go
@@ -66,7 +66,7 @@ func expandAccountResource(d *schema.ResourceData) *octopusdeploy.AccountResourc
 	}
 
 	if v, ok := d.GetOk("private_key_passphrase"); ok {
-		accountResource.PrivateKeyFile = octopusdeploy.NewSensitiveValue(v.(string))
+		accountResource.PrivateKeyPassphrase = octopusdeploy.NewSensitiveValue(v.(string))
 	}
 
 	if v, ok := d.GetOk("resource_management_endpoint_base_uri"); ok {

--- a/octopusdeploy/schema_ssh_key_account.go
+++ b/octopusdeploy/schema_ssh_key_account.go
@@ -12,10 +12,14 @@ import (
 func expandSSHKeyAccount(d *schema.ResourceData) *octopusdeploy.SSHKeyAccount {
 	name := d.Get("name").(string)
 	username := d.Get("username").(string)
-	privateKeyFile := octopusdeploy.NewSensitiveValue(d.Get("private_key_passphrase").(string))
+	privateKeyFile := octopusdeploy.NewSensitiveValue(d.Get("private_key_file").(string))
 
 	account, _ := octopusdeploy.NewSSHKeyAccount(name, username, privateKeyFile)
 	account.ID = d.Id()
+
+	if v, ok := d.GetOk("private_key_passphrase"); ok {
+		account.PrivateKeyPassphrase = octopusdeploy.NewSensitiveValue(v.(string))
+	}
 
 	if v, ok := d.GetOk("tenanted_deployment_participation"); ok {
 		account.TenantedDeploymentMode = octopusdeploy.TenantedDeploymentMode(v.(string))


### PR DESCRIPTION
The key file and passphrase were being swapped in a couple of cases, and the passphrase was being ignore completely in another.

Fixes #250 