### PR TITLE
Dont force creation of a branch during Cac

### DIFF
--- a/octopusdeploy/resource_deployment_process.go
+++ b/octopusdeploy/resource_deployment_process.go
@@ -2,13 +2,13 @@ package octopusdeploy
 
 import (
 	"context"
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
 	"log"
 	"regexp"
 	"strings"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/deployments"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/internal/errors"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -133,9 +133,7 @@ func resourceDeploymentProcessDelete(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 
-	r, _ = regexp.Compile(`\d+-\w+`)
-	gitRef := strings.SplitAfter(r.FindString(d.Id()), "-")[1]
-
+	gitRef := getGitRef(d)
 	current, err = client.DeploymentProcesses.Get(project, gitRef)
 	if err != nil {
 		return diag.FromErr(err)
@@ -179,9 +177,7 @@ func resourceDeploymentProcessRead(ctx context.Context, d *schema.ResourceData, 
 		return errors.ProcessApiError(ctx, d, err, "project")
 	}
 
-	r, _ = regexp.Compile(`\d+-\w+`)
-	gitRef := strings.SplitAfter(r.FindString(d.Id()), "-")[1]
-
+	gitRef := getGitRef(d)
 	deploymentProcess, err = client.DeploymentProcesses.Get(project, gitRef)
 	if err == nil {
 		if err := setDeploymentProcess(ctx, d, deploymentProcess); err != nil {
@@ -210,9 +206,10 @@ func resourceDeploymentProcessUpdate(ctx context.Context, d *schema.ResourceData
 			return diag.FromErr(err)
 		}
 
-		r, _ = regexp.Compile(`\d+-\w+`)
-		gitRef := strings.SplitAfter(r.FindString(d.Id()), "-")[1]
-
+		gitRef := getGitRef(d)
+		if deploymentProcess.Branch != gitRef {
+			return diag.Errorf("you cannot change a deployment processes branch. instead create a new resource with the new branch and, if required, destroy the previous one")
+		}
 		current, err = client.DeploymentProcesses.Get(project, gitRef)
 		if err != nil {
 			return diag.FromErr(err)
@@ -233,4 +230,10 @@ func resourceDeploymentProcessUpdate(ctx context.Context, d *schema.ResourceData
 
 	log.Printf("[INFO] deployment process updated (%s)", d.Id())
 	return nil
+}
+
+func getGitRef(d *schema.ResourceData) string {
+	r, _ := regexp.Compile(`\d+-\w+`)
+	gitRef := strings.SplitAfter(r.FindString(d.Id()), "-")[1]
+	return gitRef
 }

--- a/octopusdeploy/resource_project.go
+++ b/octopusdeploy/resource_project.go
@@ -41,7 +41,8 @@ func resourceProjectCreate(ctx context.Context, d *schema.ResourceData, m interf
 
 	if persistenceSettings != nil && persistenceSettings.Type() == projects.PersistenceSettingsTypeVersionControlled {
 		tflog.Info(ctx, "converting project to use VCS")
-		vcsProject, err := client.Projects.ConvertToVcs(createdProject, "converting project to use VCS", "octopus-vcs-conversion", persistenceSettings.(projects.GitPersistenceSettings))
+
+		vcsProject, err := client.Projects.ConvertToVcs(createdProject, "converting project to use VCS", "", persistenceSettings.(projects.GitPersistenceSettings))
 		if err != nil {
 			client.Projects.DeleteByID(createdProject.GetID())
 			return diag.FromErr(err)
@@ -116,7 +117,7 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, m interf
 			tflog.Info(ctx, fmt.Sprintf("converting project to use VCS (%s)", d.Id()))
 
 			project.Links["ConvertToVcs"] = convertToVcsLink
-			vcsProject, err := client.Projects.ConvertToVcs(project, "converting project to use VCS", "octopus-vcs-conversion", versionControlSettings)
+			vcsProject, err := client.Projects.ConvertToVcs(project, "converting project to use VCS", "", versionControlSettings)
 			if err != nil {
 				return diag.FromErr(err)
 			}


### PR DESCRIPTION
We shouldn't ever be creating random branches in user's repositories during conversion to VCS.

## Protected Default Branches
**Note: In general we would advise against using multiple branches like this in Octopus via the Terraform provider as there may be some unexpected behavior due to the different sources of truth that are now split between the terraform file and the git repository.**

In many cases, the default branch (which I'll refer to as `master` here on) will have no branch protection rules and the user will be able to commit directly to this primary location. For some users however, they may want to define a "default branch" (which is used in currently non VCS areas like runbooks), but not have the ability to push directly to it.

This is simple when dealing with this via the portal since the user can commit the initial project settings to their branch of choosing, and then work against that branch until someone externally to Octopus merges that branch to `master`. This deliberate action to commit to a different branch and merge externally does not work well with the stateful, source-of-truth nature of terraform.

The steps that a user needs to follow if they need to enable branch protection rules on the default branch from within a terraform script are as follows.

1. Create the target branch in directly git. The terraform provider will currently not create branches that don't exist.
2. In the hcl, set the project `default_branch` to be this alternate branch and set the `protected_branches` to include the intended default.
```hcl
resource "octopusdeploy_project" "project_acme" {
  name                                 = "AcmeProject"
  git_library_persistence_settings {
    git_credential_id  = octopusdeploy_git_credential.gitcredential.id
    url                = var.giturl
    base_path          = ".octopus/acme"
    default_branch     = "acme-staging"
    protected_branches = ["main"]
  ...
  }
```
3. Set the `branch` on the deployment process resource to be this alternate branch. Once the resource is created in this branch any TF updates will occur directly in this branch.
```hcl
resource "octopusdeploy_deployment_process" "deployment_process_project_acme" {
  project_id = "${octopusdeploy_project.project_acme.id}"
  branch = "acme-staging"
...
}
```
4. Run `terraform apply`. At this point the project should be created and configured with all resources on this alternative branch.
5. Update the project resource such that the `default_branch` is now your intended default.
```hcl
resource "octopusdeploy_project" "project_acme" {
  name                                 = "AcmeProject"
  git_library_persistence_settings {
    git_credential_id  = octopusdeploy_git_credential.gitcredential.id
    url                = var.giturl
    base_path          = ".octopus/acme"
    default_branch     = "main"
    protected_branches = ["main"]
  ...
  }
```
6. Leave the branch with the alternative name on the deployment process resource.
7. Run `terraform apply`. Now the project in Octopus will be updated to have the correct default branch protected however any changes to the resource will continue to be created in the alternative branch. It will be up to the user outside of Octopus to perform the relevant git merge operations.

