### PR TITLE
Added Git Credential data source

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,6 @@ github.com/Masterminds/sprig/v3 v3.2.2/go.mod h1:UoaO7Yp8KlPnJIYWTFkMaqPUYKTfGFP
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.12.0 h1:1THFtuXmZ4g15ZEn4z62OyNfWHIhoT0RCvKkRQ4mF5U=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.12.0/go.mod h1:2j9rwRfb5qUs9PEJ3W331W84kRaNge5bed4D7JR1ruU=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.13.0 h1:rcHpDufa/rI+aLHi1yf/+nb0eszmGe5ey02uVyC6/kA=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.13.0/go.mod h1:2j9rwRfb5qUs9PEJ3W331W84kRaNge5bed4D7JR1ruU=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
@@ -77,7 +75,6 @@ github.com/apparentlymart/go-cidr v1.1.0/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/Y
 github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
 github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0 h1:MzVXffFUye+ZcSR6opIgz9Co7WcDx6ZcY+RjfFHoA0I=
 github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
-github.com/apparentlymart/go-textseg v1.0.0 h1:rRmlIsPEEhUTIKQb7T++Nz/A5Q6C9IuX2wFoYVvnCs0=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=

--- a/octopusdeploy/data_source_git_credentials.go
+++ b/octopusdeploy/data_source_git_credentials.go
@@ -1,0 +1,43 @@
+package octopusdeploy
+
+import (
+	"context"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"time"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/credentials"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceGitCredentials() *schema.Resource {
+	return &schema.Resource{
+		Description: "Provides information about existing GitCredentials.",
+		ReadContext: dataSourceGitCredentialsRead,
+		Schema:      getGitCredentialDataSchema(),
+	}
+}
+
+func dataSourceGitCredentialsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	query := credentials.Query{
+		Name: d.Get("name").(string),
+		Skip: d.Get("skip").(int),
+		Take: d.Get("take").(int),
+	}
+
+	client := m.(*client.Client)
+	existingGitCredentials, err := client.GitCredentials.Get(query)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	flattenedGitCredentials := []interface{}{}
+	for _, gitCredential := range existingGitCredentials.Items {
+		flattenedGitCredentials = append(flattenedGitCredentials, flattenGitCredential(gitCredential))
+	}
+
+	d.Set("git_credentials", flattenedGitCredentials)
+	d.SetId("GitCredentials " + time.Now().UTC().String())
+
+	return nil
+}

--- a/octopusdeploy/provider.go
+++ b/octopusdeploy/provider.go
@@ -21,6 +21,7 @@ func Provider() *schema.Provider {
 			"octopusdeploy_deployment_targets":                              dataSourceDeploymentTargets(),
 			"octopusdeploy_environments":                                    dataSourceEnvironments(),
 			"octopusdeploy_feeds":                                           dataSourceFeeds(),
+			"octopusdeploy_git_credentials":                                 dataSourceGitCredentials(),
 			"octopusdeploy_kubernetes_cluster_deployment_targets":           dataSourceKubernetesClusterDeploymentTargets(),
 			"octopusdeploy_library_variable_sets":                           dataSourceLibraryVariableSet(),
 			"octopusdeploy_lifecycles":                                      dataSourceLifecycles(),

--- a/octopusdeploy/schema_git_credential.go
+++ b/octopusdeploy/schema_git_credential.go
@@ -55,15 +55,15 @@ func getGitCredentialDataSchema() map[string]*schema.Schema {
 			Optional:    true,
 			Type:        schema.TypeList,
 		},
-		"first_result": getQueryFirstResult(),
-		"name":         getQueryName(),
-		"skip":         getQuerySkip(),
-		"take":         getQueryTake(),
+		"name": getQueryName(),
+		"skip": getQuerySkip(),
+		"take": getQueryTake(),
 	}
 }
 
 func getGitCredentialSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"id":       getIDSchema(),
 		"space_id": getSpaceIDSchema(),
 		"name": {
 			Description:      "The name of the Git credential. This name must be unique.",
@@ -73,6 +73,11 @@ func getGitCredentialSchema() map[string]*schema.Schema {
 		},
 		"description": {
 			Description: "The description of this Git credential.",
+			Optional:    true,
+			Type:        schema.TypeString,
+		},
+		"type": {
+			Description: "The Git credential authentication type.",
 			Optional:    true,
 			Type:        schema.TypeString,
 		},

--- a/octopusdeploy/schema_git_credential.go
+++ b/octopusdeploy/schema_git_credential.go
@@ -30,15 +30,54 @@ func expandGitCredential(d *schema.ResourceData) *credentials.Resource {
 	return resource
 }
 
+func flattenGitCredential(credential *credentials.Resource) map[string]interface{} {
+	if credential == nil {
+		return nil
+	}
+
+	return map[string]interface{}{
+		"id":          credential.GetID(),
+		"name":        credential.Name,
+		"description": credential.Description,
+		"type":        credential.Details.Type(),
+	}
+}
+
+func getGitCredentialDataSchema() map[string]*schema.Schema {
+	dataSchema := getGitCredentialSchema()
+	setDataSchema(&dataSchema)
+
+	return map[string]*schema.Schema{
+		"git_credentials": {
+			Computed:    true,
+			Description: "A list of Git Credentials that match the filter(s).",
+			Elem:        &schema.Resource{Schema: dataSchema},
+			Optional:    true,
+			Type:        schema.TypeList,
+		},
+		"first_result": getQueryFirstResult(),
+		"name":         getQueryName(),
+		"skip":         getQuerySkip(),
+		"take":         getQueryTake(),
+	}
+}
+
 func getGitCredentialSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"space_id": getSpaceIDSchema(),
+		"name": {
+			Description:      "The name of the Git credential. This name must be unique.",
+			Required:         true,
+			Type:             schema.TypeString,
+			ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotWhiteSpace),
+		},
 		"description": {
 			Description: "The description of this Git credential.",
 			Optional:    true,
 			Type:        schema.TypeString,
 		},
-		"name": {
-			Description:      "The name of the Git credential. This name must be unique.",
+		"username": {
+			Description:      "The username for the Git credential.",
 			Required:         true,
 			Type:             schema.TypeString,
 			ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotWhiteSpace),
@@ -50,23 +89,15 @@ func getGitCredentialSchema() map[string]*schema.Schema {
 			Type:             schema.TypeString,
 			ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
 		},
-		"space_id": getSpaceIDSchema(),
-		"username": {
-			Description:      "The username for the Git credential.",
-			Required:         true,
-			Type:             schema.TypeString,
-			ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotWhiteSpace),
-		},
 	}
 }
 
 func setGitCredential(ctx context.Context, d *schema.ResourceData, resource *credentials.Resource) error {
-	d.Set("description", resource.Description)
-	d.Set("name", resource.GetName())
 	d.Set("space_id", resource.SpaceID)
+	d.Set("name", resource.GetName())
+	d.Set("description", resource.Description)
 
 	usernamePassword := resource.Details.(*credentials.UsernamePassword)
-
 	d.Set("username", usernamePassword.Username)
 
 	return nil


### PR DESCRIPTION
When the Git Credential support within project was corrected we didn't also include a specific data source for querying existing Git Credentials already being managed within Octopus. This PR adds support for that data source.

Usage:

```
data "octopusdeploy_git_credentials" "test-credential" {
  name = "GitHub cred"
}
```

```
resource "octopusdeploy_project" "my-project" {
...
  git_library_persistence_settings {
    base_path         = ".octopus"
    git_credential_id = data.octopusdeploy_git_credentials.test-credential.git_credentials[0].id
    url               = "https://github.com/MyOrg/MyProject.git"
  }
...
}
```

Fixes #459 