### PR TITLE
Fixed handling of prompted variables

### DIFF
--- a/docs/data-sources/variables.md
+++ b/docs/data-sources/variables.md
@@ -43,7 +43,7 @@ Read-Only:
 - `owner_id` (String)
 - `pgp_key` (String, Sensitive)
 - `project_id` (String, Deprecated)
-- `prompt` (Set of Object) (see [below for nested schema](#nestedatt--variables--prompt))
+- `prompt` (List of Object) (see [below for nested schema](#nestedatt--variables--prompt))
 - `scope` (List of Object) (see [below for nested schema](#nestedatt--variables--scope))
 - `sensitive_value` (String, Sensitive)
 - `type` (String) The type of variable represented by this resource. Valid types are `AmazonWebServicesAccount`, `AzureAccount`, `GoogleCloudAccount`, `Certificate`, `Sensitive`, `String`, or `WorkerPool`.
@@ -55,8 +55,27 @@ Read-Only:
 Read-Only:
 
 - `description` (String)
+- `display_settings` (List of Object) (see [below for nested schema](#nestedobjatt--variables--prompt--display_settings))
 - `is_required` (Boolean)
 - `label` (String)
+
+<a id="nestedobjatt--variables--prompt--display_settings"></a>
+### Nested Schema for `variables.prompt.display_settings`
+
+Read-Only:
+
+- `control_type` (String)
+- `select_option` (List of Object) (see [below for nested schema](#nestedobjatt--variables--prompt--display_settings--select_option))
+
+<a id="nestedobjatt--variables--prompt--display_settings--select_option"></a>
+### Nested Schema for `variables.prompt.display_settings.select_option`
+
+Read-Only:
+
+- `display_name` (String)
+- `value` (String)
+
+
 
 
 <a id="nestedatt--variables--scope"></a>

--- a/docs/resources/variable.md
+++ b/docs/resources/variable.md
@@ -98,7 +98,7 @@ resource "octopusdeploy_variable" "prompted_variable" {
 - `owner_id` (String)
 - `pgp_key` (String, Sensitive)
 - `project_id` (String, Deprecated)
-- `prompt` (Block Set, Max: 1) (see [below for nested schema](#nestedblock--prompt))
+- `prompt` (Block List, Max: 1) (see [below for nested schema](#nestedblock--prompt))
 - `scope` (Block List, Max: 1) (see [below for nested schema](#nestedblock--scope))
 - `sensitive_value` (String, Sensitive)
 - `value` (String)
@@ -115,8 +115,30 @@ resource "octopusdeploy_variable" "prompted_variable" {
 Optional:
 
 - `description` (String) The description of this variable prompt option.
+- `display_settings` (Block List, Max: 1) (see [below for nested schema](#nestedblock--prompt--display_settings))
 - `is_required` (Boolean)
 - `label` (String)
+
+<a id="nestedblock--prompt--display_settings"></a>
+### Nested Schema for `prompt.display_settings`
+
+Required:
+
+- `control_type` (String) The type of control for rendering this prompted variable. Valid types are `SingleLineText`, `MultiLineText`, `Checkbox`, `Select`.
+
+Optional:
+
+- `select_option` (Block List) If the `control_type` is `Select`, then this value defines an option. (see [below for nested schema](#nestedblock--prompt--display_settings--select_option))
+
+<a id="nestedblock--prompt--display_settings--select_option"></a>
+### Nested Schema for `prompt.display_settings.select_option`
+
+Required:
+
+- `display_name` (String) The display name for the select value
+- `value` (String) The select value
+
+
 
 
 <a id="nestedblock--scope"></a>

--- a/octopusdeploy/schema_variable.go
+++ b/octopusdeploy/schema_variable.go
@@ -3,8 +3,10 @@ package octopusdeploy
 import (
 	"context"
 	"fmt"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/variables"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func expandVariable(d *schema.ResourceData) *variables.Variable {
@@ -102,7 +104,58 @@ func getVariableSchema() map[string]*schema.Schema {
 			Type:          schema.TypeString,
 		},
 		"prompt": {
-			Elem:     &schema.Resource{Schema: getVariablePromptOptionsSchema()},
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"description": getDescriptionSchema("variable prompt option"),
+					"display_settings": {
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"control_type": {
+									Description: "The type of control for rendering this prompted variable. Valid types are `SingleLineText`, `MultiLineText`, `Checkbox`, `Select`.",
+									Required:    true,
+									Type:        schema.TypeString,
+									ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{
+										"Checkbox",
+										"MultiLineText",
+										"Select",
+										"SingleLineText",
+									}, false)),
+								},
+								"select_option": {
+									Elem: &schema.Resource{
+										Schema: map[string]*schema.Schema{
+											"value": {
+												Description: "The select value",
+												Required:    true,
+												Type:        schema.TypeString,
+											},
+											"display_name": {
+												Description: "The display name for the select value",
+												Required:    true,
+												Type:        schema.TypeString,
+											},
+										},
+									},
+									Description: "If the `control_type` is `Select`, then this value defines an option.",
+									Optional:    true,
+									Type:        schema.TypeList,
+								},
+							},
+						},
+						MaxItems: 1,
+						Optional: true,
+						Type:     schema.TypeList,
+					},
+					"is_required": {
+						Type:     schema.TypeBool,
+						Optional: true,
+					},
+					"label": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
+				},
+			},
 			MaxItems: 1,
 			Optional: true,
 			Type:     schema.TypeList,

--- a/octopusdeploy/schema_variable_prompt_options.go
+++ b/octopusdeploy/schema_variable_prompt_options.go
@@ -1,6 +1,96 @@
 package octopusdeploy
 
-import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+import (
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/variables"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func expandPromptedVariableSettings(v interface{}) *variables.VariablePromptOptions {
+	if v == nil {
+		return nil
+	}
+	s := v.([]interface{})
+	tfPromptList := s[0].(map[string]interface{})
+
+	newPrompt := variables.VariablePromptOptions{
+		Description:     tfPromptList["description"].(string),
+		Label:           tfPromptList["label"].(string),
+		IsRequired:      tfPromptList["is_required"].(bool),
+		DisplaySettings: expandPromptedDisplaySettings(tfPromptList["display_settings"]),
+	}
+	return &newPrompt
+}
+
+func expandPromptedDisplaySettings(v interface{}) *variables.DisplaySettings {
+	if v == nil {
+		return nil
+	}
+	s := v.([]interface{})
+	tfPromptList := s[0].(map[string]interface{})
+
+	controlType := variables.ControlType(tfPromptList["control_type"].(string))
+	var selectOptions []*variables.SelectOption
+
+	if controlType == variables.ControlTypeSelect {
+		selectOptions = expandSelectOptions(tfPromptList["select_option"])
+	}
+
+	settings := variables.NewDisplaySettings(controlType, selectOptions)
+	return settings
+}
+
+func expandSelectOptions(tfPromptList interface{}) []*variables.SelectOption {
+	list := tfPromptList.([]interface{})
+	var selectOptions []*variables.SelectOption
+
+	for i := 0; i < len(list); i++ {
+		item := list[i].(map[string]interface{})
+		selectOptions = append(selectOptions, &variables.SelectOption{
+			Value:       item["value"].(string),
+			DisplayName: item["display_name"].(string),
+		})
+	}
+	return selectOptions
+}
+
+func flattenPromptedVariableSettings(promptOptions *variables.VariablePromptOptions) []interface{} {
+	if promptOptions == nil {
+		return nil
+	}
+	flattenedPrompt := map[string]interface{}{}
+
+	flattenedPrompt["description"] = promptOptions.Description
+	flattenedPrompt["is_required"] = promptOptions.IsRequired
+	flattenedPrompt["label"] = promptOptions.Label
+
+	if promptOptions.DisplaySettings != nil {
+		flattenedPrompt["display_settings"] = flattenPromptedVariableDisplaySettings(promptOptions.DisplaySettings)
+
+	}
+
+	return []interface{}{flattenedPrompt}
+}
+
+func flattenPromptedVariableDisplaySettings(displaySettings *variables.DisplaySettings) []interface{} {
+	flattenedDisplaySettings := map[string]interface{}{}
+	flattenedDisplaySettings["control_type"] = displaySettings.ControlType
+	if displaySettings.ControlType == variables.ControlTypeSelect {
+		flattenedDisplaySettings["select_option"] = flattenSelectOptions(displaySettings.SelectOptions)
+	}
+	return []interface{}{flattenedDisplaySettings}
+}
+
+func flattenSelectOptions(selectOptions []*variables.SelectOption) []map[string]interface{} {
+	var options []map[string]interface{}
+	for i := 0; i < len(selectOptions); i++ {
+		options = append(options, map[string]interface{}{
+			"value":        selectOptions[i].Value,
+			"display_name": selectOptions[i].DisplayName,
+		})
+	}
+	return options
+}
 
 func getVariablePromptOptionsSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
@@ -12,6 +102,49 @@ func getVariablePromptOptionsSchema() map[string]*schema.Schema {
 		"label": {
 			Type:     schema.TypeString,
 			Optional: true,
+		},
+		"display_settings": {
+			Elem:     &schema.Resource{Schema: getDisplaySettingsSchema()},
+			MaxItems: 1,
+			Optional: true,
+			Type:     schema.TypeList,
+		},
+	}
+}
+
+func getDisplaySettingsSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"control_type": {
+			Description: "The type of control for rendering this prompted variable. Valid types are `SingleLineText`, `MultiLineText`, `Checkbox`, `Select`.",
+			Required:    true,
+			Type:        schema.TypeString,
+			ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{
+				"SingleLineText",
+				"MultiLineText",
+				"Checkbox",
+				"Select",
+			}, false)),
+		},
+		"select_option": {
+			Elem:        &schema.Resource{Schema: getDisplaySettingsSelectOptionsSchema()},
+			Description: "If the `control_type` is `Select`, then this value defines an option.",
+			Optional:    true,
+			Type:        schema.TypeList,
+		},
+	}
+}
+
+func getDisplaySettingsSelectOptionsSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"value": {
+			Description: "The select value",
+			Required:    true,
+			Type:        schema.TypeString,
+		},
+		"display_name": {
+			Description: "The display name for the select value",
+			Required:    true,
+			Type:        schema.TypeString,
 		},
 	}
 }

--- a/octopusdeploy/schema_variable_prompt_options.go
+++ b/octopusdeploy/schema_variable_prompt_options.go
@@ -2,77 +2,77 @@ package octopusdeploy
 
 import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/variables"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-func expandPromptedVariableSettings(v interface{}) *variables.VariablePromptOptions {
-	if v == nil {
+func expandPromptedDisplaySettings(values interface{}) *variables.DisplaySettings {
+	if values == nil {
 		return nil
 	}
-	s := v.([]interface{})
-	tfPromptList := s[0].(map[string]interface{})
 
-	newPrompt := variables.VariablePromptOptions{
-		Description:     tfPromptList["description"].(string),
-		Label:           tfPromptList["label"].(string),
-		IsRequired:      tfPromptList["is_required"].(bool),
-		DisplaySettings: expandPromptedDisplaySettings(tfPromptList["display_settings"]),
-	}
-	return &newPrompt
-}
-
-func expandPromptedDisplaySettings(v interface{}) *variables.DisplaySettings {
-	if v == nil {
+	flattenedValues := values.([]interface{})
+	if len(flattenedValues) == 0 {
 		return nil
 	}
-	s := v.([]interface{})
-	tfPromptList := s[0].(map[string]interface{})
 
-	controlType := variables.ControlType(tfPromptList["control_type"].(string))
+	promptedDisplaySettings := flattenedValues[0].(map[string]interface{})
+
+	controlType := variables.ControlType(promptedDisplaySettings["control_type"].(string))
+
 	var selectOptions []*variables.SelectOption
-
 	if controlType == variables.ControlTypeSelect {
-		selectOptions = expandSelectOptions(tfPromptList["select_option"])
+		selectOptions = expandSelectOptions(promptedDisplaySettings["select_option"])
 	}
 
-	settings := variables.NewDisplaySettings(controlType, selectOptions)
-	return settings
+	return variables.NewDisplaySettings(controlType, selectOptions)
 }
 
-func expandSelectOptions(tfPromptList interface{}) []*variables.SelectOption {
-	list := tfPromptList.([]interface{})
-	var selectOptions []*variables.SelectOption
-
-	for i := 0; i < len(list); i++ {
-		item := list[i].(map[string]interface{})
-		selectOptions = append(selectOptions, &variables.SelectOption{
-			Value:       item["value"].(string),
-			DisplayName: item["display_name"].(string),
-		})
+func expandPromptedVariableSettings(values interface{}) *variables.VariablePromptOptions {
+	if values == nil {
+		return nil
 	}
+
+	flattenedValues := values.([]interface{})
+	if len(flattenedValues) == 0 {
+		return nil
+	}
+
+	promptedVariableSettings := flattenedValues[0].(map[string]interface{})
+	return &variables.VariablePromptOptions{
+		Description:     promptedVariableSettings["description"].(string),
+		DisplaySettings: expandPromptedDisplaySettings(promptedVariableSettings["display_settings"]),
+		IsRequired:      promptedVariableSettings["is_required"].(bool),
+		Label:           promptedVariableSettings["label"].(string),
+	}
+}
+
+func expandSelectOptions(values interface{}) []*variables.SelectOption {
+	if values == nil {
+		return nil
+	}
+
+	flattenedValues := values.([]interface{})
+	if len(flattenedValues) == 0 {
+		return nil
+	}
+
+	selectOptions := make([]*variables.SelectOption, len(flattenedValues))
+
+	for i := 0; i < len(flattenedValues); i++ {
+		item := flattenedValues[i].(map[string]interface{})
+		selectOptions[i] = &variables.SelectOption{
+			DisplayName: item["display_name"].(string),
+			Value:       item["value"].(string),
+		}
+	}
+
 	return selectOptions
 }
 
-func flattenPromptedVariableSettings(promptOptions *variables.VariablePromptOptions) []interface{} {
-	if promptOptions == nil {
+func flattenPromptedVariableDisplaySettings(displaySettings *variables.DisplaySettings) []interface{} {
+	if displaySettings == nil {
 		return nil
 	}
-	flattenedPrompt := map[string]interface{}{}
 
-	flattenedPrompt["description"] = promptOptions.Description
-	flattenedPrompt["is_required"] = promptOptions.IsRequired
-	flattenedPrompt["label"] = promptOptions.Label
-
-	if promptOptions.DisplaySettings != nil {
-		flattenedPrompt["display_settings"] = flattenPromptedVariableDisplaySettings(promptOptions.DisplaySettings)
-
-	}
-
-	return []interface{}{flattenedPrompt}
-}
-
-func flattenPromptedVariableDisplaySettings(displaySettings *variables.DisplaySettings) []interface{} {
 	flattenedDisplaySettings := map[string]interface{}{}
 	flattenedDisplaySettings["control_type"] = displaySettings.ControlType
 	if displaySettings.ControlType == variables.ControlTypeSelect {
@@ -81,70 +81,31 @@ func flattenPromptedVariableDisplaySettings(displaySettings *variables.DisplaySe
 	return []interface{}{flattenedDisplaySettings}
 }
 
+func flattenPromptedVariableSettings(variablePromptOptions *variables.VariablePromptOptions) []interface{} {
+	if variablePromptOptions == nil {
+		return nil
+	}
+
+	flattenedPrompt := map[string]interface{}{}
+	flattenedPrompt["description"] = variablePromptOptions.Description
+	flattenedPrompt["is_required"] = variablePromptOptions.IsRequired
+	flattenedPrompt["label"] = variablePromptOptions.Label
+
+	if variablePromptOptions.DisplaySettings != nil {
+		flattenedPrompt["display_settings"] = flattenPromptedVariableDisplaySettings(variablePromptOptions.DisplaySettings)
+
+	}
+
+	return []interface{}{flattenedPrompt}
+}
+
 func flattenSelectOptions(selectOptions []*variables.SelectOption) []map[string]interface{} {
-	var options []map[string]interface{}
+	options := make([]map[string]interface{}, len(selectOptions))
 	for i := 0; i < len(selectOptions); i++ {
-		options = append(options, map[string]interface{}{
+		options[i] = map[string]interface{}{
 			"value":        selectOptions[i].Value,
 			"display_name": selectOptions[i].DisplayName,
-		})
+		}
 	}
 	return options
-}
-
-func getVariablePromptOptionsSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"description": getDescriptionSchema("variable prompt option"),
-		"is_required": {
-			Type:     schema.TypeBool,
-			Optional: true,
-		},
-		"label": {
-			Type:     schema.TypeString,
-			Optional: true,
-		},
-		"display_settings": {
-			Elem:     &schema.Resource{Schema: getDisplaySettingsSchema()},
-			MaxItems: 1,
-			Optional: true,
-			Type:     schema.TypeList,
-		},
-	}
-}
-
-func getDisplaySettingsSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"control_type": {
-			Description: "The type of control for rendering this prompted variable. Valid types are `SingleLineText`, `MultiLineText`, `Checkbox`, `Select`.",
-			Required:    true,
-			Type:        schema.TypeString,
-			ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{
-				"SingleLineText",
-				"MultiLineText",
-				"Checkbox",
-				"Select",
-			}, false)),
-		},
-		"select_option": {
-			Elem:        &schema.Resource{Schema: getDisplaySettingsSelectOptionsSchema()},
-			Description: "If the `control_type` is `Select`, then this value defines an option.",
-			Optional:    true,
-			Type:        schema.TypeList,
-		},
-	}
-}
-
-func getDisplaySettingsSelectOptionsSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"value": {
-			Description: "The select value",
-			Required:    true,
-			Type:        schema.TypeString,
-		},
-		"display_name": {
-			Description: "The display name for the select value",
-			Required:    true,
-			Type:        schema.TypeString,
-		},
-	}
 }

--- a/octopusdeploy/schema_variable_prompt_options_test.go
+++ b/octopusdeploy/schema_variable_prompt_options_test.go
@@ -1,0 +1,94 @@
+package octopusdeploy
+
+import (
+	"testing"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/variables"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpandPromptedDisplaySettingsWithNilInput(t *testing.T) {
+	result := expandPromptedDisplaySettings(nil)
+	require.Nil(t, result)
+}
+
+func TestExpandPromptedDisplaySettingsWithEmptyInput(t *testing.T) {
+	input := []interface{}{}
+	result := expandPromptedDisplaySettings(input)
+	require.Nil(t, result)
+}
+
+func TestExpandPromptedDisplaySettingsWithCheckbox(t *testing.T) {
+	input := []interface{}{
+		map[string]interface{}{
+			"control_type": "Checkbox",
+		},
+	}
+	result := expandPromptedDisplaySettings(input)
+	require.NotNil(t, result)
+	require.Equal(t, variables.ControlTypeCheckbox, result.ControlType)
+}
+
+func TestExpandPromptedDisplaySettingsWithSelect(t *testing.T) {
+	input := []interface{}{
+		map[string]interface{}{
+			"control_type": "Select",
+			"select_option": []interface{}{
+				map[string]interface{}{
+					"display_name": "Name-1",
+					"value":        "Value-1",
+				},
+				map[string]interface{}{
+					"display_name": "Name-2",
+					"value":        "Value-2",
+				},
+			},
+		},
+	}
+	result := expandPromptedDisplaySettings(input)
+	require.NotNil(t, result)
+	require.Equal(t, variables.ControlTypeSelect, result.ControlType)
+	require.NotNil(t, result.SelectOptions)
+	require.Len(t, result.SelectOptions, 2)
+	require.Equal(t, "Name-1", result.SelectOptions[0].DisplayName)
+	require.Equal(t, "Value-1", result.SelectOptions[0].Value)
+	require.Equal(t, "Name-2", result.SelectOptions[1].DisplayName)
+	require.Equal(t, "Value-2", result.SelectOptions[1].Value)
+}
+
+func TestExpandPromptedVariableSettingsWithNilInput(t *testing.T) {
+	result := expandPromptedVariableSettings(nil)
+	require.Nil(t, result)
+}
+
+func TestExpandPromptedVariableSettingsWithEmptyInput(t *testing.T) {
+	input := []interface{}{}
+	result := expandPromptedVariableSettings(input)
+	require.Nil(t, result)
+}
+
+func TestExpandSelectOptionsWithNilInput(t *testing.T) {
+	result := expandSelectOptions(nil)
+	require.Nil(t, result)
+}
+
+func TestExpandSelectOptionsWithEmptyInput(t *testing.T) {
+	input := []interface{}{}
+	result := expandSelectOptions(input)
+	require.Nil(t, result)
+}
+
+func TestFlattenPromptedVariableDisplaySettingsWithNilInput(t *testing.T) {
+	result := flattenPromptedVariableDisplaySettings(nil)
+	require.Empty(t, result)
+}
+
+func TestFlattenPromptedVariableSettingsWithNilInput(t *testing.T) {
+	result := flattenPromptedVariableSettings(nil)
+	require.Empty(t, result)
+}
+
+func TestFlattenSelectOptionsWithNilInput(t *testing.T) {
+	result := flattenSelectOptions(nil)
+	require.Empty(t, result)
+}


### PR DESCRIPTION
Updated the provider to properly support prompted variables.

Example TF config using a prompted variable
```terraform
resource "octopusdeploy_variable" "var1" {
  name     = "Database Name"
  type     = "String"
  value    = "MyDB"
  owner_id = octopusdeploy_project.project.id
  prompt {
    display_settings {
      control_type = "Select"
      select_option {
        value        = "Staging"
        display_name = "Staging DB"
      }
      select_option {
        value        = "Production"
        display_name = "Prod DB"
      }
    }
  }
}
```