### PR TITLE
Mattc/fix duplicate actions

### DIFF
--- a/octopusdeploy/resource_deployment_process.go
+++ b/octopusdeploy/resource_deployment_process.go
@@ -3,13 +3,9 @@ package octopusdeploy
 import (
 	"context"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"log"
-	"reflect"
 	"regexp"
 	"strings"
-	"unsafe"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/deployments"
@@ -20,55 +16,13 @@ import (
 
 func resourceDeploymentProcess() *schema.Resource {
 	return &schema.Resource{
-		Schema:               getDeploymentProcessSchema(),
-		SchemaVersion:        0,
-		MigrateState:         nil,
-		StateUpgraders:       nil,
-		Create:               nil,
-		Read:                 nil,
-		Update:               nil,
-		Delete:               nil,
-		Exists:               nil,
-		CreateContext:        resourceDeploymentProcessCreate,
-		ReadContext:          resourceDeploymentProcessRead,
-		UpdateContext:        resourceDeploymentProcessUpdate,
-		DeleteContext:        resourceDeploymentProcessDelete,
-		CreateWithoutTimeout: nil,
-		ReadWithoutTimeout:   nil,
-		UpdateWithoutTimeout: nil,
-		DeleteWithoutTimeout: nil,
-		CustomizeDiff: customdiff.All(
-			func(context context.Context, d *schema.ResourceDiff, meta interface{}) error {
-				rd := reflect.ValueOf(d).Elem()
-				rdiff := rd.FieldByName("diff")
-				diff := reflect.NewAt(rdiff.Type(), unsafe.Pointer(rdiff.UnsafeAddr())).Elem().Interface().(*terraform.InstanceDiff)
-
-				rstate := rd.FieldByName("state")
-				state := reflect.NewAt(rstate.Type(), unsafe.Pointer(rstate.UnsafeAddr())).Elem().Interface().(*terraform.InstanceState)
-
-				for k, v := range state.Attributes {
-					if (strings.HasPrefix(k, "step.0.run_script_action") || strings.HasPrefix(k, "step.1.run_script_action")) && !strings.HasSuffix(k, "#") {
-						diff.Attributes[k] = &terraform.ResourceAttrDiff{
-							Old:         v,
-							New:         "",
-							NewComputed: false,
-							NewRemoved:  true,
-							NewExtra:    nil,
-							RequiresNew: false,
-							Sensitive:   false,
-							Type:        0,
-						}
-					}
-				}
-
-				return nil
-			},
-		),
-		Importer:           getImporter(),
-		DeprecationMessage: "",
-		Timeouts:           nil,
-		Description:        "This resource manages deployment processes in Octopus Deploy.",
-		UseJSONNumber:      false,
+		CreateContext: resourceDeploymentProcessCreate,
+		DeleteContext: resourceDeploymentProcessDelete,
+		Description:   "This resource manages deployment processes in Octopus Deploy.",
+		Importer:      getImporter(),
+		ReadContext:   resourceDeploymentProcessRead,
+		Schema:        getDeploymentProcessSchema(),
+		UpdateContext: resourceDeploymentProcessUpdate,
 	}
 }
 

--- a/octopusdeploy/resource_deployment_process.go
+++ b/octopusdeploy/resource_deployment_process.go
@@ -3,9 +3,13 @@ package octopusdeploy
 import (
 	"context"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"log"
+	"reflect"
 	"regexp"
 	"strings"
+	"unsafe"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/deployments"
@@ -16,13 +20,55 @@ import (
 
 func resourceDeploymentProcess() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceDeploymentProcessCreate,
-		DeleteContext: resourceDeploymentProcessDelete,
-		Description:   "This resource manages deployment processes in Octopus Deploy.",
-		Importer:      getImporter(),
-		ReadContext:   resourceDeploymentProcessRead,
-		Schema:        getDeploymentProcessSchema(),
-		UpdateContext: resourceDeploymentProcessUpdate,
+		Schema:               getDeploymentProcessSchema(),
+		SchemaVersion:        0,
+		MigrateState:         nil,
+		StateUpgraders:       nil,
+		Create:               nil,
+		Read:                 nil,
+		Update:               nil,
+		Delete:               nil,
+		Exists:               nil,
+		CreateContext:        resourceDeploymentProcessCreate,
+		ReadContext:          resourceDeploymentProcessRead,
+		UpdateContext:        resourceDeploymentProcessUpdate,
+		DeleteContext:        resourceDeploymentProcessDelete,
+		CreateWithoutTimeout: nil,
+		ReadWithoutTimeout:   nil,
+		UpdateWithoutTimeout: nil,
+		DeleteWithoutTimeout: nil,
+		CustomizeDiff: customdiff.All(
+			func(context context.Context, d *schema.ResourceDiff, meta interface{}) error {
+				rd := reflect.ValueOf(d).Elem()
+				rdiff := rd.FieldByName("diff")
+				diff := reflect.NewAt(rdiff.Type(), unsafe.Pointer(rdiff.UnsafeAddr())).Elem().Interface().(*terraform.InstanceDiff)
+
+				rstate := rd.FieldByName("state")
+				state := reflect.NewAt(rstate.Type(), unsafe.Pointer(rstate.UnsafeAddr())).Elem().Interface().(*terraform.InstanceState)
+
+				for k, v := range state.Attributes {
+					if (strings.HasPrefix(k, "step.0.run_script_action") || strings.HasPrefix(k, "step.1.run_script_action")) && !strings.HasSuffix(k, "#") {
+						diff.Attributes[k] = &terraform.ResourceAttrDiff{
+							Old:         v,
+							New:         "",
+							NewComputed: false,
+							NewRemoved:  true,
+							NewExtra:    nil,
+							RequiresNew: false,
+							Sensitive:   false,
+							Type:        0,
+						}
+					}
+				}
+
+				return nil
+			},
+		),
+		Importer:           getImporter(),
+		DeprecationMessage: "",
+		Timeouts:           nil,
+		Description:        "This resource manages deployment processes in Octopus Deploy.",
+		UseJSONNumber:      false,
 	}
 }
 

--- a/octopusdeploy/schema_deployment_action.go
+++ b/octopusdeploy/schema_deployment_action.go
@@ -249,7 +249,7 @@ func getActionSchema() (*schema.Schema, *schema.Resource) {
 	}
 
 	actionSchema := &schema.Schema{
-		Computed: true,
+		Computed: false,
 		Elem:     element,
 		Optional: true,
 		Type:     schema.TypeList,


### PR DESCRIPTION
Fixes https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/issues/509

The issue here is that [optional and computed blocks have values from the configuration file and state merged when sent back to the server](https://github.com/hashicorp/terraform/issues/22605#issuecomment-528629997):

>  This is a known consequence of how some providers configured their resources, often relying on undefined behavior in older versions of terraform.

> This block is defined as both optional and computed in the schema, so when a value already exists in the state, removing it from the config will leave the existing value as it may have been computed. There could be a couple workarounds for this, but they will require changes in the provider, and understanding of how this block is intended to be used internally.

Script steps are always saved as a `run_script_action` in the state, and when the configuration has a plain `action`, the `action` and the `run_script_action` are merged together and sent back to the server.

There is also [no way to zero out blocks](https://github.com/hashicorp/terraform-provider-google/issues/4326):

> Blocks have no zero value, so they can't be unset. Currently we're getting around that by using a gross hack that lets us continue to use block = [], but that's not going to stick around forever, so we need to find a new solution that is more inline with the type system.

Arguably there is no reason for actions to be defined as computed. To quote from the [Terraform docs](https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors):

> Computed is often used to represent values that are not user configurable or can not be known at time of terraform plan or apply, such as date of creation or a service specific UUID. Computed can be combined with other attributes to achieve specific behaviors, and can be used as output for interpolation into other resources.

Actions are never computed - they are always defined by the end user.

This PR changes actions, and other more specialised resources like `run_script_action`, to not be computed.

This resolves the linked issue as the plan generated by Terraform treats the absence of uncomputed resources as removing them, which is the desired behaviour.