### PR TITLE
Retain deployment action id between updates

### DIFF
--- a/octopusdeploy/schema_deployment_action.go
+++ b/octopusdeploy/schema_deployment_action.go
@@ -391,6 +391,10 @@ func expandAction(flattenedAction map[string]interface{}) *deployments.Deploymen
 		action.Properties = expandProperties(v)
 	}
 
+	if v, ok := flattenedAction["id"]; ok {
+		action.ID = v.(string)
+	}
+
 	if v, ok := flattenedAction["can_be_used_for_project_versioning"]; ok {
 		action.CanBeUsedForProjectVersioning = v.(bool)
 	}

--- a/octopusdeploy/schema_deployment_action.go
+++ b/octopusdeploy/schema_deployment_action.go
@@ -386,13 +386,14 @@ func expandAction(flattenedAction map[string]interface{}) *deployments.Deploymen
 
 	action := deployments.NewDeploymentAction(name, actionType)
 
+	// Retain the existing id as older channel rules might still be referencing the action by id
+	if v, ok := flattenedAction["id"]; ok {
+		action.ID = v.(string)
+	}
+
 	// expand properties first
 	if v, ok := flattenedAction["properties"]; ok {
 		action.Properties = expandProperties(v)
-	}
-
-	if v, ok := flattenedAction["id"]; ok {
-		action.ID = v.(string)
 	}
 
 	if v, ok := flattenedAction["can_be_used_for_project_versioning"]; ok {


### PR DESCRIPTION
Channel version rules used to reference a deployment action by its id. More recent versions of Octopus have changed to using the name reference which is more resilient. This PR makes it compatible with older data.

Shoutout to https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/pull/546 for coming up with the fix.

[[sc-61417](https://app.shortcut.com/octopusdeploy/story/61417/tf-plugin-deployment-step-action-updates-fail-with-octopus-2023-3-requested-by-finnian-dempsey)]