### PR TITLE
Add support to specify k8s namespace on kubectl script step

### DIFF
--- a/octopusdeploy/schema_action_run_kubectl_script.go
+++ b/octopusdeploy/schema_action_run_kubectl_script.go
@@ -1,6 +1,7 @@
 package octopusdeploy
 
 import (
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/deployments"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -12,6 +13,11 @@ func getRunKubectlScriptSchema() *schema.Schema {
 	addPackagesSchema(element, false)
 	addWorkerPoolSchema(element)
 	addWorkerPoolVariableSchema(element)
+
+	element.Schema["namespace"] = &schema.Schema{
+		Optional: true,
+		Type:     schema.TypeString,
+	}
 
 	element.Schema["script_body"] = &schema.Schema{
 		Optional: true,
@@ -35,9 +41,18 @@ func getRunKubectlScriptSchema() *schema.Schema {
 func expandRunKubectlScriptAction(flattenedAction map[string]interface{}) *deployments.DeploymentAction {
 	action := expandRunScriptAction(flattenedAction)
 	action.ActionType = "Octopus.KubernetesRunScript"
+
+	action.Properties["Octopus.Action.KubernetesContainers.Namespace"] = core.NewPropertyValue(flattenedAction["namespace"].(string), false)
+
 	return action
 }
 
 func flattenKubernetesRunScriptAction(action *deployments.DeploymentAction) map[string]interface{} {
-	return flattenRunScriptAction(action)
+	flattenedAction := flattenRunScriptAction(action)
+
+	if v, ok := action.Properties["Octopus.Action.KubernetesContainers.Namespace"]; ok {
+		flattenedAction["namespace"] = v.Value
+	}
+
+	return flattenedAction
 }

--- a/octopusdeploy/schema_action_run_kubectl_script_test.go
+++ b/octopusdeploy/schema_action_run_kubectl_script_test.go
@@ -42,6 +42,8 @@ func testAccRunKubectlScriptAction() string {
 
 			script_file_name = "Test.ps1"
 			script_parameters = "-Test 1"
+
+			namespace = "test-namespace"
     }
 	`)
 }
@@ -59,6 +61,10 @@ func testAccCheckRunKubectlScriptAction() resource.TestCheckFunc {
 
 		if action.ActionType != "Octopus.KubernetesRunScript" {
 			return fmt.Errorf("Action type is incorrect: %s", action.ActionType)
+		}
+
+		if action.Properties["Octopus.Action.KubernetesContainers.Namespace"].Value != "test-namespace" {
+			return fmt.Errorf("Kubernetes namespace is incorrect: %s", action.Properties["Octopus.Action.KubernetesContainers.Namespace"].Value)
 		}
 
 		if action.Properties["Octopus.Action.Script.ScriptFileName"].Value != "Test.ps1" {


### PR DESCRIPTION
This PR adds ability to specify the Kubernetes namespace on the `run_kubectl_script` step resource.

[sc-71215]