### PR TITLE
Fix: Use newclient for tenant datasource

### DIFF
--- a/octopusdeploy/data_source_tenants.go
+++ b/octopusdeploy/data_source_tenants.go
@@ -31,8 +31,10 @@ func dataSourceTenantsRead(ctx context.Context, d *schema.ResourceData, meta int
 		Take:               d.Get("take").(int),
 	}
 
+	spaceID := d.Get("space_id").(string)
+
 	client := meta.(*client.Client)
-	existingTenants, err := client.Tenants.Get(query)
+	existingTenants, err := tenants.Get(client, spaceID, query)
 	if err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
The `tenant_data_source` was not using the new client, which supports the use of `space_id`.

Fixes https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/issues/586

[sc-67134]