### PR TITLE
Upgrade go-octopusdeploy package to v2.28.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/OctopusDeploy/terraform-provider-octopusdeploy
 go 1.20
 
 require (
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.27.0
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.28.0
 	github.com/google/uuid v1.3.0
 	github.com/gruntwork-io/terratest v0.41.11
 	github.com/hashicorp/go-cty v1.4.1-0.20200723130312-85980079f637

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/OctopusDeploy/go-octopusdeploy/v2 v2.24.0 h1:b6kyJL3SDbbViCSjkvrO1cb8
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.24.0/go.mod h1:GZmFu6LmN8Yg0tEoZx3ytk9FnaH+84cWm7u5TdWZC6E=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.27.0 h1:LwevbGRiVZxDUG1YJ/Wnc70LqHMUihFK6ii93iwFhtE=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.27.0/go.mod h1:GZmFu6LmN8Yg0tEoZx3ytk9FnaH+84cWm7u5TdWZC6E=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.28.0 h1:7BegZkhNkY6MKgOf0ekNgsRNlvE4lBdzy84zVG+c1+0=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.28.0/go.mod h1:GZmFu6LmN8Yg0tEoZx3ytk9FnaH+84cWm7u5TdWZC6E=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v0.0.0-20230605032624-2acff93f126c h1:nJXjt8UFkyZ4iB/2Ba9aNSRgbnv3dQwO9UvTWnor2yk=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v0.0.0-20230605032624-2acff93f126c/go.mod h1:ltRYzU6Dw2WB09wDGB/zofUkB8Un13Qx30eqsw77SFw=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v0.0.0-20230605033112-566bb7c786fc h1:FJh2axO8HInjLrBZCfkBtNKzFy/BouERvouyaHH034o=


### PR DESCRIPTION
Upgrade `go-octopusdeploy` package to [v2.28.0](https://github.com/OctopusDeploy/go-octopusdeploy/releases/tag/v2.28.0) to absorb https://github.com/OctopusDeploy/go-octopusdeploy/pull/195 - also fixes https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/issues/533

Tested using a local build of the provider and all seems good 👍 