### PR TITLE
Use new client method for creating aws oidc account

### DIFF
--- a/octopusdeploy/resource_aws_openid_connect_account.go
+++ b/octopusdeploy/resource_aws_openid_connect_account.go
@@ -29,7 +29,7 @@ func resourceAmazonWebServicesOpenIDConnectAccountCreate(ctx context.Context, d 
 	log.Printf("[INFO] creating AWS OIDC account")
 
 	client := m.(*client.Client)
-	createdAccount, err := client.Accounts.Add(account)
+	createdAccount, err := accounts.Add(account)
 	if err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
Identical to https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/pull/626 but for the AWS OIDC account