### PR TITLE
fix: prevent api call failure during deployment process delete

### DIFF
--- a/octopusdeploy/resource_deployment_process.go
+++ b/octopusdeploy/resource_deployment_process.go
@@ -114,6 +114,7 @@ func resourceDeploymentProcessDelete(ctx context.Context, d *schema.ResourceData
 	current, err := client.DeploymentProcesses.GetByID(d.Id())
 	if err == nil {
 		deploymentProcess := &deployments.DeploymentProcess{
+			Steps:   []*deployments.DeploymentStep{},
 			Version: current.Version,
 		}
 		deploymentProcess.Links = current.Links


### PR DESCRIPTION
Intializing empty array for `Steps` property in `deploymentProcess` because
`DeploymentProcesses.Update` calls "/api/Spaces-1/projects/<ProjectID>/deploymentprocesses" but
it fails if `Steps` property is undefined.