### PR TITLE
Fix crash when Project ID is invalid

### DIFF
--- a/octopusdeploy/resource_deployment_process.go
+++ b/octopusdeploy/resource_deployment_process.go
@@ -57,7 +57,11 @@ func getDeploymentProcessSchema() map[string]*schema.Schema {
 
 func resourceDeploymentProcessCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*client.Client)
-	deploymentProcess := expandDeploymentProcess(ctx, d, client)
+	deploymentProcess, err := expandDeploymentProcess(ctx, d, client)
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	log.Printf("[INFO] creating deployment process: %#v", deploymentProcess)
 
@@ -195,7 +199,12 @@ func resourceDeploymentProcessUpdate(ctx context.Context, d *schema.ResourceData
 	log.Printf("[INFO] updating deployment process (%s)", d.Id())
 
 	client := m.(*client.Client)
-	deploymentProcess := expandDeploymentProcess(ctx, d, client)
+	deploymentProcess, err := expandDeploymentProcess(ctx, d, client)
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	current, err := client.DeploymentProcesses.GetByID(d.Id())
 	if err != nil {
 		r, _ := regexp.Compile(`Projects-\d+`)

--- a/octopusdeploy/schema_deployment_process.go
+++ b/octopusdeploy/schema_deployment_process.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func expandDeploymentProcess(ctx context.Context, d *schema.ResourceData, client *client.Client) *deployments.DeploymentProcess {
+func expandDeploymentProcess(ctx context.Context, d *schema.ResourceData, client *client.Client) (*deployments.DeploymentProcess, error) {
 	projectID := d.Get("project_id").(string)
 	deploymentProcess := deployments.NewDeploymentProcess(projectID)
 	deploymentProcess.ID = d.Id()
@@ -20,7 +20,7 @@ func expandDeploymentProcess(ctx context.Context, d *schema.ResourceData, client
 	} else {
 		project, err := client.Projects.GetByID(projectID)
 		if err != nil {
-			return nil
+			return nil, err
 		}
 
 		if project.PersistenceSettings != nil && project.PersistenceSettings.Type() == projects.PersistenceSettingsTypeVersionControlled {
@@ -48,7 +48,7 @@ func expandDeploymentProcess(ctx context.Context, d *schema.ResourceData, client
 		}
 	}
 
-	return deploymentProcess
+	return deploymentProcess, nil
 }
 
 func setDeploymentProcess(ctx context.Context, d *schema.ResourceData, deploymentProcess *deployments.DeploymentProcess) error {


### PR DESCRIPTION
Issue https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/issues/556 describes a scenario where assigning an invalid project ID to a deployment process causes the TF provider to crash. This PR catches the case where the project returned by the invalid project ID is nil and displays an error rather than crashing.

The result now looks like this:

```
╷
│ Error: Octopus API error: Resource is not found or it doesn't exist in the current space context. Please contact your administrator for more information. [] 
│ 
│   with octopusdeploy_deployment_process.this,
│   on bug.tf line 54, in resource "octopusdeploy_deployment_process" "this":
│   54: resource "octopusdeploy_deployment_process" "this" {
│ 
╵

```