### PR TITLE
fix: editable project slugs

### DIFF
--- a/docs/data-sources/projects.md
+++ b/docs/data-sources/projects.md
@@ -73,7 +73,7 @@ Read-Only:
 - `release_creation_strategy` (List of Object) (see [below for nested schema](#nestedatt--projects--release_creation_strategy))
 - `release_notes_template` (String)
 - `servicenow_extension_settings` (List of Object) Provides extension settings for the ServiceNow integration for this project. (see [below for nested schema](#nestedatt--projects--servicenow_extension_settings))
-- `slug` (String)
+- `slug` (String) A human-readable, unique identifier, used to identify a project.
 - `space_id` (String) The space ID associated with this project.
 - `template` (List of Object) (see [below for nested schema](#nestedatt--projects--template))
 - `tenanted_deployment_participation` (String) The tenanted deployment mode of the resource. Valid account types are `Untenanted`, `TenantedOrUntenanted`, or `Tenanted`.

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -92,6 +92,7 @@ resource "octopusdeploy_project" "example" {
 - `release_creation_strategy` (Block List, Max: 1) (see [below for nested schema](#nestedblock--release_creation_strategy))
 - `release_notes_template` (String)
 - `servicenow_extension_settings` (Block List, Max: 1) Provides extension settings for the ServiceNow integration for this project. (see [below for nested schema](#nestedblock--servicenow_extension_settings))
+- `slug` (String) A human-readable, unique identifier, used to identify a project.
 - `space_id` (String) The space ID associated with this project.
 - `template` (Block List) (see [below for nested schema](#nestedblock--template))
 - `tenanted_deployment_participation` (String) The tenanted deployment mode of the resource. Valid account types are `Untenanted`, `TenantedOrUntenanted`, or `Tenanted`.
@@ -100,7 +101,6 @@ resource "octopusdeploy_project" "example" {
 ### Read-Only
 
 - `deployment_process_id` (String)
-- `slug` (String)
 - `variable_set_id` (String)
 
 <a id="nestedblock--connectivity_policy"></a>

--- a/octopusdeploy/schema_project.go
+++ b/octopusdeploy/schema_project.go
@@ -476,8 +476,11 @@ func getProjectSchema() map[string]*schema.Schema {
 			Type:        schema.TypeList,
 		},
 		"slug": {
-			Computed: true,
-			Type:     schema.TypeString,
+			Computed:         true,
+			Description:      "A human-readable, unique identifier, used to identify a project.",
+			Optional:         true,
+			Type:             schema.TypeString,
+			ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotWhiteSpace),
 		},
 		"space_id": {
 			Computed:         true,


### PR DESCRIPTION
This PR permits project slugs to be changed through configuration. Minimal validation (i.e. `StringIsNotWhiteSpace`) is enforced through the schema. Validating a slug's uniqueness or checking the API's capability to perform edits on slugs was deemed outside the scope of this change.

Fixes #472