### PR TITLE
include template_ids in library variable set datasource

### DIFF
--- a/octopusdeploy/schema_library_variable_set.go
+++ b/octopusdeploy/schema_library_variable_set.go
@@ -39,6 +39,13 @@ func flattenLibraryVariableSet(libraryVariableSet *variables.LibraryVariableSet)
 		return nil
 	}
 
+	templateIds := map[string]string{}
+	if libraryVariableSet.Templates != nil {
+		for _, template := range libraryVariableSet.Templates {
+			templateIds[template.Name] = template.GetID()
+		}
+	}
+
 	return map[string]interface{}{
 		"description":     libraryVariableSet.Description,
 		"id":              libraryVariableSet.GetID(),
@@ -46,6 +53,7 @@ func flattenLibraryVariableSet(libraryVariableSet *variables.LibraryVariableSet)
 		"space_id":        libraryVariableSet.SpaceID,
 		"template":        flattenActionTemplateParameters(libraryVariableSet.Templates),
 		"variable_set_id": libraryVariableSet.VariableSetID,
+		"template_ids":    templateIds,
 	}
 }
 


### PR DESCRIPTION
Fixes: #652 

For the terraform:
```
data "octopusdeploy_library_variable_sets" "platform" {
  partial_name = "Variable Set Name"
  space_id = data.octopusdeploy_space.space.id
  skip = 0
  take = 1
}

output "lvs_template_ids" {
    value = data.octopusdeploy_library_variable_sets.platform.library_variable_sets[0].template_ids
}
```

before:
```
Changes to Outputs:
  + lvs_template_ids = {}
```

after:
```
Changes to Outputs:
  + lvs_template_ids = {
      + "Common.TP.AnotherOne"    = "71a27af8-8372-4937-aa05-9ce7148df8b7"
      + "Common.TP.Environment"   = "28a603b4-6d4a-4356-b9b0-0ee530c09bdf"
      + "Common.TP.Something"     = "4415c144-9ab8-4306-a665-442e6429bd75"
      + "Common.TP.SomethingElse" = "805a1923-bcdb-4c30-80f6-b875c6f747fd"
      + "Common.TP.Target"        = "734a1e2b-2faa-4759-a652-b555c07eff88"
    }
```