### PR TITLE
Add support for runbooks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/OctopusDeploy/terraform-provider-octopusdeploy
 go 1.20
 
 require (
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.22.0
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.23.1-0.20230413224539-cbb0228d3dac
 	github.com/google/uuid v1.3.0
 	github.com/gruntwork-io/terratest v0.41.11
 	github.com/hashicorp/go-cty v1.4.1-0.20200723130312-85980079f637

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/OctopusDeploy/terraform-provider-octopusdeploy
 go 1.20
 
 require (
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.23.1-0.20230413224539-cbb0228d3dac
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.24.0
 	github.com/google/uuid v1.3.0
 	github.com/gruntwork-io/terratest v0.41.11
 	github.com/hashicorp/go-cty v1.4.1-0.20200723130312-85980079f637

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.22.0 h1:V1srSWIspgzlCNHOZvDQqaROdCZM1J43CvRbVc3G00k=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.22.0/go.mod h1:GZmFu6LmN8Yg0tEoZx3ytk9FnaH+84cWm7u5TdWZC6E=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.23.1-0.20230413224539-cbb0228d3dac h1:bjeyxyt1yla/GgkNrk5GRI28HzW+nXN2yk4pQnkLLZ0=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.23.1-0.20230413224539-cbb0228d3dac/go.mod h1:GZmFu6LmN8Yg0tEoZx3ytk9FnaH+84cWm7u5TdWZC6E=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/OctopusDeploy/go-octopusdeploy/v2 v2.22.0 h1:V1srSWIspgzlCNHOZvDQqaRO
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.22.0/go.mod h1:GZmFu6LmN8Yg0tEoZx3ytk9FnaH+84cWm7u5TdWZC6E=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.23.1-0.20230413224539-cbb0228d3dac h1:bjeyxyt1yla/GgkNrk5GRI28HzW+nXN2yk4pQnkLLZ0=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.23.1-0.20230413224539-cbb0228d3dac/go.mod h1:GZmFu6LmN8Yg0tEoZx3ytk9FnaH+84cWm7u5TdWZC6E=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.24.0 h1:b6kyJL3SDbbViCSjkvrO1cb8KOJMFNYfqA8B1SkL5g4=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.24.0/go.mod h1:GZmFu6LmN8Yg0tEoZx3ytk9FnaH+84cWm7u5TdWZC6E=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=

--- a/octopusdeploy/provider.go
+++ b/octopusdeploy/provider.go
@@ -75,6 +75,7 @@ func Provider() *schema.Provider {
 			"octopusdeploy_project":                                        resourceProject(),
 			"octopusdeploy_project_deployment_target_trigger":              resourceProjectDeploymentTargetTrigger(),
 			"octopusdeploy_project_group":                                  resourceProjectGroup(),
+			"octopusdeploy_runbook":                                        resourceRunbook(),
 			"octopusdeploy_scoped_user_role":                               resourceScopedUserRole(),
 			"octopusdeploy_script_module":                                  resourceScriptModule(),
 			"octopusdeploy_space":                                          resourceSpace(),

--- a/octopusdeploy/provider.go
+++ b/octopusdeploy/provider.go
@@ -76,6 +76,7 @@ func Provider() *schema.Provider {
 			"octopusdeploy_project_deployment_target_trigger":              resourceProjectDeploymentTargetTrigger(),
 			"octopusdeploy_project_group":                                  resourceProjectGroup(),
 			"octopusdeploy_runbook":                                        resourceRunbook(),
+			"octopusdeploy_runbook_process":                                resourceRunbookProcess(),
 			"octopusdeploy_scoped_user_role":                               resourceScopedUserRole(),
 			"octopusdeploy_script_module":                                  resourceScriptModule(),
 			"octopusdeploy_space":                                          resourceSpace(),

--- a/octopusdeploy/resource_runbook.go
+++ b/octopusdeploy/resource_runbook.go
@@ -1,0 +1,104 @@
+package octopusdeploy
+
+import (
+	"context"
+	"fmt"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/runbooks"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/internal/errors"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceRunbook() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceRunbookCreate,
+		DeleteContext: resourceRunbookDelete,
+		Description:   "This resource manages runbooks in Octopus Deploy.",
+		Importer:      getImporter(),
+		ReadContext:   resourceRunbookRead,
+		Schema:        getRunbookSchema(),
+		UpdateContext: resourceRunbookUpdate,
+	}
+}
+
+func resourceRunbookCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	runbook := expandRunbook(ctx, d)
+
+	tflog.Info(ctx, fmt.Sprintf("creating runbook (%s)", runbook.Name))
+
+	client := m.(*client.Client)
+	createdRunbook, err := client.Runbooks.Add(runbook)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := setRunbook(ctx, d, createdRunbook); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(createdRunbook.GetID())
+
+	tflog.Info(ctx, fmt.Sprintf("runbook created (%s)", d.Id()))
+	return nil
+}
+
+func resourceRunbookDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	tflog.Info(ctx, fmt.Sprintf("deleting runbook (%s)", d.Id()))
+
+	client := m.(*client.Client)
+	if err := client.Runbooks.DeleteByID(d.Id()); err != nil {
+		return diag.FromErr(err)
+	}
+
+	tflog.Info(ctx, fmt.Sprintf("runbook deleted (%s)", d.Id()))
+	d.SetId("")
+	return nil
+}
+
+func resourceRunbookRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	tflog.Info(ctx, fmt.Sprintf("reading runbook (%s)", d.Id()))
+
+	client := m.(*client.Client)
+	runbook, err := client.Runbooks.GetByID(d.Id())
+	if err != nil {
+		return errors.ProcessApiError(ctx, d, err, "runbook")
+	}
+
+	if err := setRunbook(ctx, d, runbook); err != nil {
+		return diag.FromErr(err)
+	}
+
+	tflog.Info(ctx, fmt.Sprintf("runbook read (%s)", d.Id()))
+	return nil
+}
+
+func resourceRunbookUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	tflog.Info(ctx, fmt.Sprintf("updating runbook (%s)", d.Id()))
+
+	client := m.(*client.Client)
+	runbook := expandRunbook(ctx, d)
+	var updatedRunbook *runbooks.Runbook
+	var err error
+
+	runbookLinks, err := client.Runbooks.GetByID(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	runbook.Links = runbookLinks.Links
+
+	updatedRunbook, err = client.Runbooks.Update(runbook)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := setRunbook(ctx, d, updatedRunbook); err != nil {
+		return diag.FromErr(err)
+	}
+
+	tflog.Info(ctx, fmt.Sprintf("runbook updated (%s)", d.Id()))
+	return nil
+}

--- a/octopusdeploy/resource_runbook_process.go
+++ b/octopusdeploy/resource_runbook_process.go
@@ -1,0 +1,156 @@
+package octopusdeploy
+
+import (
+	"context"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/runbooks"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"log"
+)
+
+func resourceRunbookProcess() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceRunbookProcessCreate,
+		DeleteContext: resourceRunbookProcessDelete,
+		Description:   "This resource manages runbook processes in Octopus Deploy.",
+		Importer:      getImporter(),
+		ReadContext:   resourceRunbookProcessRead,
+		Schema:        getRunbookProcessSchema(),
+		UpdateContext: resourceRunbookProcessUpdate,
+	}
+}
+
+func getRunbookProcessSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id": getIDSchema(),
+		"last_snapshot_id": {
+			Optional: true,
+			Type:     schema.TypeString,
+		},
+		"project_id": {
+			Description: "The project ID associated with this deployment process.",
+			Required:    true,
+			Type:        schema.TypeString,
+		},
+		"space_id": getSpaceIDSchema(),
+		"step":     getDeploymentStepSchema(),
+		"version": {
+			Computed:    true,
+			Description: "The version number of this deployment process.",
+			Optional:    true,
+			Type:        schema.TypeInt,
+		},
+	}
+}
+
+func resourceRunbookProcessCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*client.Client)
+	runbookProcess := expandRunbookProcess(d, client)
+
+	log.Printf("[INFO] creating runbook process: %#v", runbookProcess)
+
+	project, err := client.Projects.GetByID(runbookProcess.ProjectID)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	var current *runbooks.RunbookProcess
+	current, err = client.RunbookProcesses.GetByID(project.DeploymentProcessID)
+
+	runbookProcess.ID = current.ID
+	runbookProcess.Links = current.Links
+	runbookProcess.Version = current.Version
+
+	createdRunbookProcess, err := client.RunbookProcesses.Update(runbookProcess)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := setRunbookProcess(ctx, d, createdRunbookProcess); err != nil {
+		return diag.FromErr(err)
+	}
+
+	id := createdRunbookProcess.GetID()
+	if project.PersistenceSettings != nil && project.PersistenceSettings.Type() == projects.PersistenceSettingsTypeVersionControlled {
+		id = "runbookProcess-" + createdRunbookProcess.ProjectID + "-" + runbookProcess.Branch
+	}
+
+	d.SetId(id)
+
+	log.Printf("[INFO] deployment process created (%s)", d.Id())
+	return nil
+}
+
+func resourceRunbookProcessDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	log.Printf("[INFO] deleting runbook process (%s)", d.Id())
+
+	// "Deleting" a runbook process just means to clear it out
+	client := m.(*client.Client)
+	current, err := client.RunbookProcesses.GetByID(d.Id())
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	runbookProcess := &runbooks.RunbookProcess{
+		Version: current.Version,
+	}
+	runbookProcess.Links = current.Links
+	runbookProcess.ID = d.Id()
+
+	_, err = client.RunbookProcesses.Update(runbookProcess)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId("")
+	log.Printf("[INFO] deployment process deleted")
+	return nil
+}
+
+func resourceRunbookProcessRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	log.Printf("[INFO] reading runbook process (%s)", d.Id())
+
+	client := m.(*client.Client)
+	runbookProcess, err := client.RunbookProcesses.GetByID(d.Id())
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := setRunbookProcess(ctx, d, runbookProcess); err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] runbook process read (%s)", d.Id())
+	return nil
+}
+
+func resourceRunbookProcessUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	log.Printf("[INFO] updating runbook process (%s)", d.Id())
+
+	client := m.(*client.Client)
+	runbookProcess := expandRunbookProcess(d, client)
+	current, err := client.RunbookProcesses.GetByID(d.Id())
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	runbookProcess.Links = current.Links
+	runbookProcess.Version = current.Version
+
+	updatedRunbookProcess, err := client.RunbookProcesses.Update(runbookProcess)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := setRunbookProcess(ctx, d, updatedRunbookProcess); err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[INFO] deployment process updated (%s)", d.Id())
+	return nil
+}

--- a/octopusdeploy/resource_runbook_process.go
+++ b/octopusdeploy/resource_runbook_process.go
@@ -3,7 +3,6 @@ package octopusdeploy
 import (
 	"context"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/newclient"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/runbooks"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -73,10 +72,7 @@ func resourceRunbookProcessCreate(ctx context.Context, d *schema.ResourceData, m
 	runbookProcess.ProjectID = current.ProjectID
 	runbookProcess.RunbookID = current.RunbookID
 
-	createdRunbookProcess, err := newclient.Put[runbooks.RunbookProcess](
-		client.HttpSession(),
-		client.HttpSession().BaseURL.String()+"/Projects/"+runbook.ProjectID+"/RunbookProcesses/"+runbookProcess.ID,
-		runbookProcess)
+	createdRunbookProcess, err := client.RunbookProcesses.Update(runbookProcess)
 
 	if err != nil {
 		return diag.FromErr(err)
@@ -111,10 +107,7 @@ func resourceRunbookProcessDelete(ctx context.Context, d *schema.ResourceData, m
 	runbookProcess.Links = current.Links
 	runbookProcess.ID = d.Id()
 
-	_, err = newclient.Put[runbooks.RunbookProcess](
-		client.HttpSession(),
-		client.HttpSession().BaseURL.String()+"/RunbookProcesses/"+runbookProcess.ID,
-		runbookProcess)
+	_, err = client.RunbookProcesses.Update(runbookProcess)
 
 	if err != nil {
 		return diag.FromErr(err)
@@ -157,10 +150,7 @@ func resourceRunbookProcessUpdate(ctx context.Context, d *schema.ResourceData, m
 	runbookProcess.Links = current.Links
 	runbookProcess.Version = current.Version
 
-	updatedRunbookProcess, err := newclient.Put[runbooks.RunbookProcess](
-		client.HttpSession(),
-		client.HttpSession().BaseURL.String()+"/RunbookProcesses/"+runbookProcess.ID,
-		runbookProcess)
+	updatedRunbookProcess, err := client.RunbookProcesses.Update(runbookProcess)
 
 	if err != nil {
 		return diag.FromErr(err)

--- a/octopusdeploy/resource_runbook_process.go
+++ b/octopusdeploy/resource_runbook_process.go
@@ -69,8 +69,6 @@ func resourceRunbookProcessCreate(ctx context.Context, d *schema.ResourceData, m
 	runbookProcess.ID = current.ID
 	runbookProcess.Links = current.Links
 	runbookProcess.Version = current.Version
-	runbookProcess.ProjectID = current.ProjectID
-	runbookProcess.RunbookID = current.RunbookID
 
 	createdRunbookProcess, err := client.RunbookProcesses.Update(runbookProcess)
 

--- a/octopusdeploy/resource_runbook_process.go
+++ b/octopusdeploy/resource_runbook_process.go
@@ -25,8 +25,9 @@ func getRunbookProcessSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"id": getIDSchema(),
 		"last_snapshot_id": {
-			Optional: true,
-			Type:     schema.TypeString,
+			Description: "Read only value containing the last snapshot ID.",
+			Optional:    true,
+			Type:        schema.TypeString,
 		},
 		"project_id": {
 			Description: "The project ID associated with this deployment process.",

--- a/octopusdeploy/schema_runbook.go
+++ b/octopusdeploy/schema_runbook.go
@@ -100,20 +100,32 @@ func getRunbookDataSchema() map[string]*schema.Schema {
 
 func getRunbookSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"name": {
+			Description:      "The name of the project in Octopus Deploy. This name must be unique.",
+			Required:         true,
+			Type:             schema.TypeString,
+			ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotWhiteSpace),
+		},
 		"description": {
-			Computed:      true,
-			ConflictsWith: []string{"deployment_process_id"},
-			Description:   "The description of this project.",
-			Optional:      true,
-			Type:          schema.TypeString,
+			Computed:    true,
+			Description: "The description of this runbook.",
+			Optional:    true,
+			Type:        schema.TypeString,
+		},
+		"project_id": {
+			Description: "The project that this runbook belongs to",
+			Required:    true,
+			Type:        schema.TypeString,
 		},
 		"runbook_process_id": {
-			Computed: true,
-			Type:     schema.TypeString,
+			Description: "The runbook process ID",
+			Computed:    true,
+			Type:        schema.TypeString,
 		},
 		"published_runbook_snapshot_id": {
-			Computed: true,
-			Type:     schema.TypeString,
+			Description: "The published snapshot ID",
+			Computed:    true,
+			Type:        schema.TypeString,
 		},
 		"space_id": {
 			Computed:         true,
@@ -122,7 +134,7 @@ func getRunbookSchema() map[string]*schema.Schema {
 			Type:             schema.TypeString,
 			ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotWhiteSpace),
 		},
-		"tenanted_deployment_participation": getTenantedDeploymentSchema(),
+		"multi_tenancy_mode": getTenantedDeploymentSchema(),
 		"connectivity_policy": {
 			Computed: true,
 			Elem:     &schema.Resource{Schema: getConnectivityPolicySchema()},
@@ -132,10 +144,12 @@ func getRunbookSchema() map[string]*schema.Schema {
 		},
 		"environment_scope": {
 			Computed: true,
+			Optional: true,
 			Type:     schema.TypeString,
 		},
 		"environments": {
 			Computed: true,
+			Optional: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 			Type:     schema.TypeList,
 		},
@@ -166,7 +180,7 @@ func setRunbook(ctx context.Context, d *schema.ResourceData, runbook *runbooks.R
 	}
 	d.Set("environment_scope", runbook.EnvironmentScope)
 	d.Set("environments", runbook.Environments)
-	d.Set("default_guided_failure_modedefault_guided_failure_mode", runbook.DefaultGuidedFailureMode)
+	d.Set("default_guided_failure_mode", runbook.DefaultGuidedFailureMode)
 
 	return nil
 }

--- a/octopusdeploy/schema_runbook.go
+++ b/octopusdeploy/schema_runbook.go
@@ -62,6 +62,7 @@ func flattenRunbook(ctx context.Context, d *schema.ResourceData, runbook *runboo
 	}
 
 	runbookMap := map[string]interface{}{
+		"id":                            runbook.ID,
 		"name":                          runbook.Name,
 		"project_id":                    runbook.ProjectID,
 		"description":                   runbook.Description,
@@ -100,6 +101,7 @@ func getRunbookDataSchema() map[string]*schema.Schema {
 
 func getRunbookSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"id": getIDSchema(),
 		"name": {
 			Description:      "The name of the project in Octopus Deploy. This name must be unique.",
 			Required:         true,
@@ -113,17 +115,17 @@ func getRunbookSchema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 		},
 		"project_id": {
-			Description: "The project that this runbook belongs to",
+			Description: "The project that this runbook belongs to.",
 			Required:    true,
 			Type:        schema.TypeString,
 		},
 		"runbook_process_id": {
-			Description: "The runbook process ID",
+			Description: "The runbook process ID.",
 			Computed:    true,
 			Type:        schema.TypeString,
 		},
 		"published_runbook_snapshot_id": {
-			Description: "The published snapshot ID",
+			Description: "The published snapshot ID.",
 			Computed:    true,
 			Type:        schema.TypeString,
 		},
@@ -167,7 +169,7 @@ func getRunbookSchema() map[string]*schema.Schema {
 }
 
 func setRunbook(ctx context.Context, d *schema.ResourceData, runbook *runbooks.Runbook) error {
-	d.Set("id", runbook.ID)
+	d.Set("id", runbook.GetID())
 	d.Set("name", runbook.Name)
 	d.Set("project_id", runbook.ProjectID)
 	d.Set("description", runbook.Description)

--- a/octopusdeploy/schema_runbook.go
+++ b/octopusdeploy/schema_runbook.go
@@ -57,6 +57,10 @@ func expandRunbook(ctx context.Context, d *schema.ResourceData) *runbooks.Runboo
 		runbook.RunRetentionPolicy = expandRunbookRetentionPolicy(v.([]interface{}))
 	}
 
+	if v, ok := d.GetOk("force_package_download"); ok {
+		runbook.ForcePackageDownload = v.(bool)
+	}
+
 	return runbook
 }
 
@@ -144,6 +148,12 @@ func getRunbookSchema() map[string]*schema.Schema {
 			Optional: true,
 			Type:     schema.TypeList,
 		},
+		"force_package_download": {
+			Description: "Whether to force packages to be re-downloaded or not",
+			Computed:    true,
+			Optional:    true,
+			Type:        schema.TypeBool,
+		},
 	}
 }
 
@@ -162,6 +172,7 @@ func setRunbook(ctx context.Context, d *schema.ResourceData, runbook *runbooks.R
 	d.Set("environment_scope", runbook.EnvironmentScope)
 	d.Set("environments", runbook.Environments)
 	d.Set("default_guided_failure_mode", runbook.DefaultGuidedFailureMode)
+	d.Set("force_package_download", runbook.ForcePackageDownload)
 
 	return nil
 }

--- a/octopusdeploy/schema_runbook.go
+++ b/octopusdeploy/schema_runbook.go
@@ -1,0 +1,172 @@
+package octopusdeploy
+
+import (
+	"context"
+	"fmt"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/runbooks"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func expandRunbook(ctx context.Context, d *schema.ResourceData) *runbooks.Runbook {
+	name := d.Get("name").(string)
+	projectId := d.Get("project_id").(string)
+
+	runbook := runbooks.NewRunbook(name, projectId)
+	runbook.ID = d.Id()
+
+	if v, ok := d.GetOk("description"); ok {
+		runbook.Description = v.(string)
+	}
+
+	if v, ok := d.GetOk("runbook_process_id"); ok {
+		runbook.RunbookProcessID = v.(string)
+	}
+
+	if v, ok := d.GetOk("published_runbook_snapshot_id"); ok {
+		runbook.PublishedRunbookSnapshotID = v.(string)
+	}
+
+	if v, ok := d.GetOk("space_id"); ok {
+		runbook.SpaceID = v.(string)
+	}
+
+	if v, ok := d.GetOk("multi_tenancy_mode"); ok {
+		runbook.MultiTenancyMode = core.TenantedDeploymentMode(v.(string))
+	}
+
+	if v, ok := d.GetOk("connectivity_policy"); ok {
+		runbook.ConnectivityPolicy = expandConnectivityPolicy(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("environment_scope"); ok {
+		runbook.EnvironmentScope = v.(string)
+	}
+
+	if v, ok := d.GetOk("environments"); ok {
+		runbook.Environments = getSliceFromTerraformTypeList(v)
+	}
+
+	if v, ok := d.GetOk("default_guided_failure_mode"); ok {
+		runbook.DefaultGuidedFailureMode = v.(string)
+	}
+
+	return runbook
+}
+
+func flattenRunbook(ctx context.Context, d *schema.ResourceData, runbook *runbooks.Runbook) map[string]interface{} {
+	if runbook == nil {
+		return nil
+	}
+
+	runbookMap := map[string]interface{}{
+		"name":                          runbook.Name,
+		"project_id":                    runbook.ProjectID,
+		"description":                   runbook.Description,
+		"runbook_process_id":            runbook.RunbookProcessID,
+		"published_runbook_snapshot_id": runbook.PublishedRunbookSnapshotID,
+		"space_id":                      runbook.SpaceID,
+		"multi_tenancy_mode":            runbook.MultiTenancyMode,
+		"connectivity_policy":           runbook.ConnectivityPolicy,
+		"environment_scope":             runbook.EnvironmentScope,
+		"environments":                  runbook.Environments,
+		"default_guided_failure_mode":   runbook.DefaultGuidedFailureMode,
+	}
+
+	return runbookMap
+}
+
+func getRunbookDataSchema() map[string]*schema.Schema {
+	dataSchema := getProjectSchema()
+	setDataSchema(&dataSchema)
+
+	return map[string]*schema.Schema{
+		"id":           getDataSchemaID(),
+		"ids":          getQueryIDs(),
+		"partial_name": getQueryPartialName(),
+		"runbooks": {
+			Computed:    true,
+			Description: "A list of runbooks that match the filter(s).",
+			Elem:        &schema.Resource{Schema: dataSchema},
+			Optional:    true,
+			Type:        schema.TypeList,
+		},
+		"skip": getQuerySkip(),
+		"take": getQueryTake(),
+	}
+}
+
+func getRunbookSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"description": {
+			Computed:      true,
+			ConflictsWith: []string{"deployment_process_id"},
+			Description:   "The description of this project.",
+			Optional:      true,
+			Type:          schema.TypeString,
+		},
+		"runbook_process_id": {
+			Computed: true,
+			Type:     schema.TypeString,
+		},
+		"published_runbook_snapshot_id": {
+			Computed: true,
+			Type:     schema.TypeString,
+		},
+		"space_id": {
+			Computed:         true,
+			Description:      "The space ID associated with this project.",
+			Optional:         true,
+			Type:             schema.TypeString,
+			ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotWhiteSpace),
+		},
+		"tenanted_deployment_participation": getTenantedDeploymentSchema(),
+		"connectivity_policy": {
+			Computed: true,
+			Elem:     &schema.Resource{Schema: getConnectivityPolicySchema()},
+			MaxItems: 1,
+			Optional: true,
+			Type:     schema.TypeList,
+		},
+		"environment_scope": {
+			Computed: true,
+			Type:     schema.TypeString,
+		},
+		"environments": {
+			Computed: true,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+			Type:     schema.TypeList,
+		},
+		"default_guided_failure_mode": {
+			Computed: true,
+			Optional: true,
+			Type:     schema.TypeString,
+			ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{
+				"EnvironmentDefault",
+				"Off",
+				"On",
+			}, false)),
+		},
+	}
+}
+
+func setRunbook(ctx context.Context, d *schema.ResourceData, runbook *runbooks.Runbook) error {
+	d.Set("id", runbook.ID)
+	d.Set("name", runbook.Name)
+	d.Set("project_id", runbook.ProjectID)
+	d.Set("description", runbook.Description)
+	d.Set("runbook_process_id", runbook.RunbookProcessID)
+	d.Set("published_runbook_snapshot_id", runbook.PublishedRunbookSnapshotID)
+	d.Set("space_id", runbook.SpaceID)
+	d.Set("multi_tenancy_mode", runbook.MultiTenancyMode)
+	if err := d.Set("connectivity_policy", flattenConnectivityPolicy(runbook.ConnectivityPolicy)); err != nil {
+		return fmt.Errorf("error setting connectivity_policy: %s", err)
+	}
+	d.Set("environment_scope", runbook.EnvironmentScope)
+	d.Set("environments", runbook.Environments)
+	d.Set("default_guided_failure_modedefault_guided_failure_mode", runbook.DefaultGuidedFailureMode)
+
+	return nil
+}

--- a/octopusdeploy/schema_runbook.go
+++ b/octopusdeploy/schema_runbook.go
@@ -110,9 +110,10 @@ func getRunbookSchema() map[string]*schema.Schema {
 			Type:     schema.TypeList,
 		},
 		"environment_scope": {
-			Computed: true,
-			Optional: true,
-			Type:     schema.TypeString,
+			Description: "Determines how the runbook is scoped to environments.",
+			Computed:    true,
+			Optional:    true,
+			Type:        schema.TypeString,
 			ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{
 				"All",
 				"Specified",
@@ -120,15 +121,17 @@ func getRunbookSchema() map[string]*schema.Schema {
 			}, false)),
 		},
 		"environments": {
-			Computed: true,
-			Optional: true,
-			Elem:     &schema.Schema{Type: schema.TypeString},
-			Type:     schema.TypeList,
+			Description: "When environment_scope is set to \"Specified\", this is the list of environments the runbook can be run against.",
+			Computed:    true,
+			Optional:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Type:        schema.TypeList,
 		},
 		"default_guided_failure_mode": {
-			Computed: true,
-			Optional: true,
-			Type:     schema.TypeString,
+			Description: "Sets the runbook guided failure mode.",
+			Computed:    true,
+			Optional:    true,
+			Type:        schema.TypeString,
 			ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{
 				"EnvironmentDefault",
 				"Off",
@@ -136,7 +139,8 @@ func getRunbookSchema() map[string]*schema.Schema {
 			}, false)),
 		},
 		"retention_policy": {
-			Computed: true,
+			Description: "Sets the runbook retention policy",
+			Computed:    true,
 			DefaultFunc: func() (interface{}, error) {
 				return flattenRunbookRetentionPeriod(&runbooks.RunbookRetentionPeriod{
 					QuantityToKeep:    100,

--- a/octopusdeploy/schema_runbook_process.go
+++ b/octopusdeploy/schema_runbook_process.go
@@ -10,10 +10,16 @@ import (
 )
 
 func expandRunbookProcess(d *schema.ResourceData, client *client.Client) *runbooks.RunbookProcess {
-	projectID := d.Get("project_id").(string)
 	runbookProcess := runbooks.NewRunbookProcess()
-	runbookProcess.ProjectID = projectID
 	runbookProcess.ID = d.Id()
+
+	if v, ok := d.GetOk("project_id"); ok {
+		runbookProcess.ProjectID = v.(string)
+	}
+
+	if v, ok := d.GetOk("runbook_id"); ok {
+		runbookProcess.RunbookID = v.(string)
+	}
 
 	if v, ok := d.GetOk("last_snapshot_id"); ok {
 		runbookProcess.LastSnapshotID = v.(string)
@@ -42,6 +48,7 @@ func expandRunbookProcess(d *schema.ResourceData, client *client.Client) *runboo
 func setRunbookProcess(ctx context.Context, d *schema.ResourceData, RunbookProcess *runbooks.RunbookProcess) error {
 	d.Set("last_snapshot_id", RunbookProcess.LastSnapshotID)
 	d.Set("project_id", RunbookProcess.ProjectID)
+	d.Set("runbook_id", RunbookProcess.RunbookID)
 	d.Set("space_id", RunbookProcess.SpaceID)
 	d.Set("version", RunbookProcess.Version)
 

--- a/octopusdeploy/schema_runbook_process.go
+++ b/octopusdeploy/schema_runbook_process.go
@@ -1,0 +1,53 @@
+package octopusdeploy
+
+import (
+	"context"
+	"fmt"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/runbooks"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func expandRunbookProcess(d *schema.ResourceData, client *client.Client) *runbooks.RunbookProcess {
+	projectID := d.Get("project_id").(string)
+	runbookProcess := runbooks.NewRunbookProcess()
+	runbookProcess.ProjectID = projectID
+	runbookProcess.ID = d.Id()
+
+	if v, ok := d.GetOk("last_snapshot_id"); ok {
+		runbookProcess.LastSnapshotID = v.(string)
+	}
+
+	if v, ok := d.GetOk("space_id"); ok {
+		runbookProcess.SpaceID = v.(string)
+	}
+
+	if v, ok := d.GetOk("version"); ok {
+		version := int32(v.(int))
+		runbookProcess.Version = &version
+	}
+
+	if v, ok := d.GetOk("step"); ok {
+		steps := v.([]interface{})
+		for _, step := range steps {
+			deploymentStep := expandDeploymentStep(step.(map[string]interface{}))
+			runbookProcess.Steps = append(runbookProcess.Steps, deploymentStep)
+		}
+	}
+
+	return runbookProcess
+}
+
+func setRunbookProcess(ctx context.Context, d *schema.ResourceData, RunbookProcess *runbooks.RunbookProcess) error {
+	d.Set("last_snapshot_id", RunbookProcess.LastSnapshotID)
+	d.Set("project_id", RunbookProcess.ProjectID)
+	d.Set("space_id", RunbookProcess.SpaceID)
+	d.Set("version", RunbookProcess.Version)
+
+	if err := d.Set("step", flattenDeploymentSteps(RunbookProcess.Steps)); err != nil {
+		return fmt.Errorf("error setting step: %s", err)
+	}
+
+	return nil
+}

--- a/octopusdeploy/schema_runbook_retention_period.go
+++ b/octopusdeploy/schema_runbook_retention_period.go
@@ -1,0 +1,49 @@
+package octopusdeploy
+
+import (
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/runbooks"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func expandRunbookRetentionPolicy(flattenedRetentionPeriod interface{}) *runbooks.RunbookRetentionPeriod {
+	if flattenedRetentionPeriod == nil {
+		return nil
+	}
+
+	retentionPeriodProperties := flattenedRetentionPeriod.([]interface{})
+	if len(retentionPeriodProperties) == 1 {
+		retentionPeriodMap := retentionPeriodProperties[0].(map[string]interface{})
+		return &runbooks.RunbookRetentionPeriod{
+			QuantityToKeep:    int32(retentionPeriodMap["quantity_to_keep"].(int)),
+			ShouldKeepForever: retentionPeriodMap["should_keep_forever"].(bool),
+		}
+	}
+
+	return nil
+}
+
+func flattenRunbookRetentionPeriod(r *runbooks.RunbookRetentionPeriod) []interface{} {
+	retentionPeriod := make(map[string]interface{})
+	retentionPeriod["quantity_to_keep"] = int(r.QuantityToKeep)
+	retentionPeriod["should_keep_forever"] = r.ShouldKeepForever
+	return []interface{}{retentionPeriod}
+}
+
+func getRunbookRetentionPeriodSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"quantity_to_keep": {
+			Default:          30,
+			Description:      "The number of days/releases to keep. The default value is `100`. If `0` then all are kept.",
+			Optional:         true,
+			Type:             schema.TypeInt,
+			ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(0)),
+		},
+		"should_keep_forever": {
+			Default:     false,
+			Description: "Indicates if items should never be deleted. The default value is `false`.",
+			Optional:    true,
+			Type:        schema.TypeBool,
+		},
+	}
+}

--- a/octopusdeploy/schema_runbook_retention_period.go
+++ b/octopusdeploy/schema_runbook_retention_period.go
@@ -33,7 +33,7 @@ func flattenRunbookRetentionPeriod(r *runbooks.RunbookRetentionPeriod) []interfa
 func getRunbookRetentionPeriodSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"quantity_to_keep": {
-			Default:          30,
+			Default:          100,
 			Description:      "The number of days/releases to keep. The default value is `100`. If `0` then all are kept.",
 			Optional:         true,
 			Type:             schema.TypeInt,

--- a/octopusdeploy/schema_runbook_retention_period.go
+++ b/octopusdeploy/schema_runbook_retention_period.go
@@ -40,10 +40,11 @@ func getRunbookRetentionPeriodSchema() map[string]*schema.Schema {
 			ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(0)),
 		},
 		"should_keep_forever": {
-			Default:     false,
-			Description: "Indicates if items should never be deleted. The default value is `false`.",
-			Optional:    true,
-			Type:        schema.TypeBool,
+			Default:       false,
+			Description:   "Indicates if items should never be deleted. The default value is `false`.",
+			Optional:      true,
+			Type:          schema.TypeBool,
+			ConflictsWith: []string{"retention_policy.quantity_to_keep"},
 		},
 	}
 }


### PR DESCRIPTION
This PR adds support for runbooks. An example of the syntax is shown below:

```
data "octopusdeploy_lifecycles" "lifecycle_default_lifecycle" {
  ids          = null
  partial_name = "Default Lifecycle"
  skip         = 0
  take         = 1
}

resource "octopusdeploy_project" "deploy_frontend_project" {
  auto_create_release                  = false
  default_guided_failure_mode          = "EnvironmentDefault"
  default_to_skip_if_already_installed = false
  description                          = "Test project"
  discrete_channel_release             = false
  is_disabled                          = false
  is_discrete_channel_release          = false
  is_version_controlled                = false
  lifecycle_id                         = data.octopusdeploy_lifecycles.lifecycle_default_lifecycle.lifecycles[0].id
  name                                 = "Test"
  project_group_id                     = octopusdeploy_project_group.project_group_test.id
  tenanted_deployment_participation    = "Untenanted"
  space_id                             = var.octopus_space_id
  included_library_variable_sets       = []
  versioning_strategy {
    template = "#{Octopus.Version.LastMajor}.#{Octopus.Version.LastMinor}.#{Octopus.Version.LastPatch}.#{Octopus.Version.NextRevision}"
  }

  connectivity_policy {
    allow_deployments_to_no_targets = false
    exclude_unhealthy_targets       = false
    skip_machine_behavior           = "SkipUnavailableMachines"
  }
  retention_policy {
    quantity_to_keep = 10
    should_keep_forever = false
  }
}

resource "octopusdeploy_runbook" "runbook" {
  project_id         = octopusdeploy_project.deploy_frontend_project.id
  name               = "Runbook"
  description        = "Test Runbook"
  multi_tenancy_mode = "Untenanted"
  force_package_download = true
  connectivity_policy {
    allow_deployments_to_no_targets = false
    exclude_unhealthy_targets       = false
    skip_machine_behavior           = "SkipUnavailableMachines"
  }
  environment_scope           = "Specified"
  environments                = [octopusdeploy_environment.development_environment.id]
  default_guided_failure_mode = "EnvironmentDefault"
}

resource "octopusdeploy_runbook_process" "runbook" {
  runbook_id = octopusdeploy_runbook.runbook.id

  step {
    condition           = "Success"
    name                = "Hello world (using PowerShell)"
    package_requirement = "LetOctopusDecide"
    start_trigger       = "StartAfterPrevious"

    action {
      action_type                        = "Octopus.Script"
      name                               = "Hello world (using PowerShell)"
      condition                          = "Success"
      run_on_server                      = true
      is_disabled                        = false
      can_be_used_for_project_versioning = false
      is_required                        = true
      worker_pool_id                     = ""
      properties                         = {
        "Octopus.Action.Script.ScriptSource" = "Inline"
        "Octopus.Action.Script.ScriptBody" = "Write-Host 'Hello world, using PowerShell'\n\n#TODO: Experiment with steps of your own :)\n\nWrite-Host '[Learn more about the types of steps available in Octopus](https://oc.to/OnboardingAddStepsLearnMore)'"
        "Octopus.Action.Script.Syntax" = "PowerShell"
      }
      environments                       = []
      excluded_environments              = []
      channels                           = []
      tenant_tags                        = []
      features                           = []
    }

    properties   = {}
    target_roles = []
  }
}
```

Fixes https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/issues/135