### PR TITLE
fix: removing required attribute `PollingRequestMaximumMessageProcessingTimeout` on machine policy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/OctopusDeploy/terraform-provider-octopusdeploy
 go 1.20
 
 require (
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.36.2
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.38.3
 	github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v0.0.0-20230705105638-f5ef7c07973b
 	github.com/google/uuid v1.3.0
 	github.com/gruntwork-io/terratest v0.41.11

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,8 @@ github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugX
 github.com/Microsoft/go-winio v0.6.0 h1:slsWYD/zyx7lCXoZVlvQrj0hPTM1HI4+v1sIda2yDvg=
 github.com/Microsoft/go-winio v0.6.0/go.mod h1:cTAf44im0RAYeL23bpB+fzCyDH2MJiz2BO69KH/soAE=
 github.com/Microsoft/hcsshim v0.9.7 h1:mKNHW/Xvv1aFH87Jb6ERDzXTJTLPlmzfZ28VBFD/bfg=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.36.2 h1:ovLCSy+I1mN0nynxNtOkrxUuf4DL2jZc79kkBH6698g=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.36.2/go.mod h1:GZmFu6LmN8Yg0tEoZx3ytk9FnaH+84cWm7u5TdWZC6E=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.38.3 h1:t1y+X1xtuTRxKsre2GtYnRj1FYZPDWQTGn9i0LbMLK0=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.38.3/go.mod h1:GZmFu6LmN8Yg0tEoZx3ytk9FnaH+84cWm7u5TdWZC6E=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v0.0.0-20230705105638-f5ef7c07973b h1:XOBPcVHeDUYIpcag0yI8IYKiBL+5LLL8suysvlavQwI=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v0.0.0-20230705105638-f5ef7c07973b/go.mod h1:E0hYVpZd61fXhzTozkxjiWEy+/yTRxAnr2SIE7k8ZSM=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=

--- a/integration_test.go
+++ b/integration_test.go
@@ -1947,6 +1947,10 @@ func TestMachinePolicyResource(t *testing.T) {
 			t.Fatal("The machine policy must have a ConnectionRetryTimeLimit of \"00:05:00\" (was \"" + fmt.Sprint(resource.ConnectionRetryTimeLimit) + "\")")
 		}
 
+		if resource.PollingRequestMaximumMessageProcessingTimeout.Minutes() != 10 {
+			t.Fatal("The machine policy must have a PollingRequestMaximumMessageProcessingTimeout of \"00:10:00\" (was \"" + fmt.Sprint(resource.PollingRequestMaximumMessageProcessingTimeout) + "\")")
+		}
+
 		if resource.MachineCleanupPolicy.DeleteMachinesElapsedTimeSpan.Minutes() != 20 {
 			t.Fatal("The machine policy must have a DeleteMachinesElapsedTimeSpan of \"00:20:00\" (was \"" + fmt.Sprint(resource.MachineCleanupPolicy.DeleteMachinesElapsedTimeSpan) + "\")")
 		}

--- a/integration_test.go
+++ b/integration_test.go
@@ -1947,10 +1947,6 @@ func TestMachinePolicyResource(t *testing.T) {
 			t.Fatal("The machine policy must have a ConnectionRetryTimeLimit of \"00:05:00\" (was \"" + fmt.Sprint(resource.ConnectionRetryTimeLimit) + "\")")
 		}
 
-		if resource.PollingRequestMaximumMessageProcessingTimeout.Minutes() != 10 {
-			t.Fatal("The machine policy must have a PollingRequestMaximumMessageProcessingTimeout of \"00:10:00\" (was \"" + fmt.Sprint(resource.PollingRequestMaximumMessageProcessingTimeout) + "\")")
-		}
-
 		if resource.MachineCleanupPolicy.DeleteMachinesElapsedTimeSpan.Minutes() != 20 {
 			t.Fatal("The machine policy must have a DeleteMachinesElapsedTimeSpan of \"00:20:00\" (was \"" + fmt.Sprint(resource.MachineCleanupPolicy.DeleteMachinesElapsedTimeSpan) + "\")")
 		}

--- a/octopusdeploy/schema_variable_prompt_options.go
+++ b/octopusdeploy/schema_variable_prompt_options.go
@@ -1,10 +1,11 @@
 package octopusdeploy
 
 import (
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/variables"
 )
 
-func expandPromptedDisplaySettings(values interface{}) *variables.DisplaySettings {
+func expandPromptedDisplaySettings(values interface{}) *resources.DisplaySettings {
 	if values == nil {
 		return nil
 	}
@@ -16,14 +17,14 @@ func expandPromptedDisplaySettings(values interface{}) *variables.DisplaySetting
 
 	promptedDisplaySettings := flattenedValues[0].(map[string]interface{})
 
-	controlType := variables.ControlType(promptedDisplaySettings["control_type"].(string))
+	controlType := resources.ControlType(promptedDisplaySettings["control_type"].(string))
 
-	var selectOptions []*variables.SelectOption
-	if controlType == variables.ControlTypeSelect {
+	var selectOptions []*resources.SelectOption
+	if controlType == resources.ControlTypeSelect {
 		selectOptions = expandSelectOptions(promptedDisplaySettings["select_option"])
 	}
 
-	return variables.NewDisplaySettings(controlType, selectOptions)
+	return resources.NewDisplaySettings(controlType, selectOptions)
 }
 
 func expandPromptedVariableSettings(values interface{}) *variables.VariablePromptOptions {
@@ -45,7 +46,7 @@ func expandPromptedVariableSettings(values interface{}) *variables.VariablePromp
 	}
 }
 
-func expandSelectOptions(values interface{}) []*variables.SelectOption {
+func expandSelectOptions(values interface{}) []*resources.SelectOption {
 	if values == nil {
 		return nil
 	}
@@ -55,11 +56,11 @@ func expandSelectOptions(values interface{}) []*variables.SelectOption {
 		return nil
 	}
 
-	selectOptions := make([]*variables.SelectOption, len(flattenedValues))
+	selectOptions := make([]*resources.SelectOption, len(flattenedValues))
 
 	for i := 0; i < len(flattenedValues); i++ {
 		item := flattenedValues[i].(map[string]interface{})
-		selectOptions[i] = &variables.SelectOption{
+		selectOptions[i] = &resources.SelectOption{
 			DisplayName: item["display_name"].(string),
 			Value:       item["value"].(string),
 		}
@@ -68,14 +69,14 @@ func expandSelectOptions(values interface{}) []*variables.SelectOption {
 	return selectOptions
 }
 
-func flattenPromptedVariableDisplaySettings(displaySettings *variables.DisplaySettings) []interface{} {
+func flattenPromptedVariableDisplaySettings(displaySettings *resources.DisplaySettings) []interface{} {
 	if displaySettings == nil {
 		return nil
 	}
 
 	flattenedDisplaySettings := map[string]interface{}{}
 	flattenedDisplaySettings["control_type"] = displaySettings.ControlType
-	if displaySettings.ControlType == variables.ControlTypeSelect {
+	if displaySettings.ControlType == resources.ControlTypeSelect {
 		flattenedDisplaySettings["select_option"] = flattenSelectOptions(displaySettings.SelectOptions)
 	}
 	return []interface{}{flattenedDisplaySettings}
@@ -99,7 +100,7 @@ func flattenPromptedVariableSettings(variablePromptOptions *variables.VariablePr
 	return []interface{}{flattenedPrompt}
 }
 
-func flattenSelectOptions(selectOptions []*variables.SelectOption) []map[string]interface{} {
+func flattenSelectOptions(selectOptions []*resources.SelectOption) []map[string]interface{} {
 	options := make([]map[string]interface{}, len(selectOptions))
 	for i := 0; i < len(selectOptions); i++ {
 		options[i] = map[string]interface{}{

--- a/octopusdeploy/schema_variable_prompt_options_test.go
+++ b/octopusdeploy/schema_variable_prompt_options_test.go
@@ -4,7 +4,6 @@ import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
 	"testing"
 
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/variables"
 	"github.com/stretchr/testify/require"
 )
 
@@ -48,7 +47,7 @@ func TestExpandPromptedDisplaySettingsWithSelect(t *testing.T) {
 	}
 	result := expandPromptedDisplaySettings(input)
 	require.NotNil(t, result)
-	require.Equal(t, variables.ControlTypeSelect, result.ControlType)
+	require.Equal(t, resources.ControlTypeSelect, result.ControlType)
 	require.NotNil(t, result.SelectOptions)
 	require.Len(t, result.SelectOptions, 2)
 	require.Equal(t, "Name-1", result.SelectOptions[0].DisplayName)

--- a/octopusdeploy/schema_variable_prompt_options_test.go
+++ b/octopusdeploy/schema_variable_prompt_options_test.go
@@ -1,6 +1,7 @@
 package octopusdeploy
 
 import (
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
 	"testing"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/variables"
@@ -26,7 +27,7 @@ func TestExpandPromptedDisplaySettingsWithCheckbox(t *testing.T) {
 	}
 	result := expandPromptedDisplaySettings(input)
 	require.NotNil(t, result)
-	require.Equal(t, variables.ControlTypeCheckbox, result.ControlType)
+	require.Equal(t, resources.ControlTypeCheckbox, result.ControlType)
 }
 
 func TestExpandPromptedDisplaySettingsWithSelect(t *testing.T) {


### PR DESCRIPTION
Related to https://github.com/OctopusDeploy/go-octopusdeploy/pull/241

The property `PollingRequestMaximumMessageProcessingTimeout` was removed from the Machine Policy resource in 2024.2 and it broke some customers.
In the below example, the property doesn't need to be set. The value will still be set internally as shown in the plan, but the server will drop the value at the API. This allows older servers to still have this value set.

[sc-72087]

resource:
```
resource "octopusdeploy_machine_policy" "machine_policy_1" {
  name = "new machine policy"
}
```

result:
```
❯ terraform apply

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # octopusdeploy_machine_policy.machine_policy_1 will be created
  + resource "octopusdeploy_machine_policy" "machine_policy_1" {
      + connection_connect_timeout                         = 60000000000
      + connection_retry_count_limit                       = 5
      + connection_retry_sleep_interval                    = 1000000000
      + connection_retry_time_limit                        = 300000000000
      + id                                                 = (known after apply)
      + is_default                                         = (known after apply)
      + name                                               = "new machine policy"
      + polling_request_maximum_message_processing_timeout = 600000000000
      + polling_request_queue_timeout                      = 120000000000
      + space_id                                           = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

octopusdeploy_machine_policy.machine_policy_1: Creating...
octopusdeploy_machine_policy.machine_policy_1: Creation complete after 0s [id=MachinePolicies-2]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

-----
There is a number of changes which were just namespace/package location changes for internal types from the client