### PR TITLE
Support proccess scoped variables

### DIFF
--- a/docs/data-sources/variables.md
+++ b/docs/data-sources/variables.md
@@ -87,6 +87,7 @@ Read-Only:
 - `channels` (List of String)
 - `environments` (List of String)
 - `machines` (List of String)
+- `processes` (List of String)
 - `roles` (List of String)
 - `tenant_tags` (List of String)
 

--- a/docs/resources/variable.md
+++ b/docs/resources/variable.md
@@ -150,6 +150,7 @@ Optional:
 - `channels` (List of String) A list of channels that are scoped to this variable value.
 - `environments` (List of String) A list of environments that are scoped to this variable value.
 - `machines` (List of String) A list of machines that are scoped to this variable value.
+- `processes` (List of String) A list of processes that are scoped to this variable value.
 - `roles` (List of String) A list of roles that are scoped to this variable value.
 - `tenant_tags` (List of String) A list of tenant tags that are scoped to this variable value.
 

--- a/octopusdeploy/resource_variable.go
+++ b/octopusdeploy/resource_variable.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/variables"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/internal/errors"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -76,7 +77,7 @@ func resourceVariableCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 	for _, v := range variableSet.Variables {
 		if v.Name == variable.Name && v.Type == variable.Type && (v.IsSensitive || v.Value == variable.Value) && v.Description == variable.Description && v.IsSensitive == variable.IsSensitive {
-			scopeMatches, _, err := client.Variables.MatchesScope(v.Scope, &variable.Scope)
+			scopeMatches, _, err := matchesScope(v.Scope, &variable.Scope)
 			if err != nil {
 				return diag.FromErr(err)
 			}
@@ -161,7 +162,7 @@ func resourceVariableUpdate(ctx context.Context, d *schema.ResourceData, m inter
 
 	for _, v := range variableSet.Variables {
 		if v.Name == variable.Name && v.Type == variable.Type && (v.IsSensitive || v.Value == variable.Value) && v.Description == variable.Description && v.IsSensitive == variable.IsSensitive {
-			scopeMatches, _, _ := client.Variables.MatchesScope(v.Scope, &variable.Scope)
+			scopeMatches, _, _ := matchesScope(v.Scope, &variable.Scope)
 			if scopeMatches {
 				if err := setVariable(ctx, d, v); err != nil {
 					return diag.FromErr(err)
@@ -224,4 +225,73 @@ func validateVariable(d *schema.ResourceData) error {
 	}
 
 	return nil
+}
+
+func matchesScope(variableScope variables.VariableScope, definedScope *variables.VariableScope) (bool, *variables.VariableScope, error) {
+	if definedScope == nil {
+		return true, &variables.VariableScope{}, nil
+	}
+
+	if definedScope.IsEmpty() {
+		return true, &variables.VariableScope{}, nil
+	}
+
+	var matchedScopes variables.VariableScope
+	var matched bool
+
+	for _, e1 := range definedScope.Environments {
+		for _, e2 := range variableScope.Environments {
+			if e1 == e2 {
+				matched = true
+				matchedScopes.Environments = append(matchedScopes.Environments, e1)
+			}
+		}
+	}
+
+	for _, r1 := range definedScope.Roles {
+		for _, r2 := range variableScope.Roles {
+			if r1 == r2 {
+				matched = true
+				matchedScopes.Roles = append(matchedScopes.Roles, r1)
+			}
+		}
+	}
+
+	for _, m1 := range definedScope.Machines {
+		for _, m2 := range variableScope.Machines {
+			if m1 == m2 {
+				matched = true
+				matchedScopes.Machines = append(matchedScopes.Machines, m1)
+			}
+		}
+	}
+
+	for _, a1 := range definedScope.Actions {
+		for _, a2 := range variableScope.Actions {
+			if a1 == a2 {
+				matched = true
+				matchedScopes.Actions = append(matchedScopes.Actions, a1)
+			}
+		}
+	}
+
+	for _, c1 := range definedScope.Channels {
+		for _, c2 := range variableScope.Channels {
+			if c1 == c2 {
+				matched = true
+				matchedScopes.Channels = append(matchedScopes.Channels, c1)
+			}
+		}
+	}
+
+	for _, p1 := range definedScope.ProcessOwners {
+		for _, p2 := range variableScope.ProcessOwners {
+			if p1 == p2 {
+				matched = true
+				matchedScopes.ProcessOwners = append(matchedScopes.ProcessOwners, p1)
+			}
+		}
+	}
+
+	return matched, &matchedScopes, nil
 }

--- a/octopusdeploy/schema_variable_scope.go
+++ b/octopusdeploy/schema_variable_scope.go
@@ -21,6 +21,7 @@ func expandVariableScope(flattenedVariableScope interface{}) variables.VariableS
 			Channels:     getSliceFromTerraformTypeList(flattenedMap["channels"]),
 			Environments: getSliceFromTerraformTypeList(flattenedMap["environments"]),
 			Machines:     getSliceFromTerraformTypeList(flattenedMap["machines"]),
+			ProcessOwners: getSliceFromTerraformTypeList(flattenedMap["processes"]),
 			Roles:        getSliceFromTerraformTypeList(flattenedMap["roles"]),
 			TenantTags:   getSliceFromTerraformTypeList(flattenedMap["tenant_tags"]),
 		}
@@ -50,6 +51,10 @@ func flattenVariableScope(scope variables.VariableScope) []interface{} {
 
 	if len(scope.Machines) > 0 {
 		flattenedScope["machines"] = scope.Machines
+	}
+
+	if len(scope.ProcessOwners) > 0 {
+		flattenedScope["processes"] = scope.ProcessOwners
 	}
 
 	if len(scope.Roles) > 0 {
@@ -85,6 +90,12 @@ func getVariableScopeSchema() map[string]*schema.Schema {
 		},
 		"machines": {
 			Description: "A list of machines that are scoped to this variable value.",
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Optional:    true,
+			Type:        schema.TypeList,
+		},
+        "processes": {
+			Description: "A list of processes that are scoped to this variable value.",
 			Elem:        &schema.Schema{Type: schema.TypeString},
 			Optional:    true,
 			Type:        schema.TypeList,


### PR DESCRIPTION
adds support for scoping project variables to processes

```hcl
resource "octopusdeploy_variable" "string_variable" {
  owner_id  = "Projects-123"
  type      = "String"
  name      = "My String Value (OK to Delete)"
  value     = "PlainText"

  scope {
    process_owners = ["Runbooks-1234"]
  }
}
```

fixes #361