### PR TITLE
Allow library variable templates to be referenced by name

### DIFF
--- a/octopusdeploy/schema_action_template_parameter.go
+++ b/octopusdeploy/schema_action_template_parameter.go
@@ -49,6 +49,14 @@ func flattenActionTemplateParameters(actionTemplateParameters []actiontemplates.
 	return flattenedActionTemplateParameters
 }
 
+func mapTemplateNamesToIds(actionTemplateParameters []actiontemplates.ActionTemplateParameter) map[string]string {
+	templateNameIds := map[string]string{}
+	for _, actionTemplateParameter := range actionTemplateParameters {
+		templateNameIds[actionTemplateParameter.Name] = actionTemplateParameter.ID
+	}
+	return templateNameIds
+}
+
 func getActionTemplateParameterSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"default_value": {

--- a/octopusdeploy/schema_library_variable_set.go
+++ b/octopusdeploy/schema_library_variable_set.go
@@ -82,6 +82,16 @@ func getLibraryVariableSetSchema() map[string]*schema.Schema {
 			Elem:     &schema.Resource{Schema: getActionTemplateParameterSchema()},
 			Type:     schema.TypeList,
 		},
+		// This field is based on the suggestion at
+		// https://discuss.hashicorp.com/t/custom-provider-how-to-reference-computed-attribute-of-typemap-list-set-defined-as-nested-block/22898/2
+		"template_ids": {
+			Type: schema.TypeMap,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+			Computed: true,
+			Optional: false,
+		},
 		"variable_set_id": {
 			Computed: true,
 			Type:     schema.TypeString,
@@ -94,9 +104,14 @@ func setLibraryVariableSet(ctx context.Context, d *schema.ResourceData, libraryV
 	d.Set("name", libraryVariableSet.Name)
 	d.Set("space_id", libraryVariableSet.SpaceID)
 	d.Set("variable_set_id", libraryVariableSet.VariableSetID)
+	d.Set("template_ids", nil)
 
 	if err := d.Set("template", flattenActionTemplateParameters(libraryVariableSet.Templates)); err != nil {
 		return fmt.Errorf("error setting template: %s", err)
+	}
+
+	if err := d.Set("template_ids", mapTemplateNamesToIds(libraryVariableSet.Templates)); err != nil {
+		return fmt.Errorf("error setting template_ids: %s", err)
 	}
 
 	d.SetId(libraryVariableSet.GetID())


### PR DESCRIPTION
When defining new `octopusdeploy_tenant_common_variable` resources, it is nice to be able to reference the library variable set template ID by the template name.

This PR uses the suggestions from https://github.com/hashicorp/terraform/issues/18863 and https://discuss.hashicorp.com/t/custom-provider-how-to-reference-computed-attribute-of-typemap-list-set-defined-as-nested-block/22898/2 to create a lookup map called `template_ids` on a `octopusdeploy_library_variable_set` resource, and modify the plan to ensure the map includes all the new templates that might be added.