### PR TITLE
Update action on space resource fails

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/OctopusDeploy/terraform-provider-octopusdeploy
 go 1.20
 
 require (
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.21.0
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.22.0
 	github.com/google/uuid v1.3.0
 	github.com/gruntwork-io/terratest v0.41.11
 	github.com/hashicorp/go-cty v1.4.1-0.20200723130312-85980079f637

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,8 @@ github.com/Masterminds/sprig/v3 v3.2.3/go.mod h1:rXcFaZ2zZbLRJv/xSysmlgIM1u11eBa
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.21.0 h1:7Tz0Y2la30RzYpg3fl/y9HZ1F2MmYJlWn3rjc6EIB0s=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.21.0/go.mod h1:GZmFu6LmN8Yg0tEoZx3ytk9FnaH+84cWm7u5TdWZC6E=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.22.0 h1:V1srSWIspgzlCNHOZvDQqaROdCZM1J43CvRbVc3G00k=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.22.0/go.mod h1:GZmFu6LmN8Yg0tEoZx3ytk9FnaH+84cWm7u5TdWZC6E=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=


### PR DESCRIPTION
When attempting to update an existing space resource, the following error is displayed: The TaskQueueStopped field is required.
Destroying and Creating works fine, but updating existing always expects the TaskQueueStopped value.

Fixes https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/issues/494

Majority of the changes are done in https://github.com/OctopusDeploy/go-octopusdeploy/pull/189