### PR TITLE
Fix the cloud region data source

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -93,6 +93,13 @@ jobs:
           OCTOTESTSKIPINIT: true
           GOMAXPROCS: 1
           OCTOTESTVERSION: 2023.4
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: junit-test-summary-${{ matrix.index }}
+          path: node-summary.xml
+          retention-days: 1
+
   tests-combine-summaries:
     name: Combine Test Reports
     needs: [ tests ]

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -81,7 +81,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install gotestsum
         shell: bash
-      - name: Test Git integration
+      - name: Test integration tests
         run: gotestsum --junitfile node-summary.xml --format short-verbose -- -run "${{ steps.test_split.outputs.run }}" -timeout 0 integration_test.go
         shell: bash
         env:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,3 +1,7 @@
+# This workflow splits the tests to run across multiple nodes. This significantly reduces the testing time, as the
+# tests require starting Octopus, MSSQL, and then running Terraform against the Octopus instance.
+# See # Refer to https://github.com/hashicorp-forge/go-test-split-action for more information on how the tests are split.
+
 name: Integration Tests
 'on':
   workflow_dispatch: {}
@@ -109,8 +113,6 @@ jobs:
         uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
-        with:
-          node-version: 16
 
       - name: Download artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -93,7 +93,7 @@ jobs:
           OCTOTESTVERSION: 2023.2
   tests-combine-summaries:
     name: Combine Test Reports
-    needs: [ build ]
+    needs: [ tests ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -81,7 +81,7 @@ jobs:
           }
           EOT
       - name: Setup gotestsum
-        uses: autero1/action-gotestsum@v2
+        uses: autero1/action-gotestsum@v1
       - name: Test integration tests
         run: gotestsum --junitfile node-summary.xml --format short-verbose -- -run "${{ steps.test_split.outputs.run }}" -timeout 0 integration_test.go
         shell: bash

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -80,10 +80,10 @@ jobs:
             direct {}
           }
           EOT
-      - name: Setup gotestsum
-        uses: autero1/action-gotestsum@v1
       - name: Test integration tests
-        run: gotestsum --junitfile node-summary.xml --format short-verbose -- -run "${{ steps.test_split.outputs.run }}" -timeout 0 integration_test.go
+        run: |
+          GOBIN=$PWD/bin go install gotest.tools/gotestsum@latest
+          ./bin/gotestsum --junitfile node-summary.xml --format short-verbose -- -run "${{ steps.test_split.outputs.run }}" -timeout 0 integration_test.go
         shell: bash
         env:
           LICENSE: ${{ secrets.OCTOPUS_SERVER_BASE64_LICENSE }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -80,11 +80,8 @@ jobs:
             direct {}
           }
           EOT
-      - name: Install gotestsum
-        run: |
-          sudo apt-get update
-          sudo apt-get install gotestsum
-        shell: bash
+      - name: Setup gotestsum
+        uses: autero1/action-gotestsum@v2
       - name: Test integration tests
         run: gotestsum --junitfile node-summary.xml --format short-verbose -- -run "${{ steps.test_split.outputs.run }}" -timeout 0 integration_test.go
         shell: bash

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -12,8 +12,6 @@ jobs:
         parallel: [ 15 ]
         index: [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 ]
 
-  build:
-    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Install Terraform
@@ -95,7 +93,7 @@ jobs:
           OCTOTESTVERSION: 2023.2
   tests-combine-summaries:
     name: Combine Test Reports
-    needs: [ tests ]
+    needs: [ build ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -3,6 +3,15 @@ name: Integration Tests
   workflow_dispatch: {}
   push: {}
 jobs:
+  tests:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        parallel: [ 15 ]
+        index: [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 ]
+
   build:
     runs-on: ubuntu-latest
     steps:
@@ -13,8 +22,6 @@ jobs:
           terraform_wrapper: false
       - name: Set up Go
         uses: actions/setup-go@v2
-        with:
-          go-version: 1.20.5
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
@@ -41,6 +48,21 @@ jobs:
           --header "X-GitHub-Api-Version: 2022-11-28" | jq -r '"GIT_CREDENTIAL=" + .token' > "$GITHUB_ENV"
         env:
           GH_APP_INSTALLATION_ID: ${{ secrets.GH_APP_INSTALLATION_ID }}
+      - name: Download JUnit Summary from Previous Workflow
+        id: download-artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow_conclusion: success
+          name: junit-test-summary
+          if_no_artifact_found: warn
+          branch: main
+      - name: Split integration tests
+        id: test_split
+        uses: hashicorp-forge/go-test-split-action@v1
+        with:
+          index: ${{ matrix.index }}
+          total: ${{ matrix.parallel }}
+          junit-summary: ./junit-test-summary.xml
       - name: Install Dependencies
         run: go get ./...
         shell: bash
@@ -59,10 +81,8 @@ jobs:
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
         shell: bash
-      # The GitHub token we generated is valid for an hour. The full test suite can run for longer than an hour.
-      # So we first run the git tests while the token is fresh, and the run the rest of the tests.
       - name: Test Git integration
-        run: go test -v -timeout 0 -run "^\\QTestProjectWithGitUsernameExport\\E$" integration_test.go
+        run: gotestsum --junitfile node-summary.xml --format short-verbose -- -run "${{ steps.test_split.outputs.run }}" -timeout 0 integration_test.go
         shell: bash
         env:
           LICENSE: ${{ secrets.OCTOPUS_SERVER_BASE64_LICENSE }}
@@ -73,26 +93,56 @@ jobs:
           OCTOTESTSKIPINIT: true
           GOMAXPROCS: 1
           OCTOTESTVERSION: 2023.2
-      - name: Test everything else
-        run: gotestsum --junitfile results.xml -- -v -timeout 0 -skip "^\\QTestProjectWithGitUsernameExport\\E$" -json integration_test.go
-        shell: bash
-        env:
-          LICENSE: ${{ secrets.OCTOPUS_SERVER_BASE64_LICENSE }}
-          ECR_ACCESS_KEY: ${{ secrets.ECR_ACCESS_KEY }}
-          ECR_SECRET_KEY: ${{ secrets.ECR_SECRET_KEY }}
-          GIT_USERNAME: x-access-token
-          OCTODISABLEOCTOCONTAINERLOGGING: true
-          OCTOTESTSKIPINIT: true
-          GOMAXPROCS: 1
-          OCTOTESTVERSION: 2023.2
-      - if: always()
-        name: Report
+  tests-combine-summaries:
+    name: Combine Test Reports
+    needs: [ tests ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+
+      - name: Install junit-report-merger
+        run: npm install -g junit-report-merger
+
+      - name: Merge reports
+        run: >
+          jrm ./junit-test-summary.xml 
+          "junit-test-summary-0/*.xml" 
+          "junit-test-summary-1/*.xml" 
+          "junit-test-summary-2/*.xml" 
+          "junit-test-summary-3/*.xml" 
+          "junit-test-summary-4/*.xml" 
+          "junit-test-summary-5/*.xml" 
+          "junit-test-summary-6/*.xml" 
+          "junit-test-summary-7/*.xml" 
+          "junit-test-summary-8/*.xml" 
+          "junit-test-summary-9/*.xml"
+          "junit-test-summary-10/*.xml"
+          "junit-test-summary-11/*.xml"
+          "junit-test-summary-12/*.xml"
+          "junit-test-summary-13/*.xml"
+          "junit-test-summary-14/*.xml"
+
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: junit-test-summary
+          path: ./junit-test-summary.xml
+
+      - name: Report
         uses: dorny/test-reporter@v1
         with:
           name: Go Tests
-          path: results.xml
+          path: junit-test-summary.xml
           reporter: java-junit
-          fail-on-error: 'false'
+          fail-on-error: 'true'
 permissions:
   id-token: write
   checks: write

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -77,7 +77,9 @@ jobs:
           }
           EOT
       - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@latest
+        run: |
+          sudo apt-get update
+          sudo apt-get install gotestsum
         shell: bash
       - name: Test Git integration
         run: gotestsum --junitfile node-summary.xml --format short-verbose -- -run "${{ steps.test_split.outputs.run }}" -timeout 0 integration_test.go

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -92,7 +92,7 @@ jobs:
           OCTODISABLEOCTOCONTAINERLOGGING: true
           OCTOTESTSKIPINIT: true
           GOMAXPROCS: 1
-          OCTOTESTVERSION: 2023.2
+          OCTOTESTVERSION: 2023.4
   tests-combine-summaries:
     name: Combine Test Reports
     needs: [ tests ]

--- a/integration_test.go
+++ b/integration_test.go
@@ -2311,7 +2311,7 @@ func TestCloudRegionTargetResource(t *testing.T) {
 		err = testFramework.TerraformInitAndApply(t, container, filepath.Join("./terraform", "33a-cloudregiontargetds"), newSpaceId, []string{})
 
 		if err != nil {
-			t.Log("BUG: cloud region data source does not appear to work")
+			t.Fatal("cloud region data source does not appear to work")
 		}
 
 		// Assert

--- a/octopusdeploy/schema_cloud_region_deployment_target.go
+++ b/octopusdeploy/schema_cloud_region_deployment_target.go
@@ -54,8 +54,6 @@ func getCloudRegionDeploymentTargetDataSchema() map[string]*schema.Schema {
 func getCloudRegionDeploymentTargetSchema() map[string]*schema.Schema {
 	cloudRegionDeploymentTargetSchema := getDeploymentTargetSchema()
 
-	delete(cloudRegionDeploymentTargetSchema, "endpoint")
-
 	cloudRegionDeploymentTargetSchema["default_worker_pool_id"] = &schema.Schema{
 		Optional: true,
 		Type:     schema.TypeString,


### PR DESCRIPTION
This PR fixes the bug at https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/issues/580.

The cloud region data source was the only one that removed the `endpoint` field from the schema. This in turn broke the data source when it tried to flatten targets into the returned results.

Since other data sources leave the `endpoint` field in the schema, this PR removes the line that deletes the `endpoint` field.

To speed up the integration tests, the `hashicorp-forge/go-test-split-action@v1` action has been added. This runts the integration tests across 15 nodes, reducing the test time to under ten minutes (down from an hour).

The tests were also updated to run against Octopus 2023.4.