### PR TITLE
Set missing user role collection properties to empty array

### DIFF
--- a/octopusdeploy/schema_user_role.go
+++ b/octopusdeploy/schema_user_role.go
@@ -22,10 +22,14 @@ func expandUserRole(d *schema.ResourceData) *userroles.UserRole {
 
 	if v, ok := d.GetOk("granted_space_permissions"); ok {
 		userRole.GrantedSpacePermissions = getSliceFromTerraformTypeList(v)
+	} else {
+		userRole.GrantedSpacePermissions = []string{}
 	}
 
 	if v, ok := d.GetOk("granted_system_permissions"); ok {
 		userRole.GrantedSystemPermissions = getSliceFromTerraformTypeList(v)
+	} else {
+		userRole.GrantedSystemPermissions = []string{}
 	}
 
 	if v, ok := d.GetOk("name"); ok {


### PR DESCRIPTION
Fixes bug caused by overly strict validation on Octopus Server where a null collection type is thrown rather than handled as a default.
A more long-term fix will ideally arrive in the Server shortly