### PR TITLE
Fix the ability to create new CaC enabled projects

### DIFF
--- a/octopusdeploy/resource_project.go
+++ b/octopusdeploy/resource_project.go
@@ -41,7 +41,7 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, m interf
 
 	if persistenceSettings != nil && persistenceSettings.Type() == projects.PersistenceSettingsTypeVersionControlled {
 		tflog.Info(ctx, "converting project to use VCS")
-		vcsProject, err := client.Projects.ConvertToVcs(createdProject, "converting project to use VCS", "octopus-vcs-conversion", persistenceSettings.(projects.GitPersistenceSettings))
+		vcsProject, err := client.Projects.ConvertToVcs(createdProject, "converting project to use VCS", "", persistenceSettings.(projects.GitPersistenceSettings))
 		if err != nil {
 			client.Projects.DeleteByID(createdProject.GetID())
 			return diag.FromErr(err)


### PR DESCRIPTION
This PR fixes the issue at https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/issues/496.

At a high level, the provider used to call `client.Projects.ConvertToVcs()` with `initialCommitBranch` hard coded to `octopus-vcs-conversion`. This meant *every* new project created with CaC enabled was only enabled on the branch `octopus-vcs-conversion`, regardless of what the default branch may have been. 

Any attempt to then update the deployment process failed because the default branch did not have the initial CaC files committed.

By setting this value to an empty string, we [defer the decision as to which branch to convert to the Octopus client](https://github.com/OctopusDeploy/go-octopusdeploy/blob/257dc6c0f834c286c88ee2c09f75ffb3b5aab7d1/pkg/projects/convert_to_vcs.go#L21).

# How to test this fix

The following HCL creates a CaC enabled project, which can be used to test the fix:

```
terraform {
  required_providers {
    //octopusdeploy = { source = "OctopusDeployLabs/octopusdeploy", version = "0.10.5" }
    octopusdeploy = { source = "octopus.com/com/octopusdeploy" }
  }
}

provider "octopusdeploy" {
  address  = "${var.octopus_server}"
  api_key  = "${var.octopus_apikey}"
  space_id = "${var.octopus_space_id}"
}

variable "octopus_server" {
  type        = string
  nullable    = false
  sensitive   = false
  description = "The URL of the Octopus server e.g. https://myinstance.octopus.app."
}

variable "octopus_apikey" {
  type        = string
  nullable    = false
  sensitive   = true
  description = "The API key used to access the Octopus server. See https://octopus.com/docs/octopus-rest-api/how-to-create-an-api-key for details on creating an API key."
}

variable "octopus_space_id" {
  type        = string
  nullable    = false
  sensitive   = false
  description = "The ID of the Octopus space to populate."
}

data "octopusdeploy_lifecycles" "default" {
  ids          = []
  partial_name = "Default Lifecycle"
  skip         = 0
  take         = 1
}

data "octopusdeploy_worker_pools" "workerpool_hosted_ubuntu" {
  name = "Hosted Ubuntu"
  ids  = null
  skip = 0
  take = 1
}

resource "octopusdeploy_project_group" "project_group_products" {
  name        = "Products API"
  description = "The products REST API"
}


resource "octopusdeploy_git_credential" "gitcredential" {
  name     = "Octopub"
  type     = "UsernamePassword"
  username = "${var.gitusername}"
  password = "${var.gitcredential}"
}

variable "gitusername" {
  type        = string
  nullable    = false
  sensitive   = true
  description = "The git username"
}

variable "gitcredential" {
  type        = string
  nullable    = false
  sensitive   = true
  description = "The git credentials"
}

variable "giturl" {
  type        = string
  nullable    = false
  sensitive   = true
  description = "The git url"
}

variable "project_git_base_path" {
  type        = string
  nullable    = false
  sensitive   = true
  description = "The path where Config-as-Code files are saved"
  default     = "products"
}

variable "project_cac_enabled" {
  type        = string
  nullable    = false
  sensitive   = false
  description = "Enables whether the project has Config-as-Code enabled"
  default     = "true"
}

resource "octopusdeploy_project" "project_products_service" {
  # The connectivity policy is controlled by CaC, so this value should be ignored if
  # any settings exist and CaC is enabled
  
  lifecycle {
    ignore_changes = [
      connectivity_policy,
    ]
  }
  
  name                                 = "Products Service"
  auto_create_release                  = false
  default_guided_failure_mode          = "EnvironmentDefault"
  default_to_skip_if_already_installed = false
  description                          = "Deploys the backend service to Lambda."
  discrete_channel_release             = false
  is_disabled                          = false
  lifecycle_id                         = "${data.octopusdeploy_lifecycles.default.lifecycles[0].id}"
  project_group_id                     = "${octopusdeploy_project_group.project_group_products.id}"
  included_library_variable_sets       = []
  tenanted_deployment_participation    = "Untenanted"

  is_version_controlled                = var.project_cac_enabled

  connectivity_policy {
    allow_deployments_to_no_targets = false
    exclude_unhealthy_targets       = false
    skip_machine_behavior           = "SkipUnavailableMachines"
  }

  # This settings configure the project to use Config-as-Code

  git_library_persistence_settings {
    git_credential_id  = octopusdeploy_git_credential.gitcredential.id
    url                = var.giturl
    base_path          = ".octopus/${var.project_git_base_path}"
    default_branch     = "main"
    protected_branches = []
  }
}

resource "octopusdeploy_deployment_process" "deployment_process_project_products_service" {
  lifecycle {
    ignore_changes = [
      step,
    ]
  }

  project_id = "${octopusdeploy_project.project_products_service.id}"

    step {
    condition           = "Success"
    name                = "Run a Script"
    package_requirement = "LetOctopusDecide"
    start_trigger       = "StartAfterPrevious"

    action {
      action_type                        = "Octopus.Script"
      name                               = "Run a Script"
      condition                          = "Success"
      run_on_server                      = true
      is_disabled                        = false
      can_be_used_for_project_versioning = false
      is_required                        = false
      worker_pool_id                     = "${data.octopusdeploy_worker_pools.workerpool_hosted_ubuntu.worker_pools[0].id}"
      properties                         = {
        "Octopus.Action.Script.Syntax" = "PowerShell"
        "Octopus.Action.Script.ScriptBody" = "echo \"hello world\""
        "Octopus.Action.Script.ScriptSource" = "Inline"
      }
      environments                       = []
      excluded_environments              = []
      channels                           = []
      tenant_tags                        = []
      features                           = []
    }

    properties   = {}
    target_roles = []
  }
}
```