### PR TITLE
Update go version for the goreleaser

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,5 +15,5 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       - run: go build ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       - uses: crazy-max/ghaction-import-gpg@v5
         id: import_gpg
         with:


### PR DESCRIPTION
The go cli version has been updated from 1.20 to 1.21 as part of this [change](https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/pull/616). The builds were working fine but the release step [failed](https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/actions/runs/8386301220/job/22966492251#step:5:31) as goreleaser wasn't happy. The goreleaser version used in that step was `goreleaser-action/1.24.0/x64/goreleaser` which should support go cli 1.21  https://github.com/goreleaser/goreleaser/releases 