### PR TITLE
correctly pass environments for ssh key account

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -425,7 +425,7 @@ func TestSshAccountResource(t *testing.T) {
 			t.Fatal("The account must be have no tenant tags")
 		}
 
-		if len(resource.EnvironmentIDs) != 0 {
+		if len(resource.EnvironmentIDs) == 0 {
 			t.Fatal("The account must have environments")
 		}
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -36,12 +36,7 @@ package main
 
 import (
 	"fmt"
-<<<<<<< HEAD
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/deployments"
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/triggers"
 	"net/url"
-=======
->>>>>>> 6988f9c (Add test)
 	"os"
 	"path/filepath"
 	"sort"

--- a/integration_test.go
+++ b/integration_test.go
@@ -36,14 +36,22 @@ package main
 
 import (
 	"fmt"
+<<<<<<< HEAD
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/deployments"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/triggers"
 	"net/url"
+=======
+>>>>>>> 6988f9c (Add test)
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/deployments"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/triggers"
+
+	stdslices "slices"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/accounts"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/certificates"
@@ -66,7 +74,6 @@ import (
 	"github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework/octoclient"
 	"github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework/test"
 	"k8s.io/utils/strings/slices"
-	stdslices "slices"
 )
 
 // TestSpaceResource verifies that a space can be reimported with the correct settings
@@ -421,6 +428,10 @@ func TestSshAccountResource(t *testing.T) {
 
 		if len(resource.TenantTags) != 0 {
 			t.Fatal("The account must be have no tenant tags")
+		}
+
+		if len(resource.EnvironmentIDs) != 0 {
+			t.Fatal("The account must have environments")
 		}
 
 		return nil

--- a/octopusdeploy/schema_ssh_key_account.go
+++ b/octopusdeploy/schema_ssh_key_account.go
@@ -38,6 +38,10 @@ func expandSSHKeyAccount(d *schema.ResourceData) *accounts.SSHKeyAccount {
 		account.TenantIDs = getSliceFromTerraformTypeList(v)
 	}
 
+	if v, ok := d.GetOk("environments"); ok {
+		account.EnvironmentIDs = getSliceFromTerraformTypeList(v)
+	}
+
 	return account
 }
 

--- a/terraform/7-sshaccount/environments.tf
+++ b/terraform/7-sshaccount/environments.tf
@@ -1,0 +1,6 @@
+resource "octopusdeploy_environment" "development_environment" {
+  allow_dynamic_infrastructure = true
+  description                  = "A test environment"
+  name                         = "Development"
+  use_guided_failure           = false
+}

--- a/terraform/7-sshaccount/ssh_account.tf
+++ b/terraform/7-sshaccount/ssh_account.tf
@@ -1,7 +1,7 @@
 resource "octopusdeploy_ssh_key_account" "account_ssh" {
   description                       = "A test account"
   name                              = "SSH"
-  environments                      = null
+  environments                      = [octopusdeploy_environment.development_environment.id]
   tenant_tags                       = []
   tenants                           = null
   tenanted_deployment_participation = "Untenanted"


### PR DESCRIPTION
It looks like the `octopusdeploy_ssh_key_account` is not passing the environments configured on the desired state to the back end.

Fixes: https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/issues/255