### PR TITLE
Dependency updates and runbook fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/OctopusDeploy/terraform-provider-octopusdeploy
 go 1.20
 
 require (
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.24.0
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.27.0
 	github.com/google/uuid v1.3.0
 	github.com/gruntwork-io/terratest v0.41.11
 	github.com/hashicorp/go-cty v1.4.1-0.20200723130312-85980079f637

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/Microsoft/go-winio v0.6.0/go.mod h1:cTAf44im0RAYeL23bpB+fzCyDH2MJiz2B
 github.com/Microsoft/hcsshim v0.9.7 h1:mKNHW/Xvv1aFH87Jb6ERDzXTJTLPlmzfZ28VBFD/bfg=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.24.0 h1:b6kyJL3SDbbViCSjkvrO1cb8KOJMFNYfqA8B1SkL5g4=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.24.0/go.mod h1:GZmFu6LmN8Yg0tEoZx3ytk9FnaH+84cWm7u5TdWZC6E=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.27.0 h1:LwevbGRiVZxDUG1YJ/Wnc70LqHMUihFK6ii93iwFhtE=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.27.0/go.mod h1:GZmFu6LmN8Yg0tEoZx3ytk9FnaH+84cWm7u5TdWZC6E=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v0.0.0-20230605032624-2acff93f126c h1:nJXjt8UFkyZ4iB/2Ba9aNSRgbnv3dQwO9UvTWnor2yk=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v0.0.0-20230605032624-2acff93f126c/go.mod h1:ltRYzU6Dw2WB09wDGB/zofUkB8Un13Qx30eqsw77SFw=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v0.0.0-20230605033112-566bb7c786fc h1:FJh2axO8HInjLrBZCfkBtNKzFy/BouERvouyaHH034o=

--- a/integration_test.go
+++ b/integration_test.go
@@ -3057,9 +3057,11 @@ func TestRunbookResource(t *testing.T) {
 		}
 
 		found := false
+		runbookId := ""
 		for _, r := range resources {
 			if r.Name == "Runbook" {
 				found = true
+				runbookId = r.ID
 
 				if r.Description != "Test Runbook" {
 					t.Fatal("The runbook must be have a description of \"Test Runbook\" (was \"" + r.Description + "\")")
@@ -3123,6 +3125,15 @@ func TestRunbookResource(t *testing.T) {
 
 		if !found {
 			t.Fatalf("Space must have a runbook called \"Runbook\"")
+		}
+
+		// There was an issue where deleting a runbook and reapplying the terraform module caused an error, so
+		// verify this process works.
+		client.Runbooks.DeleteByID(runbookId)
+		err = testFramework.TerraformApply(t, "./terraform/46-runbooks", container.URI, newSpaceId, []string{})
+
+		if err != nil {
+			t.Fatal("Failed to reapply the runbooks after deleting them.")
 		}
 
 		// Verify the environment data lookups work

--- a/octopusdeploy/resource_runbook_process.go
+++ b/octopusdeploy/resource_runbook_process.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/runbooks"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/internal/errors"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"log"
@@ -124,7 +125,7 @@ func resourceRunbookProcessRead(ctx context.Context, d *schema.ResourceData, m i
 	runbookProcess, err := client.RunbookProcesses.GetByID(d.Id())
 
 	if err != nil {
-		return diag.FromErr(err)
+		return errors.ProcessApiError(ctx, d, err, "runbook_process")
 	}
 
 	if err := setRunbookProcess(ctx, d, runbookProcess); err != nil {


### PR DESCRIPTION
This PR updates the provider to use the latest version of the Octopus go client and fixes an issue where deleted runbook processes would throw an error if they were reapplied.