### PR TITLE
chore!: align config in both providers

### DIFF
--- a/octopusdeploy/provider.go
+++ b/octopusdeploy/provider.go
@@ -90,13 +90,13 @@ func Provider() *schema.Provider {
 			"address": {
 				DefaultFunc: schema.EnvDefaultFunc("OCTOPUS_URL", nil),
 				Description: "The endpoint of the Octopus REST API",
-				Required:    true,
+				Optional:    true,
 				Type:        schema.TypeString,
 			},
 			"api_key": {
 				DefaultFunc: schema.EnvDefaultFunc("OCTOPUS_APIKEY", nil),
 				Description: "The API key to use with the Octopus REST API",
-				Required:    true,
+				Optional:    true,
 				Type:        schema.TypeString,
 			},
 			"space_id": {

--- a/octopusdeploy_framework/datasource_environments.go
+++ b/octopusdeploy_framework/datasource_environments.go
@@ -36,7 +36,7 @@ func NewEnvironmentsDataSource() datasource.DataSource {
 }
 
 func (*environmentDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = ProviderTypeName + "_environments"
+	resp.TypeName = util.GetTypeName("environments")
 }
 
 func (*environmentDataSource) Schema(_ context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/octopusdeploy_framework/datasource_feeds.go
+++ b/octopusdeploy_framework/datasource_feeds.go
@@ -23,7 +23,7 @@ func NewFeedsDataSource() datasource.DataSource {
 }
 
 func (*feedsDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = ProviderTypeName + "_feeds"
+	resp.TypeName = util.GetTypeName("feeds")
 }
 
 func (e *feedsDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {

--- a/octopusdeploy_framework/datasource_project_groups.go
+++ b/octopusdeploy_framework/datasource_project_groups.go
@@ -42,7 +42,7 @@ func getNestedGroupAttributes() map[string]attr.Type {
 }
 
 func (p *projectGroupsDataSource) Metadata(_ context.Context, _ datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = ProviderTypeName + "_project_groups"
+	resp.TypeName = util.GetTypeName("project_groups")
 }
 
 func (p *projectGroupsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/octopusdeploy_framework/framework_provider.go
+++ b/octopusdeploy_framework/framework_provider.go
@@ -21,7 +21,6 @@ type octopusDeployFrameworkProvider struct {
 var _ provider.Provider = (*octopusDeployFrameworkProvider)(nil)
 var _ provider.ProviderWithMetaSchema = (*octopusDeployFrameworkProvider)(nil)
 var _ provider.ProviderWithFunctions
-var ProviderTypeName = "octopusdeploy"
 
 func NewOctopusDeployFrameworkProvider() *octopusDeployFrameworkProvider {
 	return &octopusDeployFrameworkProvider{}
@@ -87,16 +86,14 @@ func (p *octopusDeployFrameworkProvider) Resources(ctx context.Context) []func()
 	}
 }
 
-func (p *octopusDeployFrameworkProvider) Schema(ctx context.Context, req provider.SchemaRequest, resp *provider.SchemaResponse) {
+func (p *octopusDeployFrameworkProvider) Schema(_ context.Context, req provider.SchemaRequest, resp *provider.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"address": schema.StringAttribute{
-				//Required:    true,
 				Optional:    true,
 				Description: "The endpoint of the Octopus REST API",
 			},
 			"api_key": schema.StringAttribute{
-				//Required:    true,
 				Optional:    true,
 				Description: "The API key to use with the Octopus REST API",
 			},

--- a/octopusdeploy_framework/resource_artifactory_generic_feed.go
+++ b/octopusdeploy_framework/resource_artifactory_generic_feed.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -23,7 +24,7 @@ func NewArtifactoryGenericFeedResource() resource.Resource {
 }
 
 func (r *artifactoryGenericFeedTypeResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = ProviderTypeName + "_artifactory_generic_feed"
+	resp.TypeName = util.GetTypeName("artifactory_generic_feed")
 }
 
 func (r *artifactoryGenericFeedTypeResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/octopusdeploy_framework/resource_aws_elastic_container_registry.go
+++ b/octopusdeploy_framework/resource_aws_elastic_container_registry.go
@@ -6,6 +6,7 @@ import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/feeds"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -22,7 +23,7 @@ func NewAwsElasticContainerRegistryFeedResource() resource.Resource {
 }
 
 func (r *awsElasticContainerRegistryFeedTypeResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = ProviderTypeName + "_aws_elastic_container_registry"
+	resp.TypeName = util.GetTypeName("aws_elastic_container_registry")
 }
 
 func (r *awsElasticContainerRegistryFeedTypeResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/octopusdeploy_framework/resource_environment.go
+++ b/octopusdeploy_framework/resource_environment.go
@@ -20,7 +20,7 @@ func NewEnvironmentResource() resource.Resource {
 }
 
 func (r *environmentTypeResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = ProviderTypeName + "_environment"
+	resp.TypeName = util.GetTypeName("environment")
 }
 
 func (r *environmentTypeResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/octopusdeploy_framework/resource_github_repository_feed.go
+++ b/octopusdeploy_framework/resource_github_repository_feed.go
@@ -6,6 +6,7 @@ import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/feeds"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -22,7 +23,7 @@ func NewGitHubRepositoryFeedResource() resource.Resource {
 }
 
 func (r *githubRepositoryFeedTypeResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = ProviderTypeName + "_github_repository_feed"
+	resp.TypeName = util.GetTypeName("github_repository_feed")
 }
 
 func (r *githubRepositoryFeedTypeResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/octopusdeploy_framework/resource_helm_feed.go
+++ b/octopusdeploy_framework/resource_helm_feed.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -23,7 +24,7 @@ func NewHelmFeedResource() resource.Resource {
 }
 
 func (r *helmFeedTypeResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = ProviderTypeName + "_helm_feed"
+	resp.TypeName = util.GetTypeName("helm_feed")
 }
 
 func (r *helmFeedTypeResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/octopusdeploy_framework/resource_maven_feed.go
+++ b/octopusdeploy_framework/resource_maven_feed.go
@@ -6,6 +6,7 @@ import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/feeds"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -22,7 +23,7 @@ func NewMavenFeedResource() resource.Resource {
 }
 
 func (r *mavenFeedTypeResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = ProviderTypeName + "_maven_feed"
+	resp.TypeName = util.GetTypeName("maven_feed")
 }
 
 func (r *mavenFeedTypeResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/octopusdeploy_framework/resource_nuget_feed.go
+++ b/octopusdeploy_framework/resource_nuget_feed.go
@@ -6,6 +6,7 @@ import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/feeds"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -22,7 +23,7 @@ func NewNugetFeedResource() resource.Resource {
 }
 
 func (r *nugetFeedTypeResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = ProviderTypeName + "_nuget_feed"
+	resp.TypeName = util.GetTypeName("nuget_feed")
 }
 
 func (r *nugetFeedTypeResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/octopusdeploy_framework/resource_project_group.go
+++ b/octopusdeploy_framework/resource_project_group.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projectgroups"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -20,7 +21,7 @@ func NewProjectGroupResource() resource.Resource {
 }
 
 func (r *projectGroupTypeResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = ProviderTypeName + "_project_group"
+	resp.TypeName = util.GetTypeName("project_group")
 }
 
 func (r *projectGroupTypeResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {


### PR DESCRIPTION
Also, some small cleanups of the type name in a few resources, preferring using a helper utility over custom formatting in each resource

before:
```
╷
│ Error: Failed to load plugin schemas
│ 
│ Error while loading schemas for plugin components: Failed to obtain provider schema: Could not load the schema for provider octopus.com/com/octopusdeploy: failed to retrieve schema from provider "octopus.com/com/octopusdeploy": Invalid Provider Server Combination: The combined provider has differing provider schema implementations across providers. Provider schemas must be identical across providers. This is always an issue in the provider
│ implementation and should be reported to the provider developers.
│ 
│ Provider schema difference:   &tfprotov6.Schema{
│       Version: 0,
│       Block: &tfprotov6.SchemaBlock{
│               Version: 0,
│               Attributes: []*tfprotov6.SchemaAttribute{
│                       &{
│                               ... // 2 identical fields
│                               NestedType:  nil,
│                               Description: "The endpoint of the Octopus REST API",
│ -                             Required:    true,
│ +                             Required:    false,
│ -                             Optional:    false,
│ +                             Optional:    true,
│                               Computed:    false,
│                               Sensitive:   false,
│                               ... // 2 identical fields
│                       },
│                       &{
│                               ... // 2 identical fields
│                               NestedType:  nil,
│                               Description: "The API key to use with the Octopus REST API",
│ -                             Required:    true,
│ +                             Required:    false,
│ -                             Optional:    false,
│ +                             Optional:    true,
│                               Computed:    false,
│                               Sensitive:   false,
│                               ... // 2 identical fields
│                       },
│                       &{Name: "space_id", Type: s"tftypes.String", Description: "The space ID to target", Optional: true, ...},
│               },
│               BlockTypes:  nil,
│               Description: "",
│               ... // 2 identical fields
│       },
│   }
│ ..
```

after: 
```
    ~/terraform/project/generic-feed  tp                                                                                                                                                                                                                                                                                                                                                                 ✔  Team Fire and Motion - Sandbox ﴃ  12:18:52  
octopusdeploy_space.space: Refreshing state... [id=Spaces-802]
octopusdeploy_artifactory_generic_feed.feed: Refreshing state... [id=Feeds-2163]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```