### PR TITLE
Add kubernetes_agent_update_behavior to machine_update_policy

### DIFF
--- a/docs/data-sources/machine_policies.md
+++ b/docs/data-sources/machine_policies.md
@@ -102,6 +102,7 @@ Read-Only:
 Read-Only:
 
 - `calamari_update_behavior` (String)
+- `kubernetes_agent_update_behavior` (String)
 - `tentacle_update_account_id` (String)
 - `tentacle_update_behavior` (String)
 

--- a/docs/resources/machine_policy.md
+++ b/docs/resources/machine_policy.md
@@ -94,9 +94,9 @@ Optional:
 
 Optional:
 
-- `calamari_update_behavior` (String)
-- `kubernetes_agent_update_behavior` (String)
-- `tentacle_update_account_id` (String)
-- `tentacle_update_behavior` (String)
+- `calamari_update_behavior` (String) The behaviour of how Calamari is updated. Valid values are `UpdateAlways`, `UpdateOnDeployment` and `UpdateOnNewMachine`.
+- `kubernetes_agent_update_behavior` (String) The behaviour of how Kubernetes agent machines are updated. Valid values are `NeverUpdate` and `Update`.
+- `tentacle_update_account_id` (String) The Account ID to perform any Tentacle updates under.
+- `tentacle_update_behavior` (String) The behaviour of how Tentacle machines are updated. Valid values are `NeverUpdate` and `Update`.
 
 

--- a/docs/resources/machine_policy.md
+++ b/docs/resources/machine_policy.md
@@ -95,6 +95,7 @@ Optional:
 Optional:
 
 - `calamari_update_behavior` (String)
+- `kubernetes_agent_update_behavior` (String)
 - `tentacle_update_account_id` (String)
 - `tentacle_update_behavior` (String)
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/OctopusDeploy/terraform-provider-octopusdeploy
 go 1.21
 
 require (
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.42.2
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.43.0
 	github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v0.0.0-20240502041300-f71244db277d
 	github.com/google/uuid v1.6.0
 	github.com/gruntwork-io/terratest v0.41.11
@@ -16,6 +16,7 @@ require (
 	golang.org/x/exp v0.0.0-20230510235704-dd950f8aeaea
 	golang.org/x/text v0.13.0
 	k8s.io/utils v0.0.0-20230505201702-9f6742963106
+	software.sslmate.com/src/go-pkcs12 v0.4.0
 )
 
 require (
@@ -158,5 +159,4 @@ require (
 	google.golang.org/grpc v1.58.3 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	software.sslmate.com/src/go-pkcs12 v0.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/Microsoft/hcsshim v0.11.4 h1:68vKo2VN8DE9AdN4tnkWnmdhqdbpUFM8OF3Airm7fz8=
 github.com/Microsoft/hcsshim v0.11.4/go.mod h1:smjE4dvqPX9Zldna+t5FG3rnoHhaB7QYxPRqGcpAD9w=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.42.2 h1:UuDW2UkW9akLuuYE3kUf/irOr8NaegHw8qaBvQ1SRV0=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.42.2/go.mod h1:GZmFu6LmN8Yg0tEoZx3ytk9FnaH+84cWm7u5TdWZC6E=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.43.0 h1:fYwGBqG88xy3qHp5j1ySCztdqfw2NLfg2yp0N3XcBYg=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.43.0/go.mod h1:GZmFu6LmN8Yg0tEoZx3ytk9FnaH+84cWm7u5TdWZC6E=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v0.0.0-20240502041300-f71244db277d h1:E0Rm52/XBlVzdkHET/+Js1FVVgf5/0oRk1tNkI4jcyk=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v0.0.0-20240502041300-f71244db277d/go.mod h1:Nyg+7cyTrSQ/lMIy5YY1UdJekRuoMWf4uHIPfaGmgTM=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=

--- a/integration_test.go
+++ b/integration_test.go
@@ -1994,12 +1994,16 @@ func TestMachinePolicyResource(t *testing.T) {
 			t.Fatal("The machine policy must have a MachineHealthCheckPolicy.HealthCheckInterval of \"00:10:00\" (was \"" + fmt.Sprint(resource.MachineHealthCheckPolicy.HealthCheckInterval) + "\")")
 		}
 
-		if resource.MachineUpdatePolicy.CalamariUpdateBehavior != "UpdateOnDeployment" {
-			t.Fatal("The machine policy must have a MachineUpdatePolicy.CalamariUpdateBehavior of \"UpdateOnDeployment\" (was \"" + resource.MachineUpdatePolicy.CalamariUpdateBehavior + "\")")
+		if resource.MachineUpdatePolicy.CalamariUpdateBehavior != "UpdateAlways" {
+			t.Fatal("The machine policy must have a MachineUpdatePolicy.CalamariUpdateBehavior of \"UpdateAlways\" (was \"" + resource.MachineUpdatePolicy.CalamariUpdateBehavior + "\")")
 		}
 
-		if resource.MachineUpdatePolicy.TentacleUpdateBehavior != "NeverUpdate" {
-			t.Fatal("The machine policy must have a MachineUpdatePolicy.TentacleUpdateBehavior of \"NeverUpdate\" (was \"" + resource.MachineUpdatePolicy.CalamariUpdateBehavior + "\")")
+		if resource.MachineUpdatePolicy.TentacleUpdateBehavior != "Update" {
+			t.Fatal("The machine policy must have a MachineUpdatePolicy.TentacleUpdateBehavior of \"Update\" (was \"" + resource.MachineUpdatePolicy.CalamariUpdateBehavior + "\")")
+		}
+
+		if resource.MachineUpdatePolicy.KubernetesAgentUpdateBehavior != "NeverUpdate" {
+			t.Fatal("The machine policy must have a MachineUpdatePolicy.KubernetesAgentUpdateBehavior of \"NeverUpdate\" (was \"" + resource.MachineUpdatePolicy.CalamariUpdateBehavior + "\")")
 		}
 
 		return nil

--- a/octopusdeploy/schema_machine_update_policy.go
+++ b/octopusdeploy/schema_machine_update_policy.go
@@ -31,6 +31,10 @@ func expandMachineUpdatePolicy(values interface{}) *machinepolicies.MachineUpdat
 		machineUpdatePolicy.TentacleUpdateBehavior = v.(string)
 	}
 
+	if v, ok := flattenedMap["kubernetes_agent_update_behavior"]; ok {
+		machineUpdatePolicy.KubernetesAgentUpdateBehavior = v.(string)
+	}
+
 	return machineUpdatePolicy
 }
 
@@ -40,9 +44,10 @@ func flattenMachineUpdatePolicy(machineUpdatePolicy *machinepolicies.MachineUpda
 	}
 
 	return []interface{}{map[string]interface{}{
-		"calamari_update_behavior":   machineUpdatePolicy.CalamariUpdateBehavior,
-		"tentacle_update_account_id": machineUpdatePolicy.TentacleUpdateAccountID,
-		"tentacle_update_behavior":   machineUpdatePolicy.TentacleUpdateBehavior,
+		"calamari_update_behavior":         machineUpdatePolicy.CalamariUpdateBehavior,
+		"tentacle_update_account_id":       machineUpdatePolicy.TentacleUpdateAccountID,
+		"tentacle_update_behavior":         machineUpdatePolicy.TentacleUpdateBehavior,
+		"kubernetes_agent_update_behavior": machineUpdatePolicy.KubernetesAgentUpdateBehavior,
 	}}
 }
 
@@ -64,6 +69,15 @@ func getMachineUpdatePolicySchema() map[string]*schema.Schema {
 		},
 		"tentacle_update_behavior": {
 			Default:  "NeverUpdate",
+			Optional: true,
+			Type:     schema.TypeString,
+			ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{
+				"NeverUpdate",
+				"Update",
+			}, false)),
+		},
+		"kubernetes_agent_update_behavior": {
+			Default:  "Update",
 			Optional: true,
 			Type:     schema.TypeString,
 			ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{

--- a/octopusdeploy/schema_machine_update_policy.go
+++ b/octopusdeploy/schema_machine_update_policy.go
@@ -62,10 +62,12 @@ func getMachineUpdatePolicySchema() map[string]*schema.Schema {
 				"UpdateOnDeployment",
 				"UpdateOnNewMachine",
 			}, false)),
+			Description: "The behaviour of how Calamari is updated. Valid values are `UpdateAlways`, `UpdateOnDeployment` and `UpdateOnNewMachine`.",
 		},
 		"tentacle_update_account_id": {
-			Optional: true,
-			Type:     schema.TypeString,
+			Optional:    true,
+			Type:        schema.TypeString,
+			Description: "The Account ID to perform any Tentacle updates under.",
 		},
 		"tentacle_update_behavior": {
 			Default:  "NeverUpdate",
@@ -75,6 +77,7 @@ func getMachineUpdatePolicySchema() map[string]*schema.Schema {
 				"NeverUpdate",
 				"Update",
 			}, false)),
+			Description: "The behaviour of how Tentacle machines are updated. Valid values are `NeverUpdate` and `Update`.",
 		},
 		"kubernetes_agent_update_behavior": {
 			Default:  "Update",
@@ -84,6 +87,7 @@ func getMachineUpdatePolicySchema() map[string]*schema.Schema {
 				"NeverUpdate",
 				"Update",
 			}, false)),
+			Description: "The behaviour of how Kubernetes agent machines are updated. Valid values are `NeverUpdate` and `Update`.",
 		},
 	}
 }

--- a/terraform/27-machinepolicy/machinepolicy.tf
+++ b/terraform/27-machinepolicy/machinepolicy.tf
@@ -33,7 +33,8 @@ resource "octopusdeploy_machine_policy" "machinepolicy_testing" {
   }
 
   machine_update_policy {
-    calamari_update_behavior = "UpdateOnDeployment"
-    tentacle_update_behavior = "NeverUpdate"
+    calamari_update_behavior = "UpdateAlways"
+    tentacle_update_behavior = "Update"
+    kubernetes_agent_update_behavior = "NeverUpdate"
   }
 }


### PR DESCRIPTION
Adds a new `kubernetes_agent_update_behavior` property to the `machine_policy.machine_update_policy`

Possible values are `Update` and `NeverUpdate`. Default is `Update`

Shortcut story: [sc-78687]