### PR TITLE
Ensure runbookProcess has runbook ProjectId set

### DIFF
--- a/octopusdeploy/resource_runbook_process.go
+++ b/octopusdeploy/resource_runbook_process.go
@@ -72,6 +72,7 @@ func resourceRunbookProcessCreate(ctx context.Context, d *schema.ResourceData, m
 
 	runbookProcess.ID = current.ID
 	runbookProcess.Links = current.Links
+	runbookProcess.ProjectID = runbook.ProjectID
 	runbookProcess.Version = current.Version
 
 	createdRunbookProcess, err := runbookprocess.Update(client, runbookProcess)

--- a/terraform/51-deploymentprocesswithgitdependency/deployment_process.tf
+++ b/terraform/51-deploymentprocesswithgitdependency/deployment_process.tf
@@ -87,6 +87,7 @@ resource "octopusdeploy_deployment_process" "test_deployment_process" {
     name                = "Kubectl Action"
     package_requirement = "LetOctopusDecide"
     start_trigger       = "StartAfterPrevious"
+    target_roles        = [ "mycluster" ]
     run_kubectl_script_action {
       name             = "Kubectl Action"
       run_on_server    = true
@@ -106,7 +107,7 @@ resource "octopusdeploy_deployment_process" "test_deployment_process" {
     name                = "Raw Yaml Action"
     package_requirement = "LetOctopusDecide"
     start_trigger       = "StartAfterPrevious"
-    properties          = { "Octopus.Action.TargetRoles" : "Qwerty" }
+    target_roles        = [ "mycluster" ]
     action {
       action_type = "Octopus.KubernetesDeployRawYaml"
       name        = "Raw Yaml Action"
@@ -138,7 +139,7 @@ resource "octopusdeploy_deployment_process" "test_deployment_process" {
     name                = "Deploy Secret"
     package_requirement = "LetOctopusDecide"
     start_trigger       = "StartAfterPrevious"
-    properties          = { "Octopus.Action.TargetRoles" : "Qwerty" }
+    target_roles        = [ "mycluster" ]
     deploy_kubernetes_secret_action {
       name          = "Deploy secret"
       secret_name   = "name"


### PR DESCRIPTION
# Background
In order to cater for upcoming runbooks in git functionality, the latest Octopus Server instances will require the projectId value to be set.  This failure is reported through the provider as the following error

```
│ Error: Octopus API error: Object reference not set to an instance of an object. [] 
│
│   with octopusdeploy_runbook_process.runbook,
│   on main.tf line 107, in resource "octopusdeploy_runbook_process" "runbook":
│  107: resource "octopusdeploy_runbook_process" "runbook" {
```

# Solution
Since we are loading the runbook details before sending the process to the back end, we can take the `ProjectId` off the `Runbook` object and set it on the `RunbookProcess`. This area will need to be reconsidered further as it is supported by Config as Code


Also Fixes test that was relying on a bug with the K8S step validation