### PR TITLE
Certificate Password Should Be Optional

### DIFF
--- a/octopusdeploy/schema_certificate.go
+++ b/octopusdeploy/schema_certificate.go
@@ -241,7 +241,7 @@ func getCertificateSchema() map[string]*schema.Schema {
 			Optional: true,
 			Type:     schema.TypeString,
 		},
-		"password": getPasswordSchema(true),
+		"password": getPasswordSchema(false),
 		"replaced_by": {
 			Computed: true,
 			Optional: true,


### PR DESCRIPTION
Not all certificates have a password, for example Kubernetes Certificate Authorities.

This PR changes the password field to not be required to support these use-cases.