### PR TITLE
chore: when specifying name in datasource we should only return exact match

### DIFF
--- a/octopusdeploy_framework/datasource_environments.go
+++ b/octopusdeploy_framework/datasource_environments.go
@@ -84,7 +84,9 @@ func (e *environmentDataSource) Read(ctx context.Context, req datasource.ReadReq
 		Take:        util.GetNumber(data.Take),
 	}
 
-	existingEnvironments, err := environments.Get(e.Client, e.Client.GetSpaceID(), query)
+	spaceID := util.Ternary(data.SpaceID.IsNull(), e.Client.GetSpaceID(), data.SpaceID.ValueString())
+
+	existingEnvironments, err := environments.Get(e.Client, spaceID, query)
 	if err != nil {
 		resp.Diagnostics.AddError("unable to load environments", err.Error())
 		return

--- a/octopusdeploy_framework/datasource_environments.go
+++ b/octopusdeploy_framework/datasource_environments.go
@@ -84,7 +84,7 @@ func (e *environmentDataSource) Read(ctx context.Context, req datasource.ReadReq
 		Take:        util.GetNumber(data.Take),
 	}
 
-	existingEnvironments, err := environments.Get(e.Client, data.SpaceID.ValueString(), query)
+	existingEnvironments, err := environments.Get(e.Client, e.Client.GetSpaceID(), query)
 	if err != nil {
 		resp.Diagnostics.AddError("unable to load environments", err.Error())
 		return
@@ -104,7 +104,9 @@ func (e *environmentDataSource) Read(ctx context.Context, req datasource.ReadReq
 				matchedEnvironment = env
 			}
 		}
-		mappedEnvironments = append(mappedEnvironments, schemas.MapFromEnvironment(ctx, matchedEnvironment))
+		if matchedEnvironment != nil {
+			mappedEnvironments = append(mappedEnvironments, schemas.MapFromEnvironment(ctx, matchedEnvironment))
+		}
 	}
 
 	data.Environments, _ = types.ListValueFrom(ctx, types.ObjectType{AttrTypes: schemas.EnvironmentObjectType()}, mappedEnvironments)

--- a/octopusdeploy_framework/datasource_environments.go
+++ b/octopusdeploy_framework/datasource_environments.go
@@ -3,13 +3,12 @@ package octopusdeploy_framework
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/environments"
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/extensions"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -90,78 +89,26 @@ func (e *environmentDataSource) Read(ctx context.Context, req datasource.ReadReq
 		resp.Diagnostics.AddError("unable to load environments", err.Error())
 		return
 	}
-	tflog.Debug(ctx, fmt.Sprintf("environments returned from API: %#v", existingEnvironments))
-	var mappedEnvironments []schemas.EnvironmentTypeResourceModel
-	for _, environment := range existingEnvironments.Items {
-		var env schemas.EnvironmentTypeResourceModel
-		env.ID = types.StringValue(environment.ID)
-		env.SpaceID = types.StringValue(environment.SpaceID)
-		env.Slug = types.StringValue(environment.Slug)
-		env.Name = types.StringValue(environment.Name)
-		env.Description = types.StringValue(environment.Description)
-		env.AllowDynamicInfrastructure = types.BoolValue(environment.AllowDynamicInfrastructure)
-		env.SortOrder = types.Int64Value(int64(environment.SortOrder))
-		env.UseGuidedFailure = types.BoolValue(environment.UseGuidedFailure)
-		env.JiraExtensionSettings, _ = types.ListValueFrom(ctx, types.ObjectType{AttrTypes: schemas.JiraExtensionSettingsObjectType()}, []any{})
-		env.JiraServiceManagementExtensionSettings, _ = types.ListValueFrom(ctx, types.ObjectType{AttrTypes: schemas.JiraServiceManagementExtensionSettingsObjectType()}, []any{})
-		env.ServiceNowExtensionSettings, _ = types.ListValueFrom(ctx, types.ObjectType{AttrTypes: schemas.ServiceNowExtensionSettingsObjectType()}, []any{})
 
-		for _, extensionSetting := range environment.ExtensionSettings {
-			switch extensionSetting.ExtensionID() {
-			case extensions.JiraExtensionID:
-				if jiraExtension, ok := extensionSetting.(*environments.JiraExtensionSettings); ok {
-					env.JiraExtensionSettings, _ = types.ListValueFrom(
-						ctx,
-						types.ObjectType{AttrTypes: schemas.JiraExtensionSettingsObjectType()},
-						[]any{schemas.MapJiraExtensionSettings(jiraExtension)},
-					)
-				}
-			case extensions.JiraServiceManagementExtensionID:
-				if jiraServiceManagementExtensionSettings, ok := extensionSetting.(*environments.JiraServiceManagementExtensionSettings); ok {
-					env.JiraServiceManagementExtensionSettings, _ = types.ListValueFrom(
-						ctx,
-						types.ObjectType{AttrTypes: schemas.JiraServiceManagementExtensionSettingsObjectType()},
-						[]any{schemas.MapJiraServiceManagementExtensionSettings(jiraServiceManagementExtensionSettings)},
-					)
-				}
-			case extensions.ServiceNowExtensionID:
-				if serviceNowExtensionSettings, ok := extensionSetting.(*environments.ServiceNowExtensionSettings); ok {
-					env.ServiceNowExtensionSettings, _ = types.ListValueFrom(
-						ctx,
-						types.ObjectType{AttrTypes: schemas.ServiceNowExtensionSettingsObjectType()},
-						[]any{schemas.MapServiceNowExtensionSettings(serviceNowExtensionSettings)},
-					)
-				}
+	var mappedEnvironments []schemas.EnvironmentTypeResourceModel
+	if data.Name.IsNull() {
+		tflog.Debug(ctx, fmt.Sprintf("environments returned from API: %#v", existingEnvironments))
+		for _, environment := range existingEnvironments.Items {
+			mappedEnvironments = append(mappedEnvironments, schemas.MapFromEnvironment(ctx, environment))
+		}
+	} else { // if name has been specified, match by exact name rather than partial name as the API does
+		var matchedEnvironment *environments.Environment
+		tflog.Debug(ctx, fmt.Sprintf("matching environment by name: %s", data.Name))
+		for _, env := range existingEnvironments.Items {
+			if strings.EqualFold(env.Name, data.Name.ValueString()) {
+				matchedEnvironment = env
 			}
 		}
-
-		mappedEnvironments = append(mappedEnvironments, env)
+		mappedEnvironments = append(mappedEnvironments, schemas.MapFromEnvironment(ctx, matchedEnvironment))
 	}
 
-	data.Environments, _ = types.ListValueFrom(ctx, types.ObjectType{AttrTypes: environmentObjectType()}, mappedEnvironments)
+	data.Environments, _ = types.ListValueFrom(ctx, types.ObjectType{AttrTypes: schemas.EnvironmentObjectType()}, mappedEnvironments)
 	data.ID = types.StringValue("Environments " + time.Now().UTC().String())
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-}
-
-func environmentObjectType() map[string]attr.Type {
-	return map[string]attr.Type{
-		"id":          types.StringType,
-		"name":        types.StringType,
-		"slug":        types.StringType,
-		"description": types.StringType,
-		schemas.EnvironmentAllowDynamicInfrastructure: types.BoolType,
-		schemas.EnvironmentSortOrder:                  types.Int64Type,
-		schemas.EnvironmentUseGuidedFailure:           types.BoolType,
-		"space_id":                                    types.StringType,
-		schemas.EnvironmentJiraExtensionSettings: types.ListType{
-			ElemType: types.ObjectType{AttrTypes: schemas.JiraExtensionSettingsObjectType()},
-		},
-		schemas.EnvironmentJiraServiceManagementExtensionSettings: types.ListType{
-			ElemType: types.ObjectType{AttrTypes: schemas.JiraServiceManagementExtensionSettingsObjectType()},
-		},
-		schemas.EnvironmentServiceNowExtensionSettings: types.ListType{
-			ElemType: types.ObjectType{AttrTypes: schemas.ServiceNowExtensionSettingsObjectType()},
-		},
-	}
 }

--- a/octopusdeploy_framework/datasource_environments_test.go
+++ b/octopusdeploy_framework/datasource_environments_test.go
@@ -32,8 +32,10 @@ func TestAccDataSourceEnvironments(t *testing.T) {
 			{
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEnvironmentsDataSourceID(prefix),
+					resource.TestCheckResourceAttr(prefix, "name", localName),
 					resource.TestCheckResourceAttr(prefix, "environments.#", "1"),
-					resource.TestCheckResourceAttr(prefix, "environments.0.Name", localName),
+					resource.TestCheckResourceAttrSet(prefix, "environments.0.id"),
+					resource.TestCheckResourceAttr(prefix, "environments.0.name", localName),
 				),
 				Config: testAccDataSourceEnvironmentByNameConfig(localName),
 			},

--- a/octopusdeploy_framework/datasource_environments_test.go
+++ b/octopusdeploy_framework/datasource_environments_test.go
@@ -13,7 +13,10 @@ import (
 func TestAccDataSourceEnvironments(t *testing.T) {
 	localName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
 	prefix := fmt.Sprintf("data.octopusdeploy_environments.%s", localName)
-	name := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+
+	environmentLocalName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	environmentName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+
 	take := 10
 
 	resource.Test(t, resource.TestCase{
@@ -34,23 +37,23 @@ func TestAccDataSourceEnvironments(t *testing.T) {
 				Config: fmt.Sprintf(`%s
 
 %s`,
-					createTestAccDataSourceEnvironmentsConfig(localName, name),
+					createTestAccDataSourceEnvironmentsConfig(environmentLocalName, environmentName),
 					testAccDataSourceEnvironmentsConfig(localName, take),
 				),
 			},
 			{
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEnvironmentsDataSourceID(prefix),
-					resource.TestCheckResourceAttr(prefix, "name", name),
+					resource.TestCheckResourceAttr(prefix, "name", environmentName),
 					resource.TestCheckResourceAttr(prefix, "environments.#", "1"),
 					resource.TestCheckResourceAttrSet(prefix, "environments.0.id"),
-					resource.TestCheckResourceAttr(prefix, "environments.0.name", name),
+					resource.TestCheckResourceAttr(prefix, "environments.0.name", environmentName),
 				),
 				Config: fmt.Sprintf(`%s
 
 %s`,
-					createTestAccDataSourceEnvironmentsConfig(localName, name),
-					testAccDataSourceEnvironmentByNameConfig(localName, name),
+					createTestAccDataSourceEnvironmentsConfig(environmentLocalName, environmentName),
+					testAccDataSourceEnvironmentByNameConfig(localName, environmentName),
 				),
 			},
 		},

--- a/octopusdeploy_framework/datasource_environments_test.go
+++ b/octopusdeploy_framework/datasource_environments_test.go
@@ -20,19 +20,6 @@ func TestAccDataSourceEnvironments(t *testing.T) {
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: createTestAccDataSourceEnvironmentsConfig(localName),
-			},
-			{
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEnvironmentsDataSourceID(prefix),
-					resource.TestCheckResourceAttr(prefix, "name", localName),
-					resource.TestCheckResourceAttr(prefix, "environments.#", "1"),
-					resource.TestCheckResourceAttrSet(prefix, "environments.0.id"),
-					resource.TestCheckResourceAttr(prefix, "environments.0.name", localName),
-				),
-				Config: testAccDataSourceEnvironmentByNameConfig(localName),
-			},
-			{
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEnvironmentsDataSourceID(prefix),
 				),
@@ -43,7 +30,25 @@ func TestAccDataSourceEnvironments(t *testing.T) {
 					testAccCheckEnvironmentsDataSourceID(prefix),
 					resource.TestCheckResourceAttr(prefix, "environments.#", "3"),
 				),
-				Config: testAccDataSourceEnvironmentsConfig(localName, take),
+				Config: fmt.Sprintf(`%s
+				%s`,
+					createTestAccDataSourceEnvironmentsConfig(localName),
+					testAccDataSourceEnvironmentsConfig(localName, take),
+				),
+			},
+			{
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEnvironmentsDataSourceID(prefix),
+					resource.TestCheckResourceAttr(prefix, "name", localName),
+					resource.TestCheckResourceAttr(prefix, "environments.#", "1"),
+					resource.TestCheckResourceAttrSet(prefix, "environments.0.id"),
+					resource.TestCheckResourceAttr(prefix, "environments.0.name", localName),
+				),
+				Config: fmt.Sprintf(`%s
+				%s`,
+					createTestAccDataSourceEnvironmentsConfig(localName),
+					testAccDataSourceEnvironmentByNameConfig(localName),
+				),
 			},
 		},
 	})

--- a/octopusdeploy_framework/datasource_environments_test.go
+++ b/octopusdeploy_framework/datasource_environments_test.go
@@ -81,7 +81,7 @@ func testAccDataSourceEnvironmentsEmpty(localName string) string {
 func createTestAccDataSourceEnvironmentsConfig(name string) string {
 	return fmt.Sprintf(`
 		resource "octopusdeploy_environment" "%[1]s" {
-			name = "%[1]s
+			name = "%[1]s"
 		}
 		
 		resource "octopusdeploy_environment" "%[1]s-1" {

--- a/octopusdeploy_framework/datasource_environments_test.go
+++ b/octopusdeploy_framework/datasource_environments_test.go
@@ -14,7 +14,7 @@ func TestAccDataSourceEnvironments(t *testing.T) {
 	localName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
 	prefix := fmt.Sprintf("data.octopusdeploy_environments.%s", localName)
 
-	spaceName := "env_datasource_test" // acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
+	spaceName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
 
 	environmentLocalName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
 	environmentName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)

--- a/octopusdeploy_framework/datasource_environments_test.go
+++ b/octopusdeploy_framework/datasource_environments_test.go
@@ -25,13 +25,6 @@ func TestAccDataSourceEnvironments(t *testing.T) {
 			{
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEnvironmentsDataSourceID(prefix),
-					resource.TestCheckResourceAttr(prefix, "environments.#", "3"),
-				),
-				Config: testAccDataSourceEnvironmentsConfig(localName, take),
-			},
-			{
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEnvironmentsDataSourceID(prefix),
 					resource.TestCheckResourceAttr(prefix, "name", localName),
 					resource.TestCheckResourceAttr(prefix, "environments.#", "1"),
 					resource.TestCheckResourceAttrSet(prefix, "environments.0.id"),
@@ -44,6 +37,13 @@ func TestAccDataSourceEnvironments(t *testing.T) {
 					testAccCheckEnvironmentsDataSourceID(prefix),
 				),
 				Config: testAccDataSourceEnvironmentsEmpty(localName),
+			},
+			{
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEnvironmentsDataSourceID(prefix),
+					resource.TestCheckResourceAttr(prefix, "environments.#", "3"),
+				),
+				Config: testAccDataSourceEnvironmentsConfig(localName, take),
 			},
 		},
 	})

--- a/octopusdeploy_framework/datasource_environments_test.go
+++ b/octopusdeploy_framework/datasource_environments_test.go
@@ -13,6 +13,7 @@ import (
 func TestAccDataSourceEnvironments(t *testing.T) {
 	localName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
 	prefix := fmt.Sprintf("data.octopusdeploy_environments.%s", localName)
+	name := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
 	take := 10
 
 	resource.Test(t, resource.TestCase{
@@ -23,7 +24,7 @@ func TestAccDataSourceEnvironments(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEnvironmentsDataSourceID(prefix),
 				),
-				Config: testAccDataSourceEnvironmentsEmpty(localName),
+				Config: testAccDataSourceEnvironmentsEmpty(acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)),
 			},
 			{
 				Check: resource.ComposeTestCheckFunc(
@@ -31,23 +32,25 @@ func TestAccDataSourceEnvironments(t *testing.T) {
 					resource.TestCheckResourceAttr(prefix, "environments.#", "3"),
 				),
 				Config: fmt.Sprintf(`%s
-				%s`,
-					createTestAccDataSourceEnvironmentsConfig(localName),
+
+%s`,
+					createTestAccDataSourceEnvironmentsConfig(localName, name),
 					testAccDataSourceEnvironmentsConfig(localName, take),
 				),
 			},
 			{
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEnvironmentsDataSourceID(prefix),
-					resource.TestCheckResourceAttr(prefix, "name", localName),
+					resource.TestCheckResourceAttr(prefix, "name", name),
 					resource.TestCheckResourceAttr(prefix, "environments.#", "1"),
 					resource.TestCheckResourceAttrSet(prefix, "environments.0.id"),
-					resource.TestCheckResourceAttr(prefix, "environments.0.name", localName),
+					resource.TestCheckResourceAttr(prefix, "environments.0.name", name),
 				),
 				Config: fmt.Sprintf(`%s
-				%s`,
-					createTestAccDataSourceEnvironmentsConfig(localName),
-					testAccDataSourceEnvironmentByNameConfig(localName),
+
+%s`,
+					createTestAccDataSourceEnvironmentsConfig(localName, name),
+					testAccDataSourceEnvironmentByNameConfig(localName, name),
 				),
 			},
 		},
@@ -75,28 +78,28 @@ func testAccDataSourceEnvironmentsConfig(localName string, take int) string {
 	}`, localName, take)
 }
 
-func testAccDataSourceEnvironmentByNameConfig(localName string) string {
-	return fmt.Sprintf(`data "octopusdeploy_environments" "%[1]s" {
-		name = "%[1]s"	
-	}`, localName)
+func testAccDataSourceEnvironmentByNameConfig(localName string, name string) string {
+	return fmt.Sprintf(`data "octopusdeploy_environments" "%s" {
+		name = "%s"	
+	}`, localName, name)
 }
 
 func testAccDataSourceEnvironmentsEmpty(localName string) string {
 	return fmt.Sprintf(`data "octopusdeploy_environments" "%s" {}`, localName)
 }
 
-func createTestAccDataSourceEnvironmentsConfig(name string) string {
+func createTestAccDataSourceEnvironmentsConfig(localName string, name string) string {
 	return fmt.Sprintf(`
 		resource "octopusdeploy_environment" "%[1]s" {
-			name = "%[1]s"
+			name = "%[2]s"
 		}
 		
 		resource "octopusdeploy_environment" "%[1]s-1" {
-			name = "%[1]s-1"
+			name = "%[2]s-1"
 		}
 
 		resource "octopusdeploy_environment" "%[1]s-2" {
-			name = "%[1]s-2"
+			name = "%[2]s-2"
 		}
-	`, name)
+	`, localName, name)
 }

--- a/octopusdeploy_framework/datasource_environments_test.go
+++ b/octopusdeploy_framework/datasource_environments_test.go
@@ -17,7 +17,7 @@ func TestAccDataSourceEnvironments(t *testing.T) {
 	environmentLocalName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
 	environmentName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
 
-	take := 10
+	//take := 10
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: ProtoV6ProviderFactories(),
@@ -29,18 +29,18 @@ func TestAccDataSourceEnvironments(t *testing.T) {
 				),
 				Config: testAccDataSourceEnvironmentsEmpty(localName),
 			},
-			{
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEnvironmentsDataSourceID(prefix),
-					resource.TestCheckResourceAttr(prefix, "environments.#", "3"),
-				),
-				Config: fmt.Sprintf(`%s
+			// 			{
+			// 				Check: resource.ComposeTestCheckFunc(
+			// 					testAccCheckEnvironmentsDataSourceID(prefix),
+			// 					resource.TestCheckResourceAttr(prefix, "environments.#", "3"),
+			// 				),
+			// 				Config: fmt.Sprintf(`%s
 
-%s`,
-					createTestAccDataSourceEnvironmentsConfig(environmentLocalName, environmentName),
-					testAccDataSourceEnvironmentsConfig(localName, take),
-				),
-			},
+			// %s`,
+			// 					createTestAccDataSourceEnvironmentsConfig(environmentLocalName, environmentName),
+			// 					testAccDataSourceEnvironmentsConfig(localName, take),
+			// 				),
+			// 			},
 			{
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEnvironmentsDataSourceID(prefix),

--- a/octopusdeploy_framework/datasource_environments_test.go
+++ b/octopusdeploy_framework/datasource_environments_test.go
@@ -20,10 +20,22 @@ func TestAccDataSourceEnvironments(t *testing.T) {
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
+				Config: createTestAccDataSourceEnvironmentsConfig(localName),
+			},
+			{
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEnvironmentsDataSourceID(prefix),
+					resource.TestCheckResourceAttr(prefix, "environments.#", "3"),
 				),
 				Config: testAccDataSourceEnvironmentsConfig(localName, take),
+			},
+			{
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEnvironmentsDataSourceID(prefix),
+					resource.TestCheckResourceAttr(prefix, "environments.#", "1"),
+					resource.TestCheckResourceAttr(prefix, "environments.0.Name", localName),
+				),
+				Config: testAccDataSourceEnvironmentByNameConfig(localName),
 			},
 			{
 				Check: resource.ComposeTestCheckFunc(
@@ -56,6 +68,28 @@ func testAccDataSourceEnvironmentsConfig(localName string, take int) string {
 	}`, localName, take)
 }
 
+func testAccDataSourceEnvironmentByNameConfig(localName string) string {
+	return fmt.Sprintf(`data "octopusdeploy_environments" "%[1]s" {
+		name = "%[1]s"	
+	}`, localName)
+}
+
 func testAccDataSourceEnvironmentsEmpty(localName string) string {
 	return fmt.Sprintf(`data "octopusdeploy_environments" "%s" {}`, localName)
+}
+
+func createTestAccDataSourceEnvironmentsConfig(name string) string {
+	return fmt.Sprintf(`
+		resource "octopusdeploy_environment" "%[1]s" {
+			name = "%[1]s
+		}
+		
+		resource "octopusdeploy_environment" "%[1]s-1" {
+			name = "%[1]s-1"
+		}
+
+		resource "octopusdeploy_environment" "%[1]s-2" {
+			name = "%[1]s-2"
+		}
+	`, name)
 }

--- a/octopusdeploy_framework/datasource_environments_test.go
+++ b/octopusdeploy_framework/datasource_environments_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAccDataSourceEnvironments(t *testing.T) {
-	localName := acctest.RandStringFromCharSet(50, acctest.CharSetAlpha)
+	localName := acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)
 	prefix := fmt.Sprintf("data.octopusdeploy_environments.%s", localName)
 	take := 10
 

--- a/octopusdeploy_framework/datasource_environments_test.go
+++ b/octopusdeploy_framework/datasource_environments_test.go
@@ -24,7 +24,7 @@ func TestAccDataSourceEnvironments(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEnvironmentsDataSourceID(prefix),
 				),
-				Config: testAccDataSourceEnvironmentsEmpty(acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)),
+				Config: testAccDataSourceEnvironmentsEmpty(localName),
 			},
 			{
 				Check: resource.ComposeTestCheckFunc(


### PR DESCRIPTION
## Config
```terraform
data "octopusdeploy_environments" "dev" {
  name = "Dev"
}

output "dev" {
  value = data.octopusdeploy_environments.dev
}
```

## Before
```terraform
dev = {
  "environments" = tolist([
    {
      "allow_dynamic_infrastructure" = true
      "description" = ""
      "id" = "Environments-1"
      "jira_extension_settings" = tolist([
        {
          "environment_type" = "development"
        },
      ])
      "jira_service_management_extension_settings" = tolist([])
      "name" = "Dev"
      "servicenow_extension_settings" = tolist([])
      "slug" = "dev"
      "sort_order" = 1
      "space_id" = "Spaces-1"
      "use_guided_failure" = false
    },
    {
      "allow_dynamic_infrastructure" = false
      "description" = "test environment"
      "id" = "Environments-82"
      "jira_extension_settings" = tolist([])
      "jira_service_management_extension_settings" = tolist([])
      "name" = "DevEnv"
      "servicenow_extension_settings" = tolist([])
      "slug" = "devenv"
      "sort_order" = 4
      "space_id" = "Spaces-1"
      "use_guided_failure" = false
    },
    {
      "allow_dynamic_infrastructure" = true
      "description" = ""
      "id" = "Environments-161"
      "jira_extension_settings" = tolist([
        {
          "environment_type" = "development"
        },
      ])
      "jira_service_management_extension_settings" = tolist([])
      "name" = "Jira - Dev"
      "servicenow_extension_settings" = tolist([])
      "slug" = "jira-dev"
      "sort_order" = 6
      "space_id" = "Spaces-1"
      "use_guided_failure" = false
    },
  ])
  "id" = "Environments 2024-08-12 02:02:41.98982 +0000 UTC"
  "ids" = tolist(null) /* of string */
  "name" = "Dev"
  "partial_name" = tostring(null)
  "skip" = tonumber(null)
  "space_id" = tostring(null)
  "take" = tonumber(null)
}
```

## After
```terraform
dev = {
  "environments" = tolist([
    {
      "allow_dynamic_infrastructure" = true
      "description" = ""
      "id" = "Environments-1"
      "jira_extension_settings" = tolist([
        {
          "environment_type" = "development"
        },
      ])
      "jira_service_management_extension_settings" = tolist([])
      "name" = "Dev"
      "servicenow_extension_settings" = tolist([])
      "slug" = "dev"
      "sort_order" = 1
      "space_id" = "Spaces-1"
      "use_guided_failure" = false
    },
  ])
  "id" = "Environments 2024-08-12 02:03:59.739423 +0000 UTC"
  "ids" = tolist(null) /* of string */
  "name" = "Dev"
  "partial_name" = tostring(null)
  "skip" = tonumber(null)
  "space_id" = tostring(null)
  "take" = tonumber(null)
}
```

Fixes #713