### PR TITLE
chore: ensure resources deleted from Octopus are removed from state

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200723130312-85980079f637
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
-	github.com/hashicorp/terraform-plugin-framework v1.9.0
+	github.com/hashicorp/terraform-plugin-framework v1.11.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
 	github.com/hashicorp/terraform-plugin-go v0.23.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -166,6 +166,8 @@ github.com/hashicorp/terraform-plugin-docs v0.13.0 h1:6e+VIWsVGb6jYJewfzq2ok2smP
 github.com/hashicorp/terraform-plugin-docs v0.13.0/go.mod h1:W0oCmHAjIlTHBbvtppWHe8fLfZ2BznQbuv8+UD8OucQ=
 github.com/hashicorp/terraform-plugin-framework v1.9.0 h1:caLcDoxiRucNi2hk8+j3kJwkKfvHznubyFsJMWfZqKU=
 github.com/hashicorp/terraform-plugin-framework v1.9.0/go.mod h1:qBXLDn69kM97NNVi/MQ9qgd1uWWsVftGSnygYG1tImM=
+github.com/hashicorp/terraform-plugin-framework v1.11.0 h1:M7+9zBArexHFXDx/pKTxjE6n/2UCXY6b8FIq9ZYhwfE=
+github.com/hashicorp/terraform-plugin-framework v1.11.0/go.mod h1:qBXLDn69kM97NNVi/MQ9qgd1uWWsVftGSnygYG1tImM=
 github.com/hashicorp/terraform-plugin-framework-validators v0.12.0 h1:HOjBuMbOEzl7snOdOoUfE2Jgeto6JOjLVQ39Ls2nksc=
 github.com/hashicorp/terraform-plugin-framework-validators v0.12.0/go.mod h1:jfHGE/gzjxYz6XoUwi/aYiiKrJDeutQNUtGQXkaHklg=
 github.com/hashicorp/terraform-plugin-go v0.23.0 h1:AALVuU1gD1kPb48aPQUjug9Ir/125t+AAurhqphJ2Co=

--- a/internal/errors/error.go
+++ b/internal/errors/error.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -28,4 +30,24 @@ func ProcessApiError(ctx context.Context, d *schema.ResourceData, err error, res
 	}
 
 	return diag.FromErr(err)
+}
+
+func DeleteFromStateV2(ctx context.Context, resp *resource.ReadResponse, resource schemas.IResourceModel, resourceDescription string) error {
+	log.Printf("[INFO] %s (%s) not found; deleting from state", resourceDescription, resource.GetID())
+	resp.State.RemoveResource(ctx)
+	return nil
+}
+
+func ProcessApiErrorV2(ctx context.Context, resp *resource.ReadResponse, resource schemas.IResourceModel, err error, resourceDescription string) error {
+	if err == nil {
+		return nil
+	}
+
+	if apiError, ok := err.(*core.APIError); ok {
+		if apiError.StatusCode == http.StatusNotFound {
+			return DeleteFromStateV2(ctx, resp, resource, resourceDescription)
+		}
+	}
+
+	return nil
 }

--- a/octopusdeploy_framework/resource_artifactory_generic_feed.go
+++ b/octopusdeploy_framework/resource_artifactory_generic_feed.go
@@ -3,7 +3,9 @@ package octopusdeploy_framework
 import (
 	"context"
 	"fmt"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/internal/errors"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -77,7 +79,9 @@ func (r *artifactoryGenericFeedTypeResource) Read(ctx context.Context, req resou
 	client := r.Config.Client
 	feed, err := feeds.GetByID(client, data.SpaceID.ValueString(), data.ID.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("unable to load artifactoryGeneric feed", err.Error())
+		if err := errors.ProcessApiErrorV2(ctx, resp, data, err, "artifactory generic feed"); err != nil {
+			resp.Diagnostics.AddError("unable to load artifactoryGeneric feed", err.Error())
+		}
 		return
 	}
 

--- a/octopusdeploy_framework/resource_aws_elastic_container_registry.go
+++ b/octopusdeploy_framework/resource_aws_elastic_container_registry.go
@@ -3,8 +3,10 @@ package octopusdeploy_framework
 import (
 	"context"
 	"fmt"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/feeds"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/internal/errors"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -78,7 +80,9 @@ func (r *awsElasticContainerRegistryFeedTypeResource) Read(ctx context.Context, 
 	client := r.Config.Client
 	feed, err := feeds.GetByID(client, data.SpaceID.ValueString(), data.ID.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("unable to load aws elastic container registry", err.Error())
+		if err := errors.ProcessApiErrorV2(ctx, resp, data, err, "aws elastic container registry"); err != nil {
+			resp.Diagnostics.AddError("unable to load aws elastic container registry", err.Error())
+		}
 		return
 	}
 

--- a/octopusdeploy_framework/resource_docker_container_registry.go
+++ b/octopusdeploy_framework/resource_docker_container_registry.go
@@ -3,8 +3,10 @@ package octopusdeploy_framework
 import (
 	"context"
 	"fmt"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/feeds"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/internal/errors"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -76,7 +78,9 @@ func (r *dockerContainerRegistryFeedTypeResource) Read(ctx context.Context, req 
 	client := r.Config.Client
 	feed, err := feeds.GetByID(client, data.SpaceID.ValueString(), data.ID.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("unable to load docker container registry feed", err.Error())
+		if err := errors.ProcessApiErrorV2(ctx, resp, data, err, "docker container registry feed"); err != nil {
+			resp.Diagnostics.AddError("unable to load docker container registry feed", err.Error())
+		}
 		return
 	}
 

--- a/octopusdeploy_framework/resource_environment.go
+++ b/octopusdeploy_framework/resource_environment.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/environments"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/extensions"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/internal/errors"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -82,7 +83,10 @@ func (r *environmentTypeResource) Read(ctx context.Context, req resource.ReadReq
 
 	environment, err := environments.GetByID(r.Config.Client, data.SpaceID.ValueString(), data.ID.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("unable to load environment", err.Error())
+		if err := errors.ProcessApiErrorV2(ctx, resp, data, err, "environment"); err != nil {
+			resp.Diagnostics.AddError("unable to load environment", err.Error())
+		}
+		return
 	}
 
 	updateEnvironment(ctx, &data, environment)

--- a/octopusdeploy_framework/resource_git_credential.go
+++ b/octopusdeploy_framework/resource_git_credential.go
@@ -2,8 +2,10 @@ package octopusdeploy_framework
 
 import (
 	"context"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/credentials"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/internal/errors"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -18,13 +20,14 @@ type gitCredentialResource struct {
 }
 
 type gitCredentialResourceModel struct {
-	ID          types.String `tfsdk:"id"`
 	SpaceID     types.String `tfsdk:"space_id"`
 	Name        types.String `tfsdk:"name"`
 	Description types.String `tfsdk:"description"`
 	Type        types.String `tfsdk:"type"`
 	Username    types.String `tfsdk:"username"`
 	Password    types.String `tfsdk:"password"`
+
+	schemas.ResourceModel
 }
 
 func NewGitCredentialResource() resource.Resource {
@@ -92,7 +95,9 @@ func (g *gitCredentialResource) Read(ctx context.Context, req resource.ReadReque
 
 	gitCredential, err := credentials.GetByID(g.Client, state.SpaceID.ValueString(), state.ID.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("Error reading Git credential", err.Error())
+		if err := errors.ProcessApiErrorV2(ctx, resp, state, err, "git credential"); err != nil {
+			resp.Diagnostics.AddError("Error reading Git credential", err.Error())
+		}
 		return
 	}
 

--- a/octopusdeploy_framework/resource_github_repository_feed.go
+++ b/octopusdeploy_framework/resource_github_repository_feed.go
@@ -3,8 +3,10 @@ package octopusdeploy_framework
 import (
 	"context"
 	"fmt"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/feeds"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/internal/errors"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -78,7 +80,9 @@ func (r *githubRepositoryFeedTypeResource) Read(ctx context.Context, req resourc
 	client := r.Config.Client
 	feed, err := feeds.GetByID(client, data.SpaceID.ValueString(), data.ID.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("unable to load github repository feed", err.Error())
+		if err := errors.ProcessApiErrorV2(ctx, resp, data, err, "github repository feed"); err != nil {
+			resp.Diagnostics.AddError("unable to load github repository feed", err.Error())
+		}
 		return
 	}
 

--- a/octopusdeploy_framework/resource_helm_feed.go
+++ b/octopusdeploy_framework/resource_helm_feed.go
@@ -3,7 +3,9 @@ package octopusdeploy_framework
 import (
 	"context"
 	"fmt"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/internal/errors"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -77,7 +79,9 @@ func (r *helmFeedTypeResource) Read(ctx context.Context, req resource.ReadReques
 	client := r.Config.Client
 	feed, err := feeds.GetByID(client, data.SpaceID.ValueString(), data.ID.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("unable to load helm feed", err.Error())
+		if err := errors.ProcessApiErrorV2(ctx, resp, data, err, "helm feed"); err != nil {
+			resp.Diagnostics.AddError("unable to load helm feed", err.Error())
+		}
 		return
 	}
 

--- a/octopusdeploy_framework/resource_library_variable_set.go
+++ b/octopusdeploy_framework/resource_library_variable_set.go
@@ -3,12 +3,14 @@ package octopusdeploy_framework
 import (
 	"context"
 	"fmt"
+	"log"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/libraryvariablesets"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/internal/errors"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"log"
 )
 
 type libraryVariableSetFeedTypeResource struct {
@@ -61,7 +63,9 @@ func (r *libraryVariableSetFeedTypeResource) Read(ctx context.Context, req resou
 
 	libraryVariableSet, err := libraryvariablesets.GetByID(r.Config.Client, data.SpaceID.ValueString(), data.ID.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("unable to load library variable set", err.Error())
+		if err := errors.ProcessApiErrorV2(ctx, resp, data, err, "library variable set"); err != nil {
+			resp.Diagnostics.AddError("unable to load library variable set", err.Error())
+		}
 		return
 	}
 

--- a/octopusdeploy_framework/resource_lifecycle_test.go
+++ b/octopusdeploy_framework/resource_lifecycle_test.go
@@ -2,6 +2,9 @@ package octopusdeploy_framework
 
 import (
 	"fmt"
+	"path/filepath"
+	"testing"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/lifecycles"
@@ -13,8 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/require"
-	"path/filepath"
-	"testing"
 )
 
 func TestExpandLifecycleWithNil(t *testing.T) {
@@ -31,7 +32,6 @@ func TestExpandLifecycle(t *testing.T) {
 	tentacleRetention := core.NewRetentionPeriod(2, "Items", false)
 
 	data := &lifecycleTypeResourceModel{
-		ID:          types.StringValue(Id),
 		Description: types.StringValue(description),
 		Name:        types.StringValue(name),
 		SpaceID:     types.StringValue(spaceID),
@@ -62,6 +62,7 @@ func TestExpandLifecycle(t *testing.T) {
 			},
 		),
 	}
+	data.ID = types.StringValue(Id)
 
 	lifecycle := expandLifecycle(data)
 

--- a/octopusdeploy_framework/resource_maven_feed.go
+++ b/octopusdeploy_framework/resource_maven_feed.go
@@ -3,8 +3,10 @@ package octopusdeploy_framework
 import (
 	"context"
 	"fmt"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/feeds"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/internal/errors"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -76,7 +78,9 @@ func (r *mavenFeedTypeResource) Read(ctx context.Context, req resource.ReadReque
 	client := r.Config.Client
 	feed, err := feeds.GetByID(client, data.SpaceID.ValueString(), data.ID.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("unable to load maven feed", err.Error())
+		if err := errors.ProcessApiErrorV2(ctx, resp, data, err, "maven feed"); err != nil {
+			resp.Diagnostics.AddError("unable to load maven feed", err.Error())
+		}
 		return
 	}
 

--- a/octopusdeploy_framework/resource_nuget_feed.go
+++ b/octopusdeploy_framework/resource_nuget_feed.go
@@ -3,8 +3,10 @@ package octopusdeploy_framework
 import (
 	"context"
 	"fmt"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/feeds"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/internal/errors"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -78,7 +80,9 @@ func (r *nugetFeedTypeResource) Read(ctx context.Context, req resource.ReadReque
 	client := r.Config.Client
 	feed, err := feeds.GetByID(client, data.SpaceID.ValueString(), data.ID.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("unable to load nuget feed", err.Error())
+		if err := errors.ProcessApiErrorV2(ctx, resp, data, err, "nuget feed"); err != nil {
+			resp.Diagnostics.AddError("unable to load nuget feed", err.Error())
+		}
 		return
 	}
 

--- a/octopusdeploy_framework/resource_project.go
+++ b/octopusdeploy_framework/resource_project.go
@@ -3,7 +3,9 @@ package octopusdeploy_framework
 import (
 	"context"
 	"fmt"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/internal/errors"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -92,7 +94,9 @@ func (r *projectResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 	project, err := projects.GetByID(r.Client, state.SpaceID.ValueString(), state.ID.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("Error reading project", err.Error())
+		if err := errors.ProcessApiErrorV2(ctx, resp, state, err, "lifecycle"); err != nil {
+			resp.Diagnostics.AddError("Error reading project", err.Error())
+		}
 		return
 	}
 	if persistenceSettings != nil {

--- a/octopusdeploy_framework/resource_project_flatten.go
+++ b/octopusdeploy_framework/resource_project_flatten.go
@@ -3,6 +3,7 @@ package octopusdeploy_framework
 import (
 	"context"
 	"fmt"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/actiontemplates"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/credentials"
@@ -26,7 +27,6 @@ func flattenProject(ctx context.Context, project *projects.Project, state *proje
 	}
 
 	model := &projectResourceModel{
-		ID:                              types.StringValue(project.GetID()),
 		SpaceID:                         types.StringValue(project.SpaceID),
 		Name:                            types.StringValue(project.Name),
 		Description:                     types.StringValue(project.Description),
@@ -47,6 +47,8 @@ func flattenProject(ctx context.Context, project *projects.Project, state *proje
 		Slug:                            types.StringValue(project.Slug),
 		ClonedFromProjectID:             util.StringOrNull(project.ClonedFromProjectID),
 	}
+
+	model.ID = types.StringValue(project.GetID())
 
 	model.IncludedLibraryVariableSets = util.FlattenStringList(project.IncludedLibraryVariableSets)
 	model.AutoDeployReleaseOverrides = flattenAutoDeployReleaseOverrides(project.AutoDeployReleaseOverrides)

--- a/octopusdeploy_framework/resource_project_group.go
+++ b/octopusdeploy_framework/resource_project_group.go
@@ -3,7 +3,9 @@ package octopusdeploy_framework
 import (
 	"context"
 	"fmt"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projectgroups"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/internal/errors"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -67,7 +69,9 @@ func (r *projectGroupTypeResource) Read(ctx context.Context, req resource.ReadRe
 
 	group, err := projectgroups.GetByID(r.Config.Client, data.SpaceID.ValueString(), data.ID.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("unable to load project group", err.Error())
+		if err := errors.ProcessApiErrorV2(ctx, resp, data, err, "project group"); err != nil {
+			resp.Diagnostics.AddError("unable to load project group", err.Error())
+		}
 		return
 	}
 

--- a/octopusdeploy_framework/resource_project_model.go
+++ b/octopusdeploy_framework/resource_project_model.go
@@ -1,11 +1,11 @@
 package octopusdeploy_framework
 
 import (
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type projectResourceModel struct {
-	ID                                     types.String `tfsdk:"id"`
 	SpaceID                                types.String `tfsdk:"space_id"`
 	Name                                   types.String `tfsdk:"name"`
 	Description                            types.String `tfsdk:"description"`
@@ -37,6 +37,8 @@ type projectResourceModel struct {
 	ServiceNowExtensionSettings            types.List   `tfsdk:"servicenow_extension_settings"`
 	IncludedLibraryVariableSets            types.List   `tfsdk:"included_library_variable_sets"`
 	AutoDeployReleaseOverrides             types.List   `tfsdk:"auto_deploy_release_overrides"`
+
+	schemas.ResourceModel
 }
 
 type connectivityPolicyModel struct {

--- a/octopusdeploy_framework/resource_space.go
+++ b/octopusdeploy_framework/resource_space.go
@@ -3,7 +3,10 @@ package octopusdeploy_framework
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/spaces"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/internal/errors"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -11,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"strings"
 )
 
 const spaceManagersTeamIDPrefix = "teams-spacemanagers-"
@@ -129,7 +131,9 @@ func (s *spaceResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	spaceResult, err := spaces.GetByID(s.Client, data.ID.ValueString())
 
 	if err != nil {
-		resp.Diagnostics.AddError("unable to query spaces", err.Error())
+		if err := errors.ProcessApiErrorV2(ctx, resp, data, err, "space"); err != nil {
+			resp.Diagnostics.AddError("unable to query spaces", err.Error())
+		}
 		return
 	}
 

--- a/octopusdeploy_framework/resource_tenant_common_variable.go
+++ b/octopusdeploy_framework/resource_tenant_common_variable.go
@@ -24,12 +24,13 @@ type tenantCommonVariableResource struct {
 }
 
 type tenantCommonVariableResourceModel struct {
-	ID                   types.String `tfsdk:"id"`
 	SpaceID              types.String `tfsdk:"space_id"`
 	TenantID             types.String `tfsdk:"tenant_id"`
 	LibraryVariableSetID types.String `tfsdk:"library_variable_set_id"`
 	TemplateID           types.String `tfsdk:"template_id"`
 	Value                types.String `tfsdk:"value"`
+
+	schemas.ResourceModel
 }
 
 func NewTenantCommonVariableResource() resource.Resource {

--- a/octopusdeploy_framework/resource_tenant_project.go
+++ b/octopusdeploy_framework/resource_tenant_project.go
@@ -21,11 +21,12 @@ import (
 )
 
 type TenantProjectModel struct {
-	ID             types.String `tfsdk:"id"`
 	SpaceID        types.String `tfsdk:"space_id"`
 	TenantID       types.String `tfsdk:"tenant_id"`
 	ProjectID      types.String `tfsdk:"project_id"`
 	EnvironmentIDs types.List   `tfsdk:"environment_ids"`
+
+	schemas.ResourceModel
 }
 
 type tenantProjectResource struct {

--- a/octopusdeploy_framework/resource_tenant_project_variable.go
+++ b/octopusdeploy_framework/resource_tenant_project_variable.go
@@ -3,6 +3,8 @@ package octopusdeploy_framework
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/tenants"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/variables"
@@ -12,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"strings"
 )
 
 var _ resource.Resource = &tenantProjectVariableResource{}
@@ -23,13 +24,14 @@ type tenantProjectVariableResource struct {
 }
 
 type tenantProjectVariableResourceModel struct {
-	ID            types.String `tfsdk:"id"`
 	SpaceID       types.String `tfsdk:"space_id"`
 	TenantID      types.String `tfsdk:"tenant_id"`
 	ProjectID     types.String `tfsdk:"project_id"`
 	EnvironmentID types.String `tfsdk:"environment_id"`
 	TemplateID    types.String `tfsdk:"template_id"`
 	Value         types.String `tfsdk:"value"`
+
+	schemas.ResourceModel
 }
 
 func NewTenantProjectVariableResource() resource.Resource {

--- a/octopusdeploy_framework/resource_variable.go
+++ b/octopusdeploy_framework/resource_variable.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/variables"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/internal"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/internal/errors"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -125,7 +126,9 @@ func (r *variableTypeResource) Read(ctx context.Context, req resource.ReadReques
 
 	variable, err := variables.GetByID(r.Config.Client, data.SpaceID.ValueString(), variableOwnerID.ValueString(), data.ID.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("unable to load variable", err.Error())
+		if err := errors.ProcessApiErrorV2(ctx, resp, data, err, schemas.VariableResourceDescription); err != nil {
+			resp.Diagnostics.AddError("unable to load variable", err.Error())
+		}
 		return
 	}
 

--- a/octopusdeploy_framework/schemas/artifactory_generic_feed.go
+++ b/octopusdeploy_framework/schemas/artifactory_generic_feed.go
@@ -32,7 +32,7 @@ func GetArtifactoryGenericFeedResourceSchema() map[string]resourceSchema.Attribu
 }
 
 type ArtifactoryGenericFeedTypeResourceModel struct {
-	ResourceModel
+	*ResourceModel
 	FeedUri                           types.String `tfsdk:"feed_uri"`
 	Name                              types.String `tfsdk:"name"`
 	PackageAcquisitionLocationOptions types.List   `tfsdk:"package_acquisition_location_options"`

--- a/octopusdeploy_framework/schemas/artifactory_generic_feed.go
+++ b/octopusdeploy_framework/schemas/artifactory_generic_feed.go
@@ -32,8 +32,8 @@ func GetArtifactoryGenericFeedResourceSchema() map[string]resourceSchema.Attribu
 }
 
 type ArtifactoryGenericFeedTypeResourceModel struct {
+	ResourceModel
 	FeedUri                           types.String `tfsdk:"feed_uri"`
-	ID                                types.String `tfsdk:"id"`
 	Name                              types.String `tfsdk:"name"`
 	PackageAcquisitionLocationOptions types.List   `tfsdk:"package_acquisition_location_options"`
 	Password                          types.String `tfsdk:"password"`

--- a/octopusdeploy_framework/schemas/artifactory_generic_feed.go
+++ b/octopusdeploy_framework/schemas/artifactory_generic_feed.go
@@ -32,7 +32,6 @@ func GetArtifactoryGenericFeedResourceSchema() map[string]resourceSchema.Attribu
 }
 
 type ArtifactoryGenericFeedTypeResourceModel struct {
-	ResourceModel
 	FeedUri                           types.String `tfsdk:"feed_uri"`
 	Name                              types.String `tfsdk:"name"`
 	PackageAcquisitionLocationOptions types.List   `tfsdk:"package_acquisition_location_options"`
@@ -41,4 +40,6 @@ type ArtifactoryGenericFeedTypeResourceModel struct {
 	Username                          types.String `tfsdk:"username"`
 	Repository                        types.String `tfsdk:"repository"`
 	LayoutRegex                       types.String `tfsdk:"layout_regex"`
+
+	ResourceModel
 }

--- a/octopusdeploy_framework/schemas/artifactory_generic_feed.go
+++ b/octopusdeploy_framework/schemas/artifactory_generic_feed.go
@@ -32,7 +32,7 @@ func GetArtifactoryGenericFeedResourceSchema() map[string]resourceSchema.Attribu
 }
 
 type ArtifactoryGenericFeedTypeResourceModel struct {
-	*ResourceModel
+	ResourceModel
 	FeedUri                           types.String `tfsdk:"feed_uri"`
 	Name                              types.String `tfsdk:"name"`
 	PackageAcquisitionLocationOptions types.List   `tfsdk:"package_acquisition_location_options"`

--- a/octopusdeploy_framework/schemas/aws_elastic_container_registry.go
+++ b/octopusdeploy_framework/schemas/aws_elastic_container_registry.go
@@ -32,10 +32,11 @@ func GetAwsElasticContainerRegistryFeedResourceSchema() map[string]resourceSchem
 
 type AwsElasticContainerRegistryFeedTypeResourceModel struct {
 	AccessKey                         types.String `tfsdk:"access_key"`
-	ID                                types.String `tfsdk:"id"`
 	Name                              types.String `tfsdk:"name"`
 	PackageAcquisitionLocationOptions types.List   `tfsdk:"package_acquisition_location_options"`
 	Region                            types.String `tfsdk:"region"`
 	SecretKey                         types.String `tfsdk:"secret_key"`
 	SpaceID                           types.String `tfsdk:"space_id"`
+
+	ResourceModel
 }

--- a/octopusdeploy_framework/schemas/docker_container_registry_feed.go
+++ b/octopusdeploy_framework/schemas/docker_container_registry_feed.go
@@ -29,11 +29,12 @@ func GetDockerContainerRegistryFeedResourceSchema() map[string]resourceSchema.At
 type DockerContainerRegistryFeedTypeResourceModel struct {
 	APIVersion                        types.String `tfsdk:"api_version"`
 	FeedUri                           types.String `tfsdk:"feed_uri"`
-	ID                                types.String `tfsdk:"id"`
 	Name                              types.String `tfsdk:"name"`
 	PackageAcquisitionLocationOptions types.List   `tfsdk:"package_acquisition_location_options"`
 	Password                          types.String `tfsdk:"password"`
 	SpaceID                           types.String `tfsdk:"space_id"`
 	Username                          types.String `tfsdk:"username"`
 	RegistryPath                      types.String `tfsdk:"registry_path"`
+
+	ResourceModel
 }

--- a/octopusdeploy_framework/schemas/environment.go
+++ b/octopusdeploy_framework/schemas/environment.go
@@ -180,7 +180,6 @@ func MapServiceNowExtensionSettings(serviceNowExtensionSettings *environments.Se
 }
 
 type EnvironmentTypeResourceModel struct {
-	ID                                     types.String `tfsdk:"id"`
 	Slug                                   types.String `tfsdk:"slug"`
 	Name                                   types.String `tfsdk:"name"`
 	Description                            types.String `tfsdk:"description"`
@@ -191,4 +190,6 @@ type EnvironmentTypeResourceModel struct {
 	JiraExtensionSettings                  types.List   `tfsdk:"jira_extension_settings"`
 	JiraServiceManagementExtensionSettings types.List   `tfsdk:"jira_service_management_extension_settings"`
 	ServiceNowExtensionSettings            types.List   `tfsdk:"servicenow_extension_settings"`
+
+	ResourceModel
 }

--- a/octopusdeploy_framework/schemas/github_repository_feed.go
+++ b/octopusdeploy_framework/schemas/github_repository_feed.go
@@ -26,10 +26,11 @@ type GitHubRepositoryFeedTypeResourceModel struct {
 	DownloadAttempts                  types.Int64  `tfsdk:"download_attempts"`
 	DownloadRetryBackoffSeconds       types.Int64  `tfsdk:"download_retry_backoff_seconds"`
 	FeedUri                           types.String `tfsdk:"feed_uri"`
-	ID                                types.String `tfsdk:"id"`
 	Name                              types.String `tfsdk:"name"`
 	PackageAcquisitionLocationOptions types.List   `tfsdk:"package_acquisition_location_options"`
 	Password                          types.String `tfsdk:"password"`
 	SpaceID                           types.String `tfsdk:"space_id"`
 	Username                          types.String `tfsdk:"username"`
+
+	ResourceModel
 }

--- a/octopusdeploy_framework/schemas/helm_feed.go
+++ b/octopusdeploy_framework/schemas/helm_feed.go
@@ -22,10 +22,11 @@ func GetHelmFeedResourceSchema() map[string]resourceSchema.Attribute {
 
 type HelmFeedTypeResourceModel struct {
 	FeedUri                           types.String `tfsdk:"feed_uri"`
-	ID                                types.String `tfsdk:"id"`
 	Name                              types.String `tfsdk:"name"`
 	PackageAcquisitionLocationOptions types.List   `tfsdk:"package_acquisition_location_options"`
 	Password                          types.String `tfsdk:"password"`
 	SpaceID                           types.String `tfsdk:"space_id"`
 	Username                          types.String `tfsdk:"username"`
+
+	ResourceModel
 }

--- a/octopusdeploy_framework/schemas/library_variable_set.go
+++ b/octopusdeploy_framework/schemas/library_variable_set.go
@@ -12,12 +12,13 @@ import (
 
 type LibraryVariableSetResourceModel struct {
 	Description   types.String `tfsdk:"description"`
-	ID            types.String `tfsdk:"id"`
 	Name          types.String `tfsdk:"name"`
 	SpaceID       types.String `tfsdk:"space_id"`
 	Template      types.List   `tfsdk:"template"`
 	TemplateIds   types.Map    `tfsdk:"template_ids"`
 	VariableSetId types.String `tfsdk:"variable_set_id"`
+
+	ResourceModel
 }
 
 func GetLibraryVariableSetDataSourceSchema() datasourceSchema.Schema {

--- a/octopusdeploy_framework/schemas/maven_feed.go
+++ b/octopusdeploy_framework/schemas/maven_feed.go
@@ -26,10 +26,11 @@ type MavenFeedTypeResourceModel struct {
 	DownloadAttempts                  types.Int64  `tfsdk:"download_attempts"`
 	DownloadRetryBackoffSeconds       types.Int64  `tfsdk:"download_retry_backoff_seconds"`
 	FeedUri                           types.String `tfsdk:"feed_uri"`
-	ID                                types.String `tfsdk:"id"`
 	Name                              types.String `tfsdk:"name"`
 	PackageAcquisitionLocationOptions types.List   `tfsdk:"package_acquisition_location_options"`
 	Password                          types.String `tfsdk:"password"`
 	SpaceID                           types.String `tfsdk:"space_id"`
 	Username                          types.String `tfsdk:"username"`
+
+	ResourceModel
 }

--- a/octopusdeploy_framework/schemas/nuget_feed.go
+++ b/octopusdeploy_framework/schemas/nuget_feed.go
@@ -33,11 +33,12 @@ type NugetFeedTypeResourceModel struct {
 	DownloadAttempts                  types.Int64  `tfsdk:"download_attempts"`
 	DownloadRetryBackoffSeconds       types.Int64  `tfsdk:"download_retry_backoff_seconds"`
 	FeedUri                           types.String `tfsdk:"feed_uri"`
-	ID                                types.String `tfsdk:"id"`
 	IsEnhancedMode                    types.Bool   `tfsdk:"is_enhanced_mode"`
 	Name                              types.String `tfsdk:"name"`
 	PackageAcquisitionLocationOptions types.List   `tfsdk:"package_acquisition_location_options"`
 	Password                          types.String `tfsdk:"password"`
 	SpaceID                           types.String `tfsdk:"space_id"`
 	Username                          types.String `tfsdk:"username"`
+
+	ResourceModel
 }

--- a/octopusdeploy_framework/schemas/project_group.go
+++ b/octopusdeploy_framework/schemas/project_group.go
@@ -43,9 +43,10 @@ func GetProjectGroupResourceSchema() map[string]resourceSchema.Attribute {
 }
 
 type ProjectGroupTypeResourceModel struct {
-	ID                types.String `tfsdk:"id"`
 	Name              types.String `tfsdk:"name"`
 	SpaceID           types.String `tfsdk:"space_id"`
 	Description       types.String `tfsdk:"description"`
 	RetentionPolicyID types.String `tfsdk:"retention_policy_id"`
+
+	ResourceModel
 }

--- a/octopusdeploy_framework/schemas/resource.go
+++ b/octopusdeploy_framework/schemas/resource.go
@@ -11,7 +11,7 @@ type IResourceModel interface {
 type ResourceModel struct {
 	ID types.String `tfsdk:"id"`
 
-	IResourceModel `tfsdk:"-"`
+	IResourceModel `tfsdk:"-"` // Ignore resource model interface in object conversion
 }
 
 func (r ResourceModel) GetID() string {

--- a/octopusdeploy_framework/schemas/resource.go
+++ b/octopusdeploy_framework/schemas/resource.go
@@ -9,8 +9,9 @@ type IResourceModel interface {
 }
 
 type ResourceModel struct {
-	IResourceModel
 	ID types.String `tfsdk:"id"`
+
+	IResourceModel `tfsdk:"-"`
 }
 
 func (r ResourceModel) GetID() string {

--- a/octopusdeploy_framework/schemas/resource.go
+++ b/octopusdeploy_framework/schemas/resource.go
@@ -1,0 +1,18 @@
+package schemas
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type IResourceModel interface {
+	GetID() string
+}
+
+type ResourceModel struct {
+	IResourceModel
+	ID types.String `tfsdk:"id"`
+}
+
+func (r ResourceModel) GetID() string {
+	return r.ID.ValueString()
+}

--- a/octopusdeploy_framework/schemas/space.go
+++ b/octopusdeploy_framework/schemas/space.go
@@ -11,7 +11,6 @@ import (
 const spaceDescription = "space"
 
 type SpaceModel struct {
-	ID                       types.String `tfsdk:"id"`
 	Name                     types.String `tfsdk:"name"`
 	Slug                     types.String `tfsdk:"slug"`
 	Description              types.String `tfsdk:"description"`
@@ -19,6 +18,8 @@ type SpaceModel struct {
 	SpaceManagersTeams       types.Set    `tfsdk:"space_managers_teams"`
 	SpaceManagersTeamMembers types.Set    `tfsdk:"space_managers_team_members"`
 	IsTaskQueueStopped       types.Bool   `tfsdk:"is_task_queue_stopped"`
+
+	ResourceModel
 }
 
 func GetSpaceResourceSchema() map[string]resourceSchema.Attribute {

--- a/octopusdeploy_framework/schemas/variable.go
+++ b/octopusdeploy_framework/schemas/variable.go
@@ -218,7 +218,6 @@ func GetVariableResourceSchema() resourceSchema.Schema {
 }
 
 type VariableTypeResourceModel struct {
-	ResourceModel
 	Name           types.String `tfsdk:"name"`
 	Description    types.String `tfsdk:"description"`
 	OwnerID        types.String `tfsdk:"owner_id"`
@@ -234,10 +233,11 @@ type VariableTypeResourceModel struct {
 	Prompt         types.List   `tfsdk:"prompt"`
 	Scope          types.List   `tfsdk:"scope"`
 	SpaceID        types.String `tfsdk:"space_id"`
+
+	ResourceModel
 }
 
 type VariablesDataSourceModel struct {
-	ResourceModel
 	OwnerID        types.String `tfsdk:"owner_id"`
 	Name           types.String `tfsdk:"name"`
 	Scope          types.List   `tfsdk:"scope"`
@@ -249,4 +249,6 @@ type VariablesDataSourceModel struct {
 	SensitiveValue types.String `tfsdk:"sensitive_value"`
 	Type           types.String `tfsdk:"type"`
 	Value          types.String `tfsdk:"value"`
+
+	ResourceModel
 }

--- a/octopusdeploy_framework/schemas/variable.go
+++ b/octopusdeploy_framework/schemas/variable.go
@@ -218,7 +218,7 @@ func GetVariableResourceSchema() resourceSchema.Schema {
 }
 
 type VariableTypeResourceModel struct {
-	*ResourceModel
+	ResourceModel
 	Name           types.String `tfsdk:"name"`
 	Description    types.String `tfsdk:"description"`
 	OwnerID        types.String `tfsdk:"owner_id"`
@@ -237,7 +237,7 @@ type VariableTypeResourceModel struct {
 }
 
 type VariablesDataSourceModel struct {
-	*ResourceModel
+	ResourceModel
 	OwnerID        types.String `tfsdk:"owner_id"`
 	Name           types.String `tfsdk:"name"`
 	Scope          types.List   `tfsdk:"scope"`

--- a/octopusdeploy_framework/schemas/variable.go
+++ b/octopusdeploy_framework/schemas/variable.go
@@ -218,7 +218,7 @@ func GetVariableResourceSchema() resourceSchema.Schema {
 }
 
 type VariableTypeResourceModel struct {
-	ID             types.String `tfsdk:"id"`
+	ResourceModel
 	Name           types.String `tfsdk:"name"`
 	Description    types.String `tfsdk:"description"`
 	OwnerID        types.String `tfsdk:"owner_id"`
@@ -237,12 +237,12 @@ type VariableTypeResourceModel struct {
 }
 
 type VariablesDataSourceModel struct {
+	ResourceModel
 	OwnerID        types.String `tfsdk:"owner_id"`
 	Name           types.String `tfsdk:"name"`
 	Scope          types.List   `tfsdk:"scope"`
 	SpaceID        types.String `tfsdk:"space_id"`
 	Description    types.String `tfsdk:"description"`
-	ID             types.String `tfsdk:"id"`
 	IsEditable     types.Bool   `tfsdk:"is_editable"`
 	IsSensitive    types.Bool   `tfsdk:"is_sensitive"`
 	Prompt         types.List   `tfsdk:"prompt"`

--- a/octopusdeploy_framework/schemas/variable.go
+++ b/octopusdeploy_framework/schemas/variable.go
@@ -218,7 +218,7 @@ func GetVariableResourceSchema() resourceSchema.Schema {
 }
 
 type VariableTypeResourceModel struct {
-	ResourceModel
+	*ResourceModel
 	Name           types.String `tfsdk:"name"`
 	Description    types.String `tfsdk:"description"`
 	OwnerID        types.String `tfsdk:"owner_id"`
@@ -237,7 +237,7 @@ type VariableTypeResourceModel struct {
 }
 
 type VariablesDataSourceModel struct {
-	ResourceModel
+	*ResourceModel
 	OwnerID        types.String `tfsdk:"owner_id"`
 	Name           types.String `tfsdk:"name"`
 	Scope          types.List   `tfsdk:"scope"`


### PR DESCRIPTION
The old SDKv2 resources would remove a resource from state if Octopus returned a 404, this was removed in the migration so this PR adds this functionality back.