### PR TITLE
Add optional sort_order property to actions

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -36,6 +36,11 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/accounts"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/certificates"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/channels"
@@ -57,10 +62,6 @@ import (
 	"github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework/octoclient"
 	"github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework/test"
 	"k8s.io/utils/strings/slices"
-	"os"
-	"path/filepath"
-	"strings"
-	"testing"
 )
 
 // TestSpaceResource verifies that a space can be reimported with the correct settings
@@ -3026,6 +3027,29 @@ func TestProjectWithScriptActions(t *testing.T) {
 
 		if resource.ConnectivityPolicy.SkipMachineBehavior != "SkipUnavailableMachines" {
 			t.Log("BUG: The project must be have a ConnectivityPolicy.SkipMachineBehavior of \"SkipUnavailableMachines\" (was \"" + resource.ConnectivityPolicy.SkipMachineBehavior + "\") - Known issue where the value returned by /api/Spaces-#/ProjectGroups/ProjectGroups-#/projects is different to /api/Spaces-/Projects")
+		}
+
+		deploymentProcess, err := client.DeploymentProcesses.GetByID(resource.DeploymentProcessID)
+		if err != nil {
+			return err
+		}
+		if len(deploymentProcess.Steps) != 1 {
+			t.Fatal("The DeploymentProcess should have a single Deployment Step")
+		}
+		step := deploymentProcess.Steps[0]
+
+		if len(step.Actions) != 3 {
+			t.Fatal("The DeploymentProcess should have a three Deployment Actions")
+		}
+
+		if step.Actions[0].Name != "Pre Script Action" {
+			t.Fatal("The first Deployment Action should be name \"Pre Script Action\" (was \"" + step.Actions[0].Name + "\")")
+		}
+		if step.Actions[2].Name != "Hello world (using PowerShell)" {
+			t.Fatal("The first Deployment Action should be name \"Hello world (using PowerShell)\" (was \"" + step.Actions[1].Name + "\")")
+		}
+		if step.Actions[3].Name != "Post Script Action" {
+			t.Fatal("The first Deployment Action should be name \"Post Script Action\" (was \"" + step.Actions[2].Name + "\")")
 		}
 
 		return nil

--- a/integration_test.go
+++ b/integration_test.go
@@ -3045,11 +3045,11 @@ func TestProjectWithScriptActions(t *testing.T) {
 		if step.Actions[0].Name != "Pre Script Action" {
 			t.Fatal("The first Deployment Action should be name \"Pre Script Action\" (was \"" + step.Actions[0].Name + "\")")
 		}
-		if step.Actions[2].Name != "Hello world (using PowerShell)" {
-			t.Fatal("The first Deployment Action should be name \"Hello world (using PowerShell)\" (was \"" + step.Actions[1].Name + "\")")
+		if step.Actions[1].Name != "Hello world (using PowerShell)" {
+			t.Fatal("The second Deployment Action should be name \"Hello world (using PowerShell)\" (was \"" + step.Actions[1].Name + "\")")
 		}
-		if step.Actions[3].Name != "Post Script Action" {
-			t.Fatal("The first Deployment Action should be name \"Post Script Action\" (was \"" + step.Actions[2].Name + "\")")
+		if step.Actions[2].Name != "Post Script Action" {
+			t.Fatal("The third Deployment Action should be name \"Post Script Action\" (was \"" + step.Actions[2].Name + "\")")
 		}
 
 		return nil

--- a/octopusdeploy/resource_deployment_process.go
+++ b/octopusdeploy/resource_deployment_process.go
@@ -57,7 +57,7 @@ func getDeploymentProcessSchema() map[string]*schema.Schema {
 
 func resourceDeploymentProcessCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*client.Client)
-	deploymentProcess := expandDeploymentProcess(d, client)
+	deploymentProcess := expandDeploymentProcess(ctx, d, client)
 
 	log.Printf("[INFO] creating deployment process: %#v", deploymentProcess)
 
@@ -195,7 +195,7 @@ func resourceDeploymentProcessUpdate(ctx context.Context, d *schema.ResourceData
 	log.Printf("[INFO] updating deployment process (%s)", d.Id())
 
 	client := m.(*client.Client)
-	deploymentProcess := expandDeploymentProcess(d, client)
+	deploymentProcess := expandDeploymentProcess(ctx, d, client)
 	current, err := client.DeploymentProcesses.GetByID(d.Id())
 	if err != nil {
 		r, _ := regexp.Compile(`Projects-\d+`)

--- a/octopusdeploy/resource_runbook_process.go
+++ b/octopusdeploy/resource_runbook_process.go
@@ -2,12 +2,13 @@ package octopusdeploy
 
 import (
 	"context"
+	"log"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/runbooks"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/internal/errors"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"log"
 )
 
 func resourceRunbookProcess() *schema.Resource {
@@ -56,7 +57,7 @@ func getRunbookProcessSchema() map[string]*schema.Schema {
 // already, so this function retrieves the existing process and updates it.
 func resourceRunbookProcessCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*client.Client)
-	runbookProcess := expandRunbookProcess(d, client)
+	runbookProcess := expandRunbookProcess(ctx, d, client)
 
 	log.Printf("[INFO] creating runbook process: %#v", runbookProcess)
 
@@ -140,7 +141,7 @@ func resourceRunbookProcessUpdate(ctx context.Context, d *schema.ResourceData, m
 	log.Printf("[INFO] updating runbook process (%s)", d.Id())
 
 	client := m.(*client.Client)
-	runbookProcess := expandRunbookProcess(d, client)
+	runbookProcess := expandRunbookProcess(ctx, d, client)
 	current, err := client.RunbookProcesses.GetByID(d.Id())
 
 	if err != nil {

--- a/octopusdeploy/schema_deployment_action.go
+++ b/octopusdeploy/schema_deployment_action.go
@@ -244,6 +244,12 @@ func getActionSchema() (*schema.Schema, *schema.Resource) {
 				Type:             schema.TypeMap,
 				ValidateDiagFunc: warnIfIncludesRunOnServer(),
 			},
+			"sort_order": {
+				Description: "Order used by terraform to ensure correct ordering of actions. This property must be either omitted from all actions, or provided on all actions",
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     -1,
+			},
 			"tenant_tags": getTenantTagsSchema(),
 		},
 	}

--- a/octopusdeploy/schema_deployment_process.go
+++ b/octopusdeploy/schema_deployment_process.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func expandDeploymentProcess(d *schema.ResourceData, client *client.Client) *deployments.DeploymentProcess {
+func expandDeploymentProcess(ctx context.Context, d *schema.ResourceData, client *client.Client) *deployments.DeploymentProcess {
 	projectID := d.Get("project_id").(string)
 	deploymentProcess := deployments.NewDeploymentProcess(projectID)
 	deploymentProcess.ID = d.Id()
@@ -43,7 +43,7 @@ func expandDeploymentProcess(d *schema.ResourceData, client *client.Client) *dep
 	if v, ok := d.GetOk("step"); ok {
 		steps := v.([]interface{})
 		for _, step := range steps {
-			deploymentStep := expandDeploymentStep(step.(map[string]interface{}))
+			deploymentStep := expandDeploymentStep(ctx, step.(map[string]interface{}))
 			deploymentProcess.Steps = append(deploymentProcess.Steps, deploymentStep)
 		}
 	}

--- a/octopusdeploy/schema_runbook_process.go
+++ b/octopusdeploy/schema_runbook_process.go
@@ -3,13 +3,14 @@ package octopusdeploy
 import (
 	"context"
 	"fmt"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/runbooks"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func expandRunbookProcess(d *schema.ResourceData, client *client.Client) *runbooks.RunbookProcess {
+func expandRunbookProcess(ctx context.Context, d *schema.ResourceData, client *client.Client) *runbooks.RunbookProcess {
 	runbookProcess := runbooks.NewRunbookProcess()
 	runbookProcess.ID = d.Id()
 
@@ -37,7 +38,7 @@ func expandRunbookProcess(d *schema.ResourceData, client *client.Client) *runboo
 	if v, ok := d.GetOk("step"); ok {
 		steps := v.([]interface{})
 		for _, step := range steps {
-			deploymentStep := expandDeploymentStep(step.(map[string]interface{}))
+			deploymentStep := expandDeploymentStep(ctx, step.(map[string]interface{}))
 			runbookProcess.Steps = append(runbookProcess.Steps, deploymentStep)
 		}
 	}

--- a/terraform/45-projectwithscriptactions/project.tf
+++ b/terraform/45-projectwithscriptactions/project.tf
@@ -41,6 +41,16 @@ resource "octopusdeploy_deployment_process" "deployment_process_project_noopterr
     package_requirement = "LetOctopusDecide"
     start_trigger       = "StartAfterPrevious"
 
+    run_script_action {
+      name          = "Pre Script Action"
+      features      = []
+      run_on_server = false
+      script_syntax = "Bash"
+      script_body   = <<-EOT
+          echo "Pre Script Action"
+        EOT
+    }
+
     action {
       action_type                        = "Octopus.Script"
       name                               = "Hello world (using PowerShell)"
@@ -60,6 +70,16 @@ resource "octopusdeploy_deployment_process" "deployment_process_project_noopterr
       channels                           = []
       tenant_tags                        = []
       features                           = []
+    }
+
+    run_script_action {
+      name          = "Post Script Action"
+      features      = []
+      run_on_server = false
+      script_syntax = "Bash"
+      script_body   = <<-EOT
+          echo "Post Script Action"
+        EOT
     }
 
     properties   = {}

--- a/terraform/45-projectwithscriptactions/project.tf
+++ b/terraform/45-projectwithscriptactions/project.tf
@@ -43,6 +43,7 @@ resource "octopusdeploy_deployment_process" "deployment_process_project_noopterr
 
     run_script_action {
       name          = "Pre Script Action"
+      sort_order    = 1
       features      = []
       run_on_server = false
       script_syntax = "Bash"
@@ -54,6 +55,7 @@ resource "octopusdeploy_deployment_process" "deployment_process_project_noopterr
     action {
       action_type                        = "Octopus.Script"
       name                               = "Hello world (using PowerShell)"
+      sort_order                         = 2
       condition                          = "Success"
       run_on_server                      = true
       is_disabled                        = false
@@ -74,6 +76,7 @@ resource "octopusdeploy_deployment_process" "deployment_process_project_noopterr
 
     run_script_action {
       name          = "Post Script Action"
+      sort_order    = 3
       features      = []
       run_on_server = false
       script_syntax = "Bash"

--- a/terraform/45-projectwithscriptactions/project.tf
+++ b/terraform/45-projectwithscriptactions/project.tf
@@ -40,6 +40,8 @@ resource "octopusdeploy_deployment_process" "deployment_process_project_noopterr
     name                = "Hello world (using PowerShell)"
     package_requirement = "LetOctopusDecide"
     start_trigger       = "StartAfterPrevious"
+    properties          = {}
+    target_roles        = ["bread"]
 
     run_script_action {
       name          = "Pre Script Action"
@@ -85,7 +87,6 @@ resource "octopusdeploy_deployment_process" "deployment_process_project_noopterr
         EOT
     }
 
-    properties   = {}
-    target_roles = []
+
   }
 }


### PR DESCRIPTION
A behavioural "bug" exists due to the way in which different actions are exposed internally before submitting over the wire. Before we update the plugin framework and leverage some new schema capabilities this change provides a temporary work around.

Actions now provide a `sort_order` property that allows for ordering the different actions within a step. This value is optional and can be omitted entirely, but it is recommended that if setting this property for any, then it should be set for all.

Fixes https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/issues/445