### PR TITLE
Use DeploymentActionSlugPackage for external feed triggers and add resource schema for primary package references

### DIFF
--- a/docs/resources/deployment_process.md
+++ b/docs/resources/deployment_process.md
@@ -208,6 +208,10 @@ Optional:
 - `worker_pool_id` (String) The worker pool associated with this deployment action.
 - `worker_pool_variable` (String) The worker pool variable associated with this deployment action.
 
+Read-Only:
+
+- `slug` (String) The human-readable unique identifier for this resource.
+
 <a id="nestedblock--step--action--action_template"></a>
 ### Nested Schema for `step.action.action_template`
 
@@ -316,6 +320,10 @@ Optional:
 - `tenant_tags` (List of String) A list of tenant tags associated with this resource.
 - `worker_pool_id` (String) The worker pool associated with this deployment action.
 - `worker_pool_variable` (String) The worker pool variable associated with this deployment action.
+
+Read-Only:
+
+- `slug` (String) The human-readable unique identifier for this resource.
 
 <a id="nestedblock--step--apply_terraform_template_action--advanced_options"></a>
 ### Nested Schema for `step.apply_terraform_template_action.advanced_options`
@@ -486,6 +494,10 @@ Optional:
 - `worker_pool_id` (String) The worker pool associated with this deployment action.
 - `worker_pool_variable` (String) The worker pool variable associated with this deployment action.
 
+Read-Only:
+
+- `slug` (String) The human-readable unique identifier for this resource.
+
 <a id="nestedblock--step--deploy_kubernetes_secret_action--action_template"></a>
 ### Nested Schema for `step.deploy_kubernetes_secret_action.action_template`
 
@@ -568,6 +580,10 @@ Optional:
 - `sort_order` (Number) Order used by terraform to ensure correct ordering of actions. This property must be either omitted from all actions, or provided on all actions
 - `tenant_tags` (List of String) A list of tenant tags associated with this resource.
 - `windows_service` (Block Set, Max: 1) Deploy a windows service feature (see [below for nested schema](#nestedblock--step--deploy_package_action--windows_service))
+
+Read-Only:
+
+- `slug` (String) The human-readable unique identifier for this resource.
 
 <a id="nestedblock--step--deploy_package_action--primary_package"></a>
 ### Nested Schema for `step.deploy_package_action.primary_package`
@@ -699,6 +715,10 @@ Optional:
 - `start_mode` (String) When will the service start. Can be auto, delayed-auto, manual, unchanged or an expression
 - `tenant_tags` (List of String) A list of tenant tags associated with this resource.
 
+Read-Only:
+
+- `slug` (String) The human-readable unique identifier for this resource.
+
 <a id="nestedblock--step--deploy_windows_service_action--primary_package"></a>
 ### Nested Schema for `step.deploy_windows_service_action.primary_package`
 
@@ -798,6 +818,10 @@ Optional:
 - `sort_order` (Number) Order used by terraform to ensure correct ordering of actions. This property must be either omitted from all actions, or provided on all actions
 - `tenant_tags` (List of String) A list of tenant tags associated with this resource.
 
+Read-Only:
+
+- `slug` (String) The human-readable unique identifier for this resource.
+
 <a id="nestedblock--step--manual_intervention_action--action_template"></a>
 ### Nested Schema for `step.manual_intervention_action.action_template`
 
@@ -889,6 +913,10 @@ Optional:
 - `variable_substitution_in_files` (String) A newline-separated list of file names to transform, relative to the package contents. Extended wildcard syntax is supported.
 - `worker_pool_id` (String) The worker pool associated with this deployment action.
 - `worker_pool_variable` (String) The worker pool variable associated with this deployment action.
+
+Read-Only:
+
+- `slug` (String) The human-readable unique identifier for this resource.
 
 <a id="nestedblock--step--run_kubectl_script_action--action_template"></a>
 ### Nested Schema for `step.run_kubectl_script_action.action_template`
@@ -997,6 +1025,10 @@ Optional:
 - `variable_substitution_in_files` (String) A newline-separated list of file names to transform, relative to the package contents. Extended wildcard syntax is supported.
 - `worker_pool_id` (String) The worker pool associated with this deployment action.
 - `worker_pool_variable` (String) The worker pool variable associated with this deployment action.
+
+Read-Only:
+
+- `slug` (String) The human-readable unique identifier for this resource.
 
 <a id="nestedblock--step--run_script_action--action_template"></a>
 ### Nested Schema for `step.run_script_action.action_template`

--- a/docs/resources/external_feed_create_release_trigger.md
+++ b/docs/resources/external_feed_create_release_trigger.md
@@ -34,13 +34,14 @@ resource "octopusdeploy_external_feed_create_release_trigger" "my_trigger" {
 
 - `channel_id` (String) The ID of the channel in which the release will be created if the action type is CreateRelease.
 - `name` (String) The name of this resource.
-- `package` (Block List, Min: 1) List of package references that will cause the trigger to fire. The triggering condition is if any of the packages are updated. (see [below for nested schema](#nestedblock--package))
 - `project_id` (String) The ID of the project to attach the trigger.
-- `space_id` (String) The space ID associated with the project to attach the trigger.
 
 ### Optional
 
 - `is_disabled` (Boolean) Disables the trigger from being run when set.
+- `package` (Block List) List of package references that will cause the trigger to fire. Will trigger if any of the packages are updated. (see [below for nested schema](#nestedblock--package))
+- `primary_package` (Block List) List of primary package references (primary with respect to its corresponding deployment action). Will trigger if any of the primary packages are updated. (see [below for nested schema](#nestedblock--primary_package))
+- `space_id` (String) The space ID associated with the project to attach the trigger.
 
 ### Read-Only
 
@@ -49,10 +50,18 @@ resource "octopusdeploy_external_feed_create_release_trigger" "my_trigger" {
 <a id="nestedblock--package"></a>
 ### Nested Schema for `package`
 
-Optional:
+Required:
 
-- `deployment_action` (String)
+- `deployment_action_slug` (String)
 - `package_reference` (String)
+
+
+<a id="nestedblock--primary_package"></a>
+### Nested Schema for `primary_package`
+
+Required:
+
+- `deployment_action_slug` (String)
 
 ## Import
 

--- a/docs/resources/external_feed_create_release_trigger.md
+++ b/docs/resources/external_feed_create_release_trigger.md
@@ -39,8 +39,8 @@ resource "octopusdeploy_external_feed_create_release_trigger" "my_trigger" {
 ### Optional
 
 - `is_disabled` (Boolean) Disables the trigger from being run when set.
-- `package` (Block List) List of package references that will cause the trigger to fire. Will trigger if any of the packages are updated. (see [below for nested schema](#nestedblock--package))
-- `primary_package` (Block List) List of primary package references (primary with respect to its corresponding deployment action). Will trigger if any of the primary packages are updated. (see [below for nested schema](#nestedblock--primary_package))
+- `package` (Block List) List of referenced packages that will cause the trigger to fire. New versions of any of the packages you select will trigger release creation. (see [below for nested schema](#nestedblock--package))
+- `primary_package` (Block List) List of deployment actions for which the primary packages will cause the trigger to fire. New versions of any of the packages you select will trigger release creation. (see [below for nested schema](#nestedblock--primary_package))
 - `space_id` (String) The space ID associated with the project to attach the trigger.
 
 ### Read-Only

--- a/docs/resources/runbook_process.md
+++ b/docs/resources/runbook_process.md
@@ -86,6 +86,10 @@ Optional:
 - `worker_pool_id` (String) The worker pool associated with this deployment action.
 - `worker_pool_variable` (String) The worker pool variable associated with this deployment action.
 
+Read-Only:
+
+- `slug` (String) The human-readable unique identifier for this resource.
+
 <a id="nestedblock--step--action--action_template"></a>
 ### Nested Schema for `step.action.action_template`
 
@@ -194,6 +198,10 @@ Optional:
 - `tenant_tags` (List of String) A list of tenant tags associated with this resource.
 - `worker_pool_id` (String) The worker pool associated with this deployment action.
 - `worker_pool_variable` (String) The worker pool variable associated with this deployment action.
+
+Read-Only:
+
+- `slug` (String) The human-readable unique identifier for this resource.
 
 <a id="nestedblock--step--apply_terraform_template_action--advanced_options"></a>
 ### Nested Schema for `step.apply_terraform_template_action.advanced_options`
@@ -364,6 +372,10 @@ Optional:
 - `worker_pool_id` (String) The worker pool associated with this deployment action.
 - `worker_pool_variable` (String) The worker pool variable associated with this deployment action.
 
+Read-Only:
+
+- `slug` (String) The human-readable unique identifier for this resource.
+
 <a id="nestedblock--step--deploy_kubernetes_secret_action--action_template"></a>
 ### Nested Schema for `step.deploy_kubernetes_secret_action.action_template`
 
@@ -446,6 +458,10 @@ Optional:
 - `sort_order` (Number) Order used by terraform to ensure correct ordering of actions. This property must be either omitted from all actions, or provided on all actions
 - `tenant_tags` (List of String) A list of tenant tags associated with this resource.
 - `windows_service` (Block Set, Max: 1) Deploy a windows service feature (see [below for nested schema](#nestedblock--step--deploy_package_action--windows_service))
+
+Read-Only:
+
+- `slug` (String) The human-readable unique identifier for this resource.
 
 <a id="nestedblock--step--deploy_package_action--primary_package"></a>
 ### Nested Schema for `step.deploy_package_action.primary_package`
@@ -577,6 +593,10 @@ Optional:
 - `start_mode` (String) When will the service start. Can be auto, delayed-auto, manual, unchanged or an expression
 - `tenant_tags` (List of String) A list of tenant tags associated with this resource.
 
+Read-Only:
+
+- `slug` (String) The human-readable unique identifier for this resource.
+
 <a id="nestedblock--step--deploy_windows_service_action--primary_package"></a>
 ### Nested Schema for `step.deploy_windows_service_action.primary_package`
 
@@ -676,6 +696,10 @@ Optional:
 - `sort_order` (Number) Order used by terraform to ensure correct ordering of actions. This property must be either omitted from all actions, or provided on all actions
 - `tenant_tags` (List of String) A list of tenant tags associated with this resource.
 
+Read-Only:
+
+- `slug` (String) The human-readable unique identifier for this resource.
+
 <a id="nestedblock--step--manual_intervention_action--action_template"></a>
 ### Nested Schema for `step.manual_intervention_action.action_template`
 
@@ -767,6 +791,10 @@ Optional:
 - `variable_substitution_in_files` (String) A newline-separated list of file names to transform, relative to the package contents. Extended wildcard syntax is supported.
 - `worker_pool_id` (String) The worker pool associated with this deployment action.
 - `worker_pool_variable` (String) The worker pool variable associated with this deployment action.
+
+Read-Only:
+
+- `slug` (String) The human-readable unique identifier for this resource.
 
 <a id="nestedblock--step--run_kubectl_script_action--action_template"></a>
 ### Nested Schema for `step.run_kubectl_script_action.action_template`
@@ -876,6 +904,10 @@ Optional:
 - `worker_pool_id` (String) The worker pool associated with this deployment action.
 - `worker_pool_variable` (String) The worker pool variable associated with this deployment action.
 
+Read-Only:
+
+- `slug` (String) The human-readable unique identifier for this resource.
+
 <a id="nestedblock--step--run_script_action--action_template"></a>
 ### Nested Schema for `step.run_script_action.action_template`
 
@@ -944,5 +976,3 @@ Optional:
 - `id` (String) The unique ID for this resource.
 - `name` (String) The name of this resource.
 - `properties` (Map of String) A list of properties associated with this package.
-
-

--- a/docs/resources/variable.md
+++ b/docs/resources/variable.md
@@ -36,6 +36,14 @@ resource "octopusdeploy_variable" "google_cloud_account_variable" {
   value     = "Accounts-123"
 }
 
+# Create a UsernamePassword account variable
+resource "octopusdeploy_variable" "usernamepassword_account_variable" {
+  owner_id = "Projects-123"
+  type     = "UsernamePasswordAccount"
+  name     = "UsernamePasswordVariable"
+  value    = octopusdeploy_username_password_account.account_user_pass.id
+}
+
 # create a Certificate variable
 resource "octopusdeploy_variable" "certificate_variable" {
   owner_id  = "Projects-123"

--- a/docs/resources/variable.md
+++ b/docs/resources/variable.md
@@ -88,7 +88,7 @@ resource "octopusdeploy_variable" "prompted_variable" {
 ### Required
 
 - `name` (String) The name of this resource.
-- `type` (String) The type of variable represented by this resource. Valid types are `AmazonWebServicesAccount`, `AzureAccount`, `GoogleCloudAccount`, `Certificate`, `Sensitive`, `String`, or `WorkerPool`.
+- `type` (String) The type of variable represented by this resource. Valid types are `AmazonWebServicesAccount`, `AzureAccount`, `GoogleCloudAccount`, `UsernamePasswordAccount`, `Certificate`, `Sensitive`, `String`, or `WorkerPool`.
 
 ### Optional
 

--- a/examples/resources/octopusdeploy_variable/resource.tf
+++ b/examples/resources/octopusdeploy_variable/resource.tf
@@ -22,6 +22,14 @@ resource "octopusdeploy_variable" "google_cloud_account_variable" {
   value     = "Accounts-123"
 }
 
+# Create a UsernamePassword account variable
+resource "octopusdeploy_variable" "usernamepassword_account_variable" {
+  owner_id = "Projects-123"
+  type     = "UsernamePasswordAccount"
+  name     = "UsernamePasswordVariable"
+  value    = octopusdeploy_username_password_account.account_user_pass.id
+}
+
 # create a Certificate variable
 resource "octopusdeploy_variable" "certificate_variable" {
   owner_id  = "Projects-123"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/OctopusDeploy/terraform-provider-octopusdeploy
 go 1.21
 
 require (
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.40.3
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.41.0
 	github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v0.0.0-20240409225949-b27d14ff2bcb
 	github.com/google/uuid v1.6.0
 	github.com/gruntwork-io/terratest v0.41.11

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.41.1
-	github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v0.0.0-20240409225949-b27d14ff2bcb
+	github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v0.0.0-20240502041300-f71244db277d
 	github.com/google/uuid v1.6.0
 	github.com/gruntwork-io/terratest v0.41.11
 	github.com/hashicorp/go-cty v1.4.1-0.20200723130312-85980079f637

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/OctopusDeploy/terraform-provider-octopusdeploy
 go 1.21
 
 require (
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.41.1
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.42.0
 	github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v0.0.0-20240502041300-f71244db277d
 	github.com/google/uuid v1.6.0
 	github.com/gruntwork-io/terratest v0.41.11

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/OctopusDeploy/terraform-provider-octopusdeploy
 go 1.21
 
 require (
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.41.0
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.41.1
 	github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v0.0.0-20240409225949-b27d14ff2bcb
 	github.com/google/uuid v1.6.0
 	github.com/gruntwork-io/terratest v0.41.11

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/Microsoft/hcsshim v0.11.4 h1:68vKo2VN8DE9AdN4tnkWnmdhqdbpUFM8OF3Airm7fz8=
 github.com/Microsoft/hcsshim v0.11.4/go.mod h1:smjE4dvqPX9Zldna+t5FG3rnoHhaB7QYxPRqGcpAD9w=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.41.1 h1:CpKfSXxI8HlwD6wOY4x2jpRHjQCZNssHZ5qr0HyB7PQ=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.41.1/go.mod h1:GZmFu6LmN8Yg0tEoZx3ytk9FnaH+84cWm7u5TdWZC6E=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.42.0 h1:LZ8qWUHrUhnG1TLT0c38o2/22T0JspvO1zK7Ha+eXgs=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.42.0/go.mod h1:GZmFu6LmN8Yg0tEoZx3ytk9FnaH+84cWm7u5TdWZC6E=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v0.0.0-20240502041300-f71244db277d h1:E0Rm52/XBlVzdkHET/+Js1FVVgf5/0oRk1tNkI4jcyk=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v0.0.0-20240502041300-f71244db277d/go.mod h1:Nyg+7cyTrSQ/lMIy5YY1UdJekRuoMWf4uHIPfaGmgTM=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,8 @@ github.com/Microsoft/hcsshim v0.11.4 h1:68vKo2VN8DE9AdN4tnkWnmdhqdbpUFM8OF3Airm7
 github.com/Microsoft/hcsshim v0.11.4/go.mod h1:smjE4dvqPX9Zldna+t5FG3rnoHhaB7QYxPRqGcpAD9w=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.41.1 h1:CpKfSXxI8HlwD6wOY4x2jpRHjQCZNssHZ5qr0HyB7PQ=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.41.1/go.mod h1:GZmFu6LmN8Yg0tEoZx3ytk9FnaH+84cWm7u5TdWZC6E=
-github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v0.0.0-20240409225949-b27d14ff2bcb h1:4Lzs6TsvSZkahw99VlIDP5aAihQiJZPoCQKTw1A9el4=
-github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v0.0.0-20240409225949-b27d14ff2bcb/go.mod h1:Nyg+7cyTrSQ/lMIy5YY1UdJekRuoMWf4uHIPfaGmgTM=
+github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v0.0.0-20240502041300-f71244db277d h1:E0Rm52/XBlVzdkHET/+Js1FVVgf5/0oRk1tNkI4jcyk=
+github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v0.0.0-20240502041300-f71244db277d/go.mod h1:Nyg+7cyTrSQ/lMIy5YY1UdJekRuoMWf4uHIPfaGmgTM=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/Microsoft/hcsshim v0.11.4 h1:68vKo2VN8DE9AdN4tnkWnmdhqdbpUFM8OF3Airm7fz8=
 github.com/Microsoft/hcsshim v0.11.4/go.mod h1:smjE4dvqPX9Zldna+t5FG3rnoHhaB7QYxPRqGcpAD9w=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.40.3 h1:Gi3tlcwFJPQe9mmdIV0NcScnHGvOcTFcoM67L+dx6gE=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.40.3/go.mod h1:GZmFu6LmN8Yg0tEoZx3ytk9FnaH+84cWm7u5TdWZC6E=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.41.0 h1:11fXSFfz0YQ9/e4KX7v7XW99z2+Q8qgyL9Z9E195YgM=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.41.0/go.mod h1:GZmFu6LmN8Yg0tEoZx3ytk9FnaH+84cWm7u5TdWZC6E=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v0.0.0-20240409225949-b27d14ff2bcb h1:4Lzs6TsvSZkahw99VlIDP5aAihQiJZPoCQKTw1A9el4=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v0.0.0-20240409225949-b27d14ff2bcb/go.mod h1:Nyg+7cyTrSQ/lMIy5YY1UdJekRuoMWf4uHIPfaGmgTM=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/Microsoft/hcsshim v0.11.4 h1:68vKo2VN8DE9AdN4tnkWnmdhqdbpUFM8OF3Airm7fz8=
 github.com/Microsoft/hcsshim v0.11.4/go.mod h1:smjE4dvqPX9Zldna+t5FG3rnoHhaB7QYxPRqGcpAD9w=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.41.0 h1:11fXSFfz0YQ9/e4KX7v7XW99z2+Q8qgyL9Z9E195YgM=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.41.0/go.mod h1:GZmFu6LmN8Yg0tEoZx3ytk9FnaH+84cWm7u5TdWZC6E=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.41.1 h1:CpKfSXxI8HlwD6wOY4x2jpRHjQCZNssHZ5qr0HyB7PQ=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.41.1/go.mod h1:GZmFu6LmN8Yg0tEoZx3ytk9FnaH+84cWm7u5TdWZC6E=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v0.0.0-20240409225949-b27d14ff2bcb h1:4Lzs6TsvSZkahw99VlIDP5aAihQiJZPoCQKTw1A9el4=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v0.0.0-20240409225949-b27d14ff2bcb/go.mod h1:Nyg+7cyTrSQ/lMIy5YY1UdJekRuoMWf4uHIPfaGmgTM=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=

--- a/integration_test.go
+++ b/integration_test.go
@@ -3553,18 +3553,20 @@ func TestPackageFeedCreateReleaseTriggerResources(t *testing.T) {
 			return err
 		}
 
-		if len(project_triggers) != 2 {
-			t.Fatal("There must be exactly 2 project triggers")
+		if len(project_triggers) != 3 {
+			t.Fatal("There must be exactly 3 project triggers")
 		}
 
 		tr1Name := "My first trigger"
 		tr2Name := "My second trigger"
+		tr3Name := "My third trigger"
 
 		tr1Index := stdslices.IndexFunc(project_triggers, func(t *triggers.ProjectTrigger) bool { return t.Name == tr1Name })
 		tr2Index := stdslices.IndexFunc(project_triggers, func(t *triggers.ProjectTrigger) bool { return t.Name == tr2Name })
+		tr3Index := stdslices.IndexFunc(project_triggers, func(t *triggers.ProjectTrigger) bool { return t.Name == tr3Name })
 
-		if tr1Index == -1 || tr2Index == -1 {
-			t.Fatalf("Unable to find both triggers. Expecting there to be \"%s\" and \"%s\".", tr1Name, tr2Name)
+		if tr1Index == -1 || tr2Index == -1 || tr3Index == -1 {
+			t.Fatalf("Unable to find all triggers. Expecting there to be \"%s\", \"%s\", and \"%s\".", tr1Name, tr2Name, tr3Name)
 		}
 
 		if project_triggers[0].Filter.GetFilterType() != filters.FeedFilter || project_triggers[1].Filter.GetFilterType() != filters.FeedFilter {
@@ -3579,8 +3581,13 @@ func TestPackageFeedCreateReleaseTriggerResources(t *testing.T) {
 			t.Fatalf("The trigger \"%s\" should be disabled", tr2Name)
 		}
 
+		if project_triggers[tr3Index].IsDisabled {
+			t.Fatalf("The trigger \"%s\" should not be disabled", tr3Name)
+		}
+
 		tr1Filter := project_triggers[tr1Index].Filter.(*filters.FeedTriggerFilter)
 		tr2Filter := project_triggers[tr2Index].Filter.(*filters.FeedTriggerFilter)
+		tr3Filter := project_triggers[tr3Index].Filter.(*filters.FeedTriggerFilter)
 
 		if len(tr1Filter.Packages) != 2 {
 			t.Fatalf("The trigger \"%s\" should have 2 package references", tr1Name)
@@ -3588,6 +3595,10 @@ func TestPackageFeedCreateReleaseTriggerResources(t *testing.T) {
 
 		if len(tr2Filter.Packages) != 1 {
 			t.Fatalf("The trigger \"%s\" should have 1 package reference", tr2Name)
+		}
+
+		if len(tr3Filter.Packages) != 3 {
+			t.Fatalf("The trigger \"%s\" should have 3 package reference", tr3Name)
 		}
 
 		return nil

--- a/integration_test.go
+++ b/integration_test.go
@@ -3565,8 +3565,10 @@ func TestPackageFeedCreateReleaseTriggerResources(t *testing.T) {
 			t.Fatalf("Unable to find all triggers. Expecting there to be \"%s\", \"%s\", and \"%s\".", tr1Name, tr2Name, tr3Name)
 		}
 
-		if project_triggers[0].Filter.GetFilterType() != filters.FeedFilter || project_triggers[1].Filter.GetFilterType() != filters.FeedFilter {
-			t.Fatal("The project triggers must all be of \"FeedFilter\" type")
+		for _, triggerIndex := range []int{tr1Index, tr2Index, tr3Index} {
+			if project_triggers[triggerIndex].Filter.GetFilterType() != filters.FeedFilter {
+				t.Fatal("The project triggers must all be of \"FeedFilter\" type")
+			}
 		}
 
 		if project_triggers[tr1Index].IsDisabled {

--- a/integration_test.go
+++ b/integration_test.go
@@ -3553,10 +3553,6 @@ func TestPackageFeedCreateReleaseTriggerResources(t *testing.T) {
 			return err
 		}
 
-		if len(project_triggers) != 3 {
-			t.Fatal("There must be exactly 3 project triggers")
-		}
-
 		tr1Name := "My first trigger"
 		tr2Name := "My second trigger"
 		tr3Name := "My third trigger"

--- a/octopusdeploy/resource_external_feed_create_release_trigger.go
+++ b/octopusdeploy/resource_external_feed_create_release_trigger.go
@@ -39,6 +39,11 @@ func buildExternalFeedCreateReleaseTriggerResource(d *schema.ResourceData, clien
 	flattenedPackages := d.Get("package")
 	packages := expandDeploymentActionSlugPackages(flattenedPackages)
 
+	flattenedPrimaryPackages := d.Get("primary_package")
+	primaryPackages := expandDeploymentActionSlugPrimaryPackages(flattenedPrimaryPackages)
+
+	packages = append(packages, primaryPackages...)
+
 	action := actions.NewCreateReleaseAction(channelId)
 	filter := filters.NewFeedTriggerFilter(packages)
 
@@ -96,6 +101,7 @@ func resourceExternalFeedCreateReleaseTriggerRead(ctx context.Context, d *schema
 	d.Set("is_disabled", projectTrigger.IsDisabled)
 	d.Set("channel_id", action.ChannelID)
 	d.Set("package", flattenDeploymentActionSlugPackages(filter.Packages))
+	d.Set("primary_package", flattenDeploymentActionSlugPrimaryPackages(filter.Packages))
 
 	return nil
 }

--- a/octopusdeploy/resource_external_feed_create_release_trigger.go
+++ b/octopusdeploy/resource_external_feed_create_release_trigger.go
@@ -37,7 +37,7 @@ func buildExternalFeedCreateReleaseTriggerResource(d *schema.ResourceData, clien
 	}
 
 	flattenedPackages := d.Get("package")
-	packages := expandDeploymentActionPackages(flattenedPackages)
+	packages := expandDeploymentActionSlugPackages(flattenedPackages)
 
 	action := actions.NewCreateReleaseAction(channelId)
 	filter := filters.NewFeedTriggerFilter(packages)
@@ -95,7 +95,7 @@ func resourceExternalFeedCreateReleaseTriggerRead(ctx context.Context, d *schema
 	d.Set("project_id", projectTrigger.ProjectID)
 	d.Set("is_disabled", projectTrigger.IsDisabled)
 	d.Set("channel_id", action.ChannelID)
-	d.Set("package", flattenDeploymentActionPackages(filter.Packages))
+	d.Set("package", flattenDeploymentActionSlugPackages(filter.Packages))
 
 	return nil
 }

--- a/octopusdeploy/schema_deployment_action.go
+++ b/octopusdeploy/schema_deployment_action.go
@@ -78,6 +78,10 @@ func flattenAction(action *deployments.DeploymentAction) map[string]interface{} 
 		flattenedAction["name"] = action.Name
 	}
 
+	if len(action.Slug) > 0 {
+		flattenedAction["slug"] = action.Slug
+	}
+
 	if len(action.Notes) > 0 {
 		flattenedAction["notes"] = action.Notes
 	}
@@ -257,6 +261,7 @@ func getActionSchema() (*schema.Schema, *schema.Resource) {
 				Optional:    true,
 				Default:     -1,
 			},
+			"slug":        getSlugSchema(),
 			"tenant_tags": getTenantTagsSchema(),
 		},
 	}
@@ -446,6 +451,10 @@ func expandAction(flattenedAction map[string]interface{}) *deployments.Deploymen
 	if v, ok := flattenedAction["run_on_server"]; ok {
 		runOnServer := v.(bool)
 		action.Properties["Octopus.Action.RunOnServer"] = core.NewPropertyValue(cases.Title(language.Und, cases.NoLower).String(strconv.FormatBool(runOnServer)), false)
+	}
+
+	if v, ok := flattenedAction["slug"]; ok {
+		action.Slug = v.(string)
 	}
 
 	if v, ok := flattenedAction["action_template"]; ok {

--- a/octopusdeploy/schema_deployment_action_slug_package.go
+++ b/octopusdeploy/schema_deployment_action_slug_package.go
@@ -21,6 +21,21 @@ func expandDeploymentActionSlugPackages(values interface{}) []packages.Deploymen
 	return actionPackages
 }
 
+func expandDeploymentActionSlugPrimaryPackages(values interface{}) []packages.DeploymentActionSlugPackage {
+	if values == nil {
+		return nil
+	}
+
+	actionPackages := []packages.DeploymentActionSlugPackage{}
+	for _, v := range values.([]interface{}) {
+		flattenedMap := v.(map[string]interface{})
+		actionPackages = append(actionPackages, packages.DeploymentActionSlugPackage{
+			DeploymentActionSlug: flattenedMap["deployment_action_slug"].(string),
+		})
+	}
+	return actionPackages
+}
+
 func flattenDeploymentActionSlugPackages(deploymentActionSlugPackages []packages.DeploymentActionSlugPackage) []interface{} {
 	if len(deploymentActionSlugPackages) == 0 {
 		return nil
@@ -28,11 +43,30 @@ func flattenDeploymentActionSlugPackages(deploymentActionSlugPackages []packages
 
 	flattenedDeploymentActionSlugPackages := []interface{}{}
 	for _, v := range deploymentActionSlugPackages {
-		flattenedDeploymentActionSlugPackage := map[string]interface{}{
-			"deployment_action_slug": v.DeploymentActionSlug,
-			"package_reference":      v.PackageReference,
+		if v.PackageReference != "" {
+			flattenedDeploymentActionSlugPackage := map[string]interface{}{
+				"deployment_action_slug": v.DeploymentActionSlug,
+				"package_reference":      v.PackageReference,
+			}
+			flattenedDeploymentActionSlugPackages = append(flattenedDeploymentActionSlugPackages, flattenedDeploymentActionSlugPackage)
 		}
-		flattenedDeploymentActionSlugPackages = append(flattenedDeploymentActionSlugPackages, flattenedDeploymentActionSlugPackage)
+	}
+	return flattenedDeploymentActionSlugPackages
+}
+
+func flattenDeploymentActionSlugPrimaryPackages(deploymentActionSlugPackages []packages.DeploymentActionSlugPackage) []interface{} {
+	if len(deploymentActionSlugPackages) == 0 {
+		return nil
+	}
+
+	flattenedDeploymentActionSlugPackages := []interface{}{}
+	for _, v := range deploymentActionSlugPackages {
+		if v.PackageReference == "" {
+			flattenedDeploymentActionSlugPackage := map[string]interface{}{
+				"deployment_action_slug": v.DeploymentActionSlug,
+			}
+			flattenedDeploymentActionSlugPackages = append(flattenedDeploymentActionSlugPackages, flattenedDeploymentActionSlugPackage)
+		}
 	}
 	return flattenedDeploymentActionSlugPackages
 }
@@ -40,11 +74,20 @@ func flattenDeploymentActionSlugPackages(deploymentActionSlugPackages []packages
 func getDeploymentActionSlugPackageSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"deployment_action_slug": {
-			Optional: true,
+			Required: true,
 			Type:     schema.TypeString,
 		},
 		"package_reference": {
-			Optional: true,
+			Required: true,
+			Type:     schema.TypeString,
+		},
+	}
+}
+
+func getDeploymentActionSlugPrimaryPackageSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"deployment_action_slug": {
+			Required: true,
 			Type:     schema.TypeString,
 		},
 	}

--- a/octopusdeploy/schema_deployment_action_slug_package.go
+++ b/octopusdeploy/schema_deployment_action_slug_package.go
@@ -1,0 +1,51 @@
+package octopusdeploy
+
+import (
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/packages"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func expandDeploymentActionSlugPackages(values interface{}) []packages.DeploymentActionSlugPackage {
+	if values == nil {
+		return nil
+	}
+
+	actionPackages := []packages.DeploymentActionSlugPackage{}
+	for _, v := range values.([]interface{}) {
+		flattenedMap := v.(map[string]interface{})
+		actionPackages = append(actionPackages, packages.DeploymentActionSlugPackage{
+			DeploymentActionSlug: flattenedMap["deployment_action_slug"].(string),
+			PackageReference:     flattenedMap["package_reference"].(string),
+		})
+	}
+	return actionPackages
+}
+
+func flattenDeploymentActionSlugPackages(deploymentActionSlugPackages []packages.DeploymentActionSlugPackage) []interface{} {
+	if len(deploymentActionSlugPackages) == 0 {
+		return nil
+	}
+
+	flattenedDeploymentActionSlugPackages := []interface{}{}
+	for _, v := range deploymentActionSlugPackages {
+		flattenedDeploymentActionSlugPackage := map[string]interface{}{
+			"deployment_action_slug": v.DeploymentActionSlug,
+			"package_reference":      v.PackageReference,
+		}
+		flattenedDeploymentActionSlugPackages = append(flattenedDeploymentActionSlugPackages, flattenedDeploymentActionSlugPackage)
+	}
+	return flattenedDeploymentActionSlugPackages
+}
+
+func getDeploymentActionSlugPackageSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"deployment_action_slug": {
+			Optional: true,
+			Type:     schema.TypeString,
+		},
+		"package_reference": {
+			Optional: true,
+			Type:     schema.TypeString,
+		},
+	}
+}

--- a/octopusdeploy/schema_deployment_action_slug_package_test.go
+++ b/octopusdeploy/schema_deployment_action_slug_package_test.go
@@ -33,6 +33,31 @@ func TestExpandDeploymentActionSlugPackages(t *testing.T) {
 	require.Equal(t, expected, actual)
 }
 
+func TestExpandDeploymentActionSlugPrimaryPackages(t *testing.T) {
+	actual := expandDeploymentActionSlugPrimaryPackages(nil)
+	require.Nil(t, actual)
+
+	actual = expandDeploymentActionSlugPrimaryPackages([]interface{}{})
+	expected := []packages.DeploymentActionSlugPackage{}
+	require.Equal(t, expected, actual)
+
+	flattened := []interface{}{
+		map[string]interface{}{
+			"deployment_action_slug": "",
+		},
+		map[string]interface{}{
+			"deployment_action_slug": "test-deployment_action",
+			"package_reference":      "should_be_ignored",
+		},
+	}
+	expected = []packages.DeploymentActionSlugPackage{
+		{DeploymentActionSlug: "", PackageReference: ""},
+		{DeploymentActionSlug: "test-deployment_action", PackageReference: ""},
+	}
+	actual = expandDeploymentActionSlugPrimaryPackages(flattened)
+	require.Equal(t, expected, actual)
+}
+
 func TestFlattenDeploymentActionSlugPackages(t *testing.T) {
 	actual := flattenDeploymentActionSlugPackages(nil)
 	require.Nil(t, actual)
@@ -40,20 +65,77 @@ func TestFlattenDeploymentActionSlugPackages(t *testing.T) {
 	actual = flattenDeploymentActionSlugPackages([]packages.DeploymentActionSlugPackage{})
 	require.Nil(t, actual)
 
-	expanded := []packages.DeploymentActionSlugPackage{{}, {
-		DeploymentActionSlug: "test-deployment_action",
-		PackageReference:     "test-package_reference",
-	}}
-	actual = flattenDeploymentActionSlugPackages(expanded)
-	expected := []interface{}{
-		map[string]interface{}{
-			"deployment_action_slug": "",
-			"package_reference":      "",
+	expanded := []packages.DeploymentActionSlugPackage{
+		{
+			DeploymentActionSlug: "action-one",
+			PackageReference:     "",
 		},
+		{
+			DeploymentActionSlug: "action-two",
+			PackageReference:     "",
+		},
+	}
+	actual = flattenDeploymentActionSlugPackages(expanded)
+	expected := []interface{}{}
+	require.Equal(t, expected, actual)
+
+	expanded = getCommonExpandedPackages()
+	actual = flattenDeploymentActionSlugPackages(expanded)
+	expected = []interface{}{
 		map[string]interface{}{
-			"deployment_action_slug": "test-deployment_action",
-			"package_reference":      "test-package_reference",
+			"deployment_action_slug": "action-one",
+			"package_reference":      "some-package",
 		},
 	}
 	require.Equal(t, expected, actual)
+
+}
+
+func TestFlattenDeploymentActionSlugPrimaryPackages(t *testing.T) {
+	actual := flattenDeploymentActionSlugPrimaryPackages(nil)
+	require.Nil(t, actual)
+
+	actual = flattenDeploymentActionSlugPrimaryPackages([]packages.DeploymentActionSlugPackage{})
+	require.Nil(t, actual)
+
+	expanded := []packages.DeploymentActionSlugPackage{
+		{
+			DeploymentActionSlug: "action-one",
+			PackageReference:     "some-package",
+		},
+		{
+			DeploymentActionSlug: "action-two",
+			PackageReference:     "some-other-package",
+		},
+	}
+	actual = flattenDeploymentActionSlugPrimaryPackages(expanded)
+	expected := []interface{}{}
+
+	expanded = getCommonExpandedPackages()
+	actual = flattenDeploymentActionSlugPrimaryPackages(expanded)
+	expected = []interface{}{
+		map[string]interface{}{
+			"deployment_action_slug": "action-two",
+		},
+		map[string]interface{}{
+			"deployment_action_slug": "action-three",
+		},
+	}
+	require.Equal(t, expected, actual)
+}
+
+func getCommonExpandedPackages() []packages.DeploymentActionSlugPackage {
+	return []packages.DeploymentActionSlugPackage{
+		{
+			DeploymentActionSlug: "action-one",
+			PackageReference:     "some-package",
+		},
+		{
+			DeploymentActionSlug: "action-two",
+			PackageReference:     "",
+		},
+		{
+			DeploymentActionSlug: "action-three",
+		},
+	}
 }

--- a/octopusdeploy/schema_deployment_action_slug_package_test.go
+++ b/octopusdeploy/schema_deployment_action_slug_package_test.go
@@ -7,14 +7,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestExpandDeploymentActionSlugPackages(t *testing.T) {
+func TestExpandDeploymentActionSlugPackages_NilExpandsToNil(t *testing.T) {
 	actual := expandDeploymentActionSlugPackages(nil)
 	require.Nil(t, actual)
+}
 
-	actual = expandDeploymentActionSlugPackages([]interface{}{})
+func TestExpandDeploymentActionSlugPackages_EmptyExpandsToEmpty(t *testing.T) {
+	actual := expandDeploymentActionSlugPackages([]interface{}{})
 	expected := []packages.DeploymentActionSlugPackage{}
 	require.Equal(t, expected, actual)
+}
 
+func TestExpandDeploymentActionSlugPackages_ArrayExpandsCorrectly(t *testing.T) {
 	flattened := []interface{}{
 		map[string]interface{}{
 			"deployment_action_slug": "",
@@ -25,22 +29,26 @@ func TestExpandDeploymentActionSlugPackages(t *testing.T) {
 			"package_reference":      "test-package_reference",
 		},
 	}
-	expected = []packages.DeploymentActionSlugPackage{
+	expected := []packages.DeploymentActionSlugPackage{
 		{DeploymentActionSlug: "", PackageReference: ""},
 		{DeploymentActionSlug: "test-deployment_action", PackageReference: "test-package_reference"},
 	}
-	actual = expandDeploymentActionSlugPackages(flattened)
+	actual := expandDeploymentActionSlugPackages(flattened)
 	require.Equal(t, expected, actual)
 }
 
-func TestExpandDeploymentActionSlugPrimaryPackages(t *testing.T) {
+func TestExpandDeploymentActionSlugPrimaryPackages_NilExpandsToNil(t *testing.T) {
 	actual := expandDeploymentActionSlugPrimaryPackages(nil)
 	require.Nil(t, actual)
+}
 
-	actual = expandDeploymentActionSlugPrimaryPackages([]interface{}{})
+func TestExpandDeploymentActionSlugPrimaryPackages_EmptyExpandsToEmpty(t *testing.T) {
+	actual := expandDeploymentActionSlugPrimaryPackages([]interface{}{})
 	expected := []packages.DeploymentActionSlugPackage{}
 	require.Equal(t, expected, actual)
+}
 
+func TestExpandDeploymentActionSlugPrimaryPackages_ArrayExpandsCorrectly(t *testing.T) {
 	flattened := []interface{}{
 		map[string]interface{}{
 			"deployment_action_slug": "",
@@ -50,21 +58,25 @@ func TestExpandDeploymentActionSlugPrimaryPackages(t *testing.T) {
 			"package_reference":      "should_be_ignored",
 		},
 	}
-	expected = []packages.DeploymentActionSlugPackage{
+	expected := []packages.DeploymentActionSlugPackage{
 		{DeploymentActionSlug: "", PackageReference: ""},
 		{DeploymentActionSlug: "test-deployment_action", PackageReference: ""},
 	}
-	actual = expandDeploymentActionSlugPrimaryPackages(flattened)
+	actual := expandDeploymentActionSlugPrimaryPackages(flattened)
 	require.Equal(t, expected, actual)
 }
 
-func TestFlattenDeploymentActionSlugPackages(t *testing.T) {
+func TestFlattenDeploymentActionSlugPackages_NilFlattensToNil(t *testing.T) {
 	actual := flattenDeploymentActionSlugPackages(nil)
 	require.Nil(t, actual)
+}
 
-	actual = flattenDeploymentActionSlugPackages([]packages.DeploymentActionSlugPackage{})
+func TestFlattenDeploymentActionSlugPackages_EmptyFlattensToNil(t *testing.T) {
+	actual := flattenDeploymentActionSlugPackages([]packages.DeploymentActionSlugPackage{})
 	require.Nil(t, actual)
+}
 
+func TestFlattenDeploymentActionSlugPackages_IgnoresPrimaryPackages_NoPackagesAfterFlattening(t *testing.T) {
 	expanded := []packages.DeploymentActionSlugPackage{
 		{
 			DeploymentActionSlug: "action-one",
@@ -75,29 +87,34 @@ func TestFlattenDeploymentActionSlugPackages(t *testing.T) {
 			PackageReference:     "",
 		},
 	}
-	actual = flattenDeploymentActionSlugPackages(expanded)
+	actual := flattenDeploymentActionSlugPackages(expanded)
 	expected := []interface{}{}
 	require.Equal(t, expected, actual)
+}
 
-	expanded = getCommonExpandedPackages()
-	actual = flattenDeploymentActionSlugPackages(expanded)
-	expected = []interface{}{
+func TestFlattenDeploymentActionSlugPackages_IgnoresPrimaryPackages_ArrayFlattensCorrectly(t *testing.T) {
+	expanded := getCommonExpandedPackages()
+	actual := flattenDeploymentActionSlugPackages(expanded)
+	expected := []interface{}{
 		map[string]interface{}{
 			"deployment_action_slug": "action-one",
 			"package_reference":      "some-package",
 		},
 	}
 	require.Equal(t, expected, actual)
-
 }
 
-func TestFlattenDeploymentActionSlugPrimaryPackages(t *testing.T) {
+func TestFlattenDeploymentActionSlugPrimaryPackages_NilFlattensToNil(t *testing.T) {
 	actual := flattenDeploymentActionSlugPrimaryPackages(nil)
 	require.Nil(t, actual)
+}
 
-	actual = flattenDeploymentActionSlugPrimaryPackages([]packages.DeploymentActionSlugPackage{})
+func TestFlattenDeploymentActionSlugPrimaryPackages_EmptyFlattensToNil(t *testing.T) {
+	actual := flattenDeploymentActionSlugPrimaryPackages([]packages.DeploymentActionSlugPackage{})
 	require.Nil(t, actual)
+}
 
+func TestFlattenDeploymentActionSlugPrimaryPackages_IgnoresPackages_NoPrimaryPackagesAfterFlattening(t *testing.T) {
 	expanded := []packages.DeploymentActionSlugPackage{
 		{
 			DeploymentActionSlug: "action-one",
@@ -108,12 +125,15 @@ func TestFlattenDeploymentActionSlugPrimaryPackages(t *testing.T) {
 			PackageReference:     "some-other-package",
 		},
 	}
-	actual = flattenDeploymentActionSlugPrimaryPackages(expanded)
+	actual := flattenDeploymentActionSlugPrimaryPackages(expanded)
 	expected := []interface{}{}
+	require.Equal(t, expected, actual)
+}
 
-	expanded = getCommonExpandedPackages()
-	actual = flattenDeploymentActionSlugPrimaryPackages(expanded)
-	expected = []interface{}{
+func TestFlattenDeploymentActionSlugPrimaryPackages_IgnoresPackages_ArrayFlattensCorrectly(t *testing.T) {
+	expanded := getCommonExpandedPackages()
+	actual := flattenDeploymentActionSlugPrimaryPackages(expanded)
+	expected := []interface{}{
 		map[string]interface{}{
 			"deployment_action_slug": "action-two",
 		},

--- a/octopusdeploy/schema_deployment_action_slug_package_test.go
+++ b/octopusdeploy/schema_deployment_action_slug_package_test.go
@@ -1,0 +1,59 @@
+package octopusdeploy
+
+import (
+	"testing"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/packages"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpandDeploymentActionSlugPackages(t *testing.T) {
+	actual := expandDeploymentActionSlugPackages(nil)
+	require.Nil(t, actual)
+
+	actual = expandDeploymentActionSlugPackages([]interface{}{})
+	expected := []packages.DeploymentActionSlugPackage{}
+	require.Equal(t, expected, actual)
+
+	flattened := []interface{}{
+		map[string]interface{}{
+			"deployment_action_slug": "",
+			"package_reference":      "",
+		},
+		map[string]interface{}{
+			"deployment_action_slug": "test-deployment_action",
+			"package_reference":      "test-package_reference",
+		},
+	}
+	expected = []packages.DeploymentActionSlugPackage{
+		{DeploymentActionSlug: "", PackageReference: ""},
+		{DeploymentActionSlug: "test-deployment_action", PackageReference: "test-package_reference"},
+	}
+	actual = expandDeploymentActionSlugPackages(flattened)
+	require.Equal(t, expected, actual)
+}
+
+func TestFlattenDeploymentActionSlugPackages(t *testing.T) {
+	actual := flattenDeploymentActionSlugPackages(nil)
+	require.Nil(t, actual)
+
+	actual = flattenDeploymentActionSlugPackages([]packages.DeploymentActionSlugPackage{})
+	require.Nil(t, actual)
+
+	expanded := []packages.DeploymentActionSlugPackage{{}, {
+		DeploymentActionSlug: "test-deployment_action",
+		PackageReference:     "test-package_reference",
+	}}
+	actual = flattenDeploymentActionSlugPackages(expanded)
+	expected := []interface{}{
+		map[string]interface{}{
+			"deployment_action_slug": "",
+			"package_reference":      "",
+		},
+		map[string]interface{}{
+			"deployment_action_slug": "test-deployment_action",
+			"package_reference":      "test-package_reference",
+		},
+	}
+	require.Equal(t, expected, actual)
+}

--- a/octopusdeploy/schema_external_feed_create_release_trigger.go
+++ b/octopusdeploy/schema_external_feed_create_release_trigger.go
@@ -9,7 +9,7 @@ func getExternalFeedCreateReleaseTriggerSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"name": getNameSchema(true),
 		"space_id": {
-			Required:         true,
+			Optional:         true,
 			Description:      "The space ID associated with the project to attach the trigger.",
 			Type:             schema.TypeString,
 			ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotWhiteSpace),

--- a/octopusdeploy/schema_external_feed_create_release_trigger.go
+++ b/octopusdeploy/schema_external_feed_create_release_trigger.go
@@ -27,8 +27,7 @@ func getExternalFeedCreateReleaseTriggerSchema() map[string]*schema.Schema {
 			ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotWhiteSpace),
 		},
 		"package": {
-			Description: "List of referenced package that will cause the trigger to fire. New versions of any of the packages you select will trigger release creation.
- ",
+			Description: "List of referenced packages that will cause the trigger to fire. New versions of any of the packages you select will trigger release creation.",
 			Optional:    true,
 			Type:        schema.TypeList,
 			Elem:        &schema.Resource{Schema: getDeploymentActionSlugPackageSchema()},

--- a/octopusdeploy/schema_external_feed_create_release_trigger.go
+++ b/octopusdeploy/schema_external_feed_create_release_trigger.go
@@ -34,7 +34,7 @@ func getExternalFeedCreateReleaseTriggerSchema() map[string]*schema.Schema {
 			Elem:        &schema.Resource{Schema: getDeploymentActionSlugPackageSchema()},
 		},
 		"primary_package": {
-			Description: "List of primary package references (primary with respect to its corresponding deployment action). Will trigger if any of the primary packages are updated.",
+			Description: "List of deployment actions for which the primary packages will cause the trigger to fire. New versions of any of the packages you select will trigger release creation.",
 			Optional:    true,
 			Type:        schema.TypeList,
 			Elem:        &schema.Resource{Schema: getDeploymentActionSlugPrimaryPackageSchema()},

--- a/octopusdeploy/schema_external_feed_create_release_trigger.go
+++ b/octopusdeploy/schema_external_feed_create_release_trigger.go
@@ -27,10 +27,16 @@ func getExternalFeedCreateReleaseTriggerSchema() map[string]*schema.Schema {
 			ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotWhiteSpace),
 		},
 		"package": {
-			Description: "List of package references that will cause the trigger to fire. The triggering condition is if any of the packages are updated.",
-			Required:    true,
+			Description: "List of package references that will cause the trigger to fire. Will trigger if any of the packages are updated.",
+			Optional:    true,
 			Type:        schema.TypeList,
 			Elem:        &schema.Resource{Schema: getDeploymentActionSlugPackageSchema()},
+		},
+		"primary_package": {
+			Description: "List of primary package references (primary with respect to its corresponding deployment action). Will trigger if any of the primary packages are updated.",
+			Optional:    true,
+			Type:        schema.TypeList,
+			Elem:        &schema.Resource{Schema: getDeploymentActionSlugPrimaryPackageSchema()},
 		},
 		"is_disabled": {
 			Description: "Disables the trigger from being run when set.",

--- a/octopusdeploy/schema_external_feed_create_release_trigger.go
+++ b/octopusdeploy/schema_external_feed_create_release_trigger.go
@@ -30,7 +30,7 @@ func getExternalFeedCreateReleaseTriggerSchema() map[string]*schema.Schema {
 			Description: "List of package references that will cause the trigger to fire. The triggering condition is if any of the packages are updated.",
 			Required:    true,
 			Type:        schema.TypeList,
-			Elem:        &schema.Resource{Schema: getDeploymentActionPackageSchema()},
+			Elem:        &schema.Resource{Schema: getDeploymentActionSlugPackageSchema()},
 		},
 		"is_disabled": {
 			Description: "Disables the trigger from being run when set.",

--- a/octopusdeploy/schema_external_feed_create_release_trigger.go
+++ b/octopusdeploy/schema_external_feed_create_release_trigger.go
@@ -27,7 +27,8 @@ func getExternalFeedCreateReleaseTriggerSchema() map[string]*schema.Schema {
 			ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotWhiteSpace),
 		},
 		"package": {
-			Description: "List of package references that will cause the trigger to fire. Will trigger if any of the packages are updated.",
+			Description: "List of referenced package that will cause the trigger to fire. New versions of any of the packages you select will trigger release creation.
+ ",
 			Optional:    true,
 			Type:        schema.TypeList,
 			Elem:        &schema.Resource{Schema: getDeploymentActionSlugPackageSchema()},

--- a/octopusdeploy/schema_utilities.go
+++ b/octopusdeploy/schema_utilities.go
@@ -185,6 +185,14 @@ func getIDSchema() *schema.Schema {
 	}
 }
 
+func getSlugSchema() *schema.Schema {
+	return &schema.Schema{
+		Computed:    true,
+		Description: "The human-readable unique identifier for this resource.",
+		Type:        schema.TypeString,
+	}
+}
+
 func getIsSensitiveSchema() *schema.Schema {
 	return &schema.Schema{
 		Default:     false,

--- a/terraform/52-packagefeedcreatereleasetrigger/deployment_process.tf
+++ b/terraform/52-packagefeedcreatereleasetrigger/deployment_process.tf
@@ -65,4 +65,82 @@ resource "octopusdeploy_deployment_process" "example" {
       }
     }
   }
+  step {
+    condition           = "Success"
+    name                = "Helm one"
+    package_requirement = "LetOctopusDecide"
+    start_trigger       = "StartAfterPrevious"
+
+    action {
+      action_type                        = "Octopus.HelmChartUpgrade"
+      name                               = "Helm one"
+      condition                          = "Success"
+      run_on_server                      = true
+      is_disabled                        = false
+      can_be_used_for_project_versioning = true
+      is_required                        = false
+      worker_pool_id                     = ""
+      properties = {
+        "Octopus.Action.Helm.ClientVersion"         = "V3"
+        "Octopus.Action.Helm.Namespace"             = "dev"
+        "Octopus.Action.Package.DownloadOnTentacle" = "False"
+        "Octopus.Action.Helm.ResetValues"           = "True"
+      }
+      environments          = []
+      excluded_environments = []
+      channels              = []
+      tenant_tags           = []
+
+      primary_package {
+        package_id           = "redis"
+        acquisition_location = "Server"
+        feed_id              = "${octopusdeploy_helm_feed.feed_helm_charts.id}"
+        properties           = { SelectionMode = "immediate" }
+      }
+
+      features = []
+    }
+
+    properties   = {}
+    target_roles = ["k8s"]
+  }
+  step {
+    condition           = "Success"
+    name                = "Helm two"
+    package_requirement = "LetOctopusDecide"
+    start_trigger       = "StartAfterPrevious"
+
+    action {
+      action_type                        = "Octopus.HelmChartUpgrade"
+      name                               = "Helm two"
+      condition                          = "Success"
+      run_on_server                      = true
+      is_disabled                        = false
+      can_be_used_for_project_versioning = true
+      is_required                        = false
+      worker_pool_id                     = ""
+      properties = {
+        "Octopus.Action.Helm.ClientVersion"         = "V3"
+        "Octopus.Action.Helm.Namespace"             = "dev"
+        "Octopus.Action.Package.DownloadOnTentacle" = "False"
+        "Octopus.Action.Helm.ResetValues"           = "True"
+      }
+      environments          = []
+      excluded_environments = []
+      channels              = []
+      tenant_tags           = []
+
+      primary_package {
+        package_id           = "prometheus"
+        acquisition_location = "Server"
+        feed_id              = "${octopusdeploy_helm_feed.feed_helm_charts.id}"
+        properties           = { SelectionMode = "immediate" }
+      }
+
+      features = []
+    }
+
+    properties   = {}
+    target_roles = ["k8s"]
+  }
 }

--- a/terraform/52-packagefeedcreatereleasetrigger/feed.tf
+++ b/terraform/52-packagefeedcreatereleasetrigger/feed.tf
@@ -2,3 +2,9 @@ resource "octopusdeploy_docker_container_registry" "docker_feed" {
   feed_uri      = "https://index.docker.io"
   name          = "Test Docker Container Registry"
 }
+
+resource "octopusdeploy_helm_feed" "feed_helm_charts" {
+  name                                 = "Test Helm Charts"
+  feed_uri                             = "https://charts.helm.sh/stable"
+  package_acquisition_location_options = ["ExecutionTarget", "NotAcquired"]
+}

--- a/terraform/52-packagefeedcreatereleasetrigger/project.tf
+++ b/terraform/52-packagefeedcreatereleasetrigger/project.tf
@@ -10,8 +10,22 @@ resource "octopusdeploy_project_group" "project_group_test" {
   description = "Test Description"
 }
 
-resource "octopusdeploy_channel" "test_channel" {
-    name = "Test Channel"
+resource "octopusdeploy_channel" "test_channel_1" {
+    name = "Test Channel 1"
+    project_id = "${octopusdeploy_project.deploy_frontend_project.id}"
+    space_id = var.octopus_space_id
+    lifecycle_id = data.octopusdeploy_lifecycles.lifecycle_default_lifecycle.lifecycles[0].id
+}
+
+resource "octopusdeploy_channel" "test_channel_2" {
+    name = "Test Channel 2"
+    project_id = "${octopusdeploy_project.deploy_frontend_project.id}"
+    space_id = var.octopus_space_id
+    lifecycle_id = data.octopusdeploy_lifecycles.lifecycle_default_lifecycle.lifecycles[0].id
+}
+
+resource "octopusdeploy_channel" "test_channel_3" {
+    name = "Test Channel 3"
     project_id = "${octopusdeploy_project.deploy_frontend_project.id}"
     space_id = var.octopus_space_id
     lifecycle_id = data.octopusdeploy_lifecycles.lifecycle_default_lifecycle.lifecycles[0].id

--- a/terraform/52-packagefeedcreatereleasetrigger/project_triggers.tf
+++ b/terraform/52-packagefeedcreatereleasetrigger/project_triggers.tf
@@ -3,11 +3,11 @@ resource "octopusdeploy_external_feed_create_release_trigger" "external_feed_tri
   space_id    = var.octopus_space_id
   project_id  = "${octopusdeploy_project.deploy_frontend_project.id}"
   package {
-    deployment_action_slug = "hello-world-using-powershell-1"
+    deployment_action_slug = octopusdeploy_deployment_process.example.step[0].run_script_action[0].slug
     package_reference = "busybox"
   }
   package {
-    deployment_action_slug = "hello-world-using-powershell-1"
+    deployment_action_slug = octopusdeploy_deployment_process.example.step[0].run_script_action[0].slug
     package_reference = "nginx"
   }
   channel_id = octopusdeploy_channel.test_channel_1.id
@@ -23,7 +23,7 @@ resource "octopusdeploy_external_feed_create_release_trigger" "external_feed_tri
   project_id  = "${octopusdeploy_project.deploy_frontend_project.id}"
   is_disabled = true
   package {
-    deployment_action_slug = "hello-world-using-powershell-2"
+    deployment_action_slug = octopusdeploy_deployment_process.example.step[1].run_script_action[0].slug
     package_reference = "scratch"
   }
   channel_id = octopusdeploy_channel.test_channel_2.id
@@ -39,14 +39,14 @@ resource "octopusdeploy_external_feed_create_release_trigger" "external_feed_tri
   project_id  = "${octopusdeploy_project.deploy_frontend_project.id}"
   is_disabled = false
   package {
-    deployment_action_slug = "hello-world-using-powershell-1"
+    deployment_action_slug = octopusdeploy_deployment_process.example.step[0].run_script_action[0].slug
     package_reference = "busybox"
   }
   primary_package {
-    deployment_action_slug = "helm-one"
+    deployment_action_slug = octopusdeploy_deployment_process.example.step[2].action[0].slug
   }
   primary_package {
-    deployment_action_slug = "helm-two"
+    deployment_action_slug = octopusdeploy_deployment_process.example.step[3].action[0].slug
   }
   channel_id = octopusdeploy_channel.test_channel_3.id
 

--- a/terraform/52-packagefeedcreatereleasetrigger/project_triggers.tf
+++ b/terraform/52-packagefeedcreatereleasetrigger/project_triggers.tf
@@ -3,14 +3,18 @@ resource "octopusdeploy_external_feed_create_release_trigger" "external_feed_tri
   space_id    = var.octopus_space_id
   project_id  = "${octopusdeploy_project.deploy_frontend_project.id}"
   package {
-    deployment_action = octopusdeploy_deployment_process.example.step[0].run_script_action[0].name
+    deployment_action_slug = "hello-world-using-powershell-1"
     package_reference = "busybox"
   }
   package {
-    deployment_action = octopusdeploy_deployment_process.example.step[0].run_script_action[0].name
+    deployment_action_slug = "hello-world-using-powershell-1"
     package_reference = "nginx"
   }
-  channel_id = octopusdeploy_channel.test_channel.id
+  channel_id = octopusdeploy_channel.test_channel_1.id
+
+  depends_on = [
+    octopusdeploy_deployment_process.example
+  ]
 }
 
 resource "octopusdeploy_external_feed_create_release_trigger" "external_feed_trigger_2" {
@@ -19,8 +23,34 @@ resource "octopusdeploy_external_feed_create_release_trigger" "external_feed_tri
   project_id  = "${octopusdeploy_project.deploy_frontend_project.id}"
   is_disabled = true
   package {
-    deployment_action = octopusdeploy_deployment_process.example.step[1].run_script_action[0].name
+    deployment_action_slug = "hello-world-using-powershell-2"
     package_reference = "scratch"
   }
-  channel_id = octopusdeploy_channel.test_channel.id
+  channel_id = octopusdeploy_channel.test_channel_2.id
+
+  depends_on = [
+    octopusdeploy_deployment_process.example
+  ]
+}
+
+resource "octopusdeploy_external_feed_create_release_trigger" "external_feed_trigger_3" {
+  name        = "My third trigger"
+  space_id    = var.octopus_space_id
+  project_id  = "${octopusdeploy_project.deploy_frontend_project.id}"
+  is_disabled = false
+  package {
+    deployment_action_slug = "hello-world-using-powershell-1"
+    package_reference = "busybox"
+  }
+  primary_package {
+    deployment_action_slug = "helm-one"
+  }
+  primary_package {
+    deployment_action_slug = "helm-two"
+  }
+  channel_id = octopusdeploy_channel.test_channel_3.id
+
+  depends_on = [
+    octopusdeploy_deployment_process.example
+  ]
 }


### PR DESCRIPTION
## Changes in this PR

- Use the new [version](https://github.com/OctopusDeploy/go-octopusdeploy/pull/245) of the go-octopusdeploy library following the renaming of the `DeploymentAction` field to `DeploymentActionSlug` for `package` references.
- Add a new `primary_package` resource schema for external feed triggers. This will make it easier to distinguish between the two types of packages in Octopus deployment steps, and is easier to remember than otherwise having to set `package_reference = null` for primary packages.
- Make the `space_id` field optional for the external feed trigger resource. This is in line with every other resource in the Octopus TF provider. [sc-77155]
- Includes a [fix](https://github.com/OctopusDeploy/go-octopusdeploy/pull/246) in the go-octopusdeploy library to use the `space_id` in the request to fetch project triggers. This fixes the bug where triggers weren't being successfully retrieved on any space other than the default space. [sc-76114]
- Includes new [version](https://github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework/pull/2) of the TF testing framework which stops the tests from sending telemetry to Amplitude
- Adds the computed property `slug` on DeploymentActions so that it can be referenced and used in the specification of external feed triggers