### PR TITLE
Use new client method for creating aws account

### DIFF
--- a/octopusdeploy/resource_aws_account.go
+++ b/octopusdeploy/resource_aws_account.go
@@ -29,7 +29,8 @@ func resourceAmazonWebServicesAccountCreate(ctx context.Context, d *schema.Resou
 	log.Printf("[INFO] creating AWS account")
 
 	client := m.(*client.Client)
-	createdAccount, err := client.Accounts.Add(account)
+	createdAccount, err := accounts.Add(client, account)
+
 	if err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
The changes to support setting spaces on resources seems to have missed aws accounts. This small change fixes that.

Fixes https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/issues/592 