### PR TITLE
Enable Kubernetes Object Status Check by default on all Kubernetes steps

### DIFF
--- a/docs/data-sources/library_variable_sets.md
+++ b/docs/data-sources/library_variable_sets.md
@@ -39,6 +39,7 @@ Read-Only:
 - `name` (String) The name of this resource.
 - `space_id` (String) The space ID associated with this resource.
 - `template` (List of Object) (see [below for nested schema](#nestedatt--library_variable_sets--template))
+- `template_ids` (Map of String)
 - `variable_set_id` (String)
 
 <a id="nestedatt--library_variable_sets--template"></a>

--- a/docs/resources/deployment_process.md
+++ b/docs/resources/deployment_process.md
@@ -485,6 +485,7 @@ Optional:
 - `id` (String) The unique ID for this resource.
 - `is_disabled` (Boolean) Indicates the disabled status of this deployment action.
 - `is_required` (Boolean) Indicates the required status of this deployment action.
+- `kubernetes_object_status_check_enabled` (Boolean) Indicates the status of the Kubernetes Object Status feature
 - `notes` (String) The notes associated with this deployment action.
 - `package` (Block List) The package assocated with this action. (see [below for nested schema](#nestedblock--step--deploy_kubernetes_secret_action--package))
 - `properties` (Map of String) The properties associated with this deployment action.

--- a/docs/resources/library_variable_set.md
+++ b/docs/resources/library_variable_set.md
@@ -28,6 +28,7 @@ This resource manages library variable sets in Octopus Deploy.
 
 ### Read-Only
 
+- `template_ids` (Map of String)
 - `variable_set_id` (String)
 
 <a id="nestedblock--template"></a>

--- a/docs/resources/runbook_process.md
+++ b/docs/resources/runbook_process.md
@@ -363,6 +363,7 @@ Optional:
 - `id` (String) The unique ID for this resource.
 - `is_disabled` (Boolean) Indicates the disabled status of this deployment action.
 - `is_required` (Boolean) Indicates the required status of this deployment action.
+- `kubernetes_object_status_check_enabled` (Boolean) Indicates the status of the Kubernetes Object Status feature
 - `notes` (String) The notes associated with this deployment action.
 - `package` (Block List) The package assocated with this action. (see [below for nested schema](#nestedblock--step--deploy_kubernetes_secret_action--package))
 - `properties` (Map of String) The properties associated with this deployment action.

--- a/octopusdeploy/schema_action_deploy_kubernetes_secret.go
+++ b/octopusdeploy/schema_action_deploy_kubernetes_secret.go
@@ -22,6 +22,10 @@ func expandDeployKubernetesSecretAction(flattenedAction map[string]interface{}) 
 		action.Properties["Octopus.Action.KubernetesContainers.SecretValues"] = core.NewPropertyValue(string(j), false)
 	}
 
+	if v, ok := flattenedAction["kubernetes_object_status_check_enabled"]; ok {
+		action.Properties["Octopus.Action.Kubernetes.ResourceStatusCheck"] = core.NewPropertyValue(strconv.FormatBool(v.(bool)), false)
+	}
+
 	return action
 }
 
@@ -35,6 +39,11 @@ func flattenDeployKubernetesSecretAction(action *deployments.DeploymentAction) m
 
 	if v, ok := action.Properties["Octopus.Action.KubernetesContainers.SecretName"]; ok {
 		flattenedAction["secret_name"] = v.Value
+	}
+
+	if v, ok := action.Properties["Octopus.Action.Kubernetes.ResourceStatusCheck"]; ok {
+		statusCheckEnabled, _ := strconv.ParseBool(v.Value)
+		flattenedAction["kubernetes_object_status_check_enabled"] = statusCheckEnabled
 	}
 
 	if len(action.WorkerPool) > 0 {

--- a/octopusdeploy/schema_action_deploy_kubernetes_secret.go
+++ b/octopusdeploy/schema_action_deploy_kubernetes_secret.go
@@ -23,7 +23,7 @@ func expandDeployKubernetesSecretAction(flattenedAction map[string]interface{}) 
 	}
 
 	if v, ok := flattenedAction["kubernetes_object_status_check_enabled"]; ok {
-		action.Properties["Octopus.Action.Kubernetes.ResourceStatusCheck"] = core.NewPropertyValue(strconv.FormatBool(v.(bool)), false)
+		action.Properties["Octopus.Action.Kubernetes.ResourceStatusCheck"] = core.NewPropertyValue(formatBoolForActionProperty(v.(bool)), false)
 	}
 
 	return action
@@ -79,6 +79,13 @@ func getDeployKubernetesSecretActionSchema() *schema.Schema {
 		Elem:     &schema.Schema{Type: schema.TypeString},
 		Required: true,
 		Type:     schema.TypeMap,
+	}
+
+	element.Schema["kubernetes_object_status_check_enabled"] = &schema.Schema{
+		Optional:    true,
+		Default:     true,
+		Type:        schema.TypeBool,
+		Description: "Indicates the status of the Kubernetes Object Status feature",
 	}
 
 	return actionSchema

--- a/octopusdeploy/schema_action_deploy_kubernetes_secret_test.go
+++ b/octopusdeploy/schema_action_deploy_kubernetes_secret_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccOctopusDeployDeployKuberentesSecretAction(t *testing.T) {
+func TestAccOctopusDeployDeployKubernetesSecretAction(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			testAccProjectCheckDestroy,
@@ -20,21 +20,22 @@ func TestAccOctopusDeployDeployKuberentesSecretAction(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDeployKuberentesSecretAction(),
+				Config: testAccDeployKubernetesSecretAction(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeployKuberentesSecretAction(),
+					testAccCheckDeployKubernetesSecretAction(),
 				),
 			},
 		},
 	})
 }
 
-func testAccDeployKuberentesSecretAction() string {
+func testAccDeployKubernetesSecretAction() string {
 	return testAccBuildTestAction(`
 		deploy_kubernetes_secret_action {
 			name          = "Run Script"
 			run_on_server = true
 			secret_name   = "secret name"
+			kubernetes_object_status_check_enabled = false
 
 			secret_values = {
 				"key-123" = "value-123",
@@ -44,7 +45,7 @@ func testAccDeployKuberentesSecretAction() string {
 	`)
 }
 
-func testAccCheckDeployKuberentesSecretAction() resource.TestCheckFunc {
+func testAccCheckDeployKubernetesSecretAction() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*client.Client)
 
@@ -65,6 +66,10 @@ func testAccCheckDeployKuberentesSecretAction() resource.TestCheckFunc {
 
 		if action.Properties["Octopus.Action.KubernetesContainers.SecretValues"].Value != `{"key-123":"value-123","key-321":"value-321"}` {
 			return fmt.Errorf("SecretValue is incorrect: %s", action.Properties["Octopus.Action.KubernetesContainers.SecretValues"].Value)
+		}
+
+		if action.Properties["Octopus.Action.Kubernetes.ResourceStatusCheck"].Value != "False" {
+			return fmt.Errorf("Kubernetes Object Status Check is incorrect: %s", action.Properties["Octopus.Action.Kubernetes.ResourceStatusCheck"].Value)
 		}
 
 		return nil

--- a/octopusdeploy/schema_deployment_action.go
+++ b/octopusdeploy/schema_deployment_action.go
@@ -517,5 +517,24 @@ func expandAction(flattenedAction map[string]interface{}) *deployments.Deploymen
 		}
 	}
 
+	// Polyfill the Kubernetes Object status check to default to true if not specified for Kubernetes steps
+	switch actionType {
+	case "Octopus.KubernetesDeployContainers":
+		fallthrough
+	case "Octopus.KubernetesDeployRawYaml":
+		fallthrough
+	case "Octopus.KubernetesDeployService":
+		fallthrough
+	case "Octopus.KubernetesDeployIngress":
+		fallthrough
+	case "Octopus.KubernetesDeployConfigMap":
+		fallthrough
+	case "Octopus.Kustomize":
+		if _, exists := action.Properties["Octopus.Action.Kubernetes.ResourceStatusCheck"]; !exists {
+			action.Properties["Octopus.Action.Kubernetes.ResourceStatusCheck"] = core.NewPropertyValue(formatBoolForActionProperty(true), false)
+		}
+		break
+	}
+
 	return action
 }

--- a/octopusdeploy/util.go
+++ b/octopusdeploy/util.go
@@ -112,3 +112,10 @@ func stringHashCode(s string) int {
 	}
 	return 0
 }
+
+func formatBoolForActionProperty(b bool) string {
+	if b {
+		return "True"
+	}
+	return "False"
+}


### PR DESCRIPTION
In the UI, the Kubernetes Object Status Check is enabled by default, however, in the TF provider, this action property is not being set for kubernetes action types.

We only have 1 defined kubernetes action, `deploy_kubernetes_secret_action`, so I've added a new 1st class property, `kubernetes_object_status_check_enabled` that defaults to `true`.

For all other normal `action` blocks, we polyfill the `properties` with the `Octopus.Action.Kubernetes.ResourceStatusCheck` property set to true _if_ the `action_type` is a known Kubernetes action.

This results in the value being correctly sent to the server. However, the property doesn't get saved in the Terraform state, so it means subsequent plans will show a change to remove the property, but any apply after that will then _reapply_ that change.

The user just needs to add this key/value to their properties map `"Octopus.Action.Kubernetes.ResourceStatusCheck" = "True"` to get around this planned change.