### PR TITLE
Added the ability to configure a k8s target with a certificate

### DIFF
--- a/octopusdeploy/schema_kubernetes_cluster_deployment_target.go
+++ b/octopusdeploy/schema_kubernetes_cluster_deployment_target.go
@@ -26,6 +26,10 @@ func expandKubernetesClusterDeploymentTarget(d *schema.ResourceData) *machines.D
 		endpoint.Authentication = expandKubernetesAzureAuthentication(v)
 	}
 
+	if v, ok := d.GetOk("certificate_authentication"); ok {
+		endpoint.Authentication = expandKubernetesCertificateAuthentication(v)
+	}
+
 	if v, ok := d.GetOk("cluster_certificate"); ok {
 		endpoint.ClusterCertificate = v.(string)
 	}
@@ -162,7 +166,7 @@ func getKubernetesClusterDeploymentTargetSchema() map[string]*schema.Schema {
 		MaxItems:     1,
 		MinItems:     0,
 		Optional:     true,
-		Type:         schema.TypeSet,
+		Type:         schema.TypeList,
 	}
 
 	kubernetesClusterDeploymentTargetSchema["cluster_certificate"] = &schema.Schema{


### PR DESCRIPTION
This PR provides the ability to create a k8s target with a client certificate like this:

```
resource octopusdeploy_kubernetes_cluster_deployment_target test_eks{
  cluster_url                       = var.k8s_cluster_url
  environments                      = [
    data.octopusdeploy_environments.development.environments[0].id,
    data.octopusdeploy_environments.test.environments[0].id,
    data.octopusdeploy_environments.production.environments[0].id]
  name                              = "Kind"
  roles                             = ["k8s"]
  cluster_certificate               = ""
  machine_policy_id                 = data.octopusdeploy_machine_policies.default_machine_policy.machine_policies[0].id
  namespace                         = ""
  skip_tls_verification             = true
  tenant_tags                       = []
  tenanted_deployment_participation = "Untenanted"
  tenants                           = []
  thumbprint                        = ""
  uri                               = ""

  endpoint {
    communication_style    = "Kubernetes"
    cluster_certificate    = ""
    cluster_url            = var.k8s_cluster_url
    namespace              = ""
    skip_tls_verification  = true
    default_worker_pool_id = ""
  }

  certificate_authentication {
    client_certificate = octopusdeploy_certificate.certificate_kind_ca.id
  }
}
```