### PR TITLE
Add aws oidc account type

### DIFF
--- a/docs/data-sources/accounts.md
+++ b/docs/data-sources/accounts.md
@@ -26,7 +26,7 @@ data "octopusdeploy_accounts" "example" {
 
 ### Optional
 
-- `account_type` (String) A filter to search by a list of account types.  Valid account types are `AmazonWebServicesAccount`, `AmazonWebServicesRoleAccount`, `AzureServicePrincipal`, `AzureSubscription`, `None`, `SshKeyPair`, `Token`, or `UsernamePassword`.
+- `account_type` (String) A filter to search by a list of account types.  Valid account types are `AmazonWebServicesAccount`, `AmazonWebServicesRoleAccount`, `AmazonWebServicesOidcAccount`, `AzureServicePrincipal`, `AzureSubscription`, `None`, `SshKeyPair`, `Token`, or `UsernamePassword`.
 - `ids` (List of String) A filter to search by a list of IDs.
 - `partial_name` (String) A filter to search by the partial match of a name.
 - `skip` (Number) A filter to specify the number of items to skip in the response.

--- a/examples/resources/octopusdeploy_account/resource.tf
+++ b/examples/resources/octopusdeploy_account/resource.tf
@@ -7,7 +7,7 @@ resource "octopusdeploy_account" "amazon_web_services_account" {
 }
 
 resource "octopusdeploy_account" "amazon_web_services_openid_connect_account" {
-  account_type = "AwsOIDCAccount"
+  account_type = "AmazonWebServicesOidcAccount"
   name         = "AWS OIDC Account (OK to Delete)"
   role_arn = "arn:aws:iam::sourceAccountId:roleroleName"
   session_duration = "3600"

--- a/octopusdeploy/schema_queries.go
+++ b/octopusdeploy/schema_queries.go
@@ -7,13 +7,13 @@ import (
 
 func getQueryAccountType() *schema.Schema {
 	return &schema.Schema{
-		Description: "A filter to search by a list of account types.  Valid account types are `AmazonWebServicesAccount`, `AmazonWebServicesRoleAccount`, `AzureServicePrincipal`, `AzureSubscription`, `None`, `SshKeyPair`, `Token`, or `UsernamePassword`.",
+		Description: "A filter to search by a list of account types.  Valid account types are `AmazonWebServicesAccount`, `AmazonWebServicesRoleAccount`, `AmazonWebServicesOidcAccount`, `AzureServicePrincipal`, `AzureSubscription`, `None`, `SshKeyPair`, `Token`, or `UsernamePassword`.",
 		Optional:    true,
 		Type:        schema.TypeString,
 		ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{
 			"AmazonWebServicesAccount",
 			"AmazonWebServicesRoleAccount",
-			"AwsOIDCAccount",
+			"AmazonWebServicesOidcAccount",
 			"AzureServicePrincipal",
 			"AzureOIDC",
 			"AzureSubscription",

--- a/octopusdeploy/schema_utilities.go
+++ b/octopusdeploy/schema_utilities.go
@@ -9,7 +9,7 @@ import (
 
 func getAccountTypeSchema(isRequired bool) *schema.Schema {
 	schema := &schema.Schema{
-		Description: "Specifies the type of the account. Valid account types are `AmazonWebServicesAccount`, `AmazonWebServicesRoleAccount`, `AzureServicePrincipal`, `AzureOIDC`, `AzureSubscription`, `None`, `SshKeyPair`, `Token`, or `UsernamePassword`.",
+		Description: "Specifies the type of the account. Valid account types are `AmazonWebServicesAccount`, `AmazonWebServicesRoleAccount`, `AzureServicePrincipal`, `AzureOIDC`, `AzureSubscription`, `AmazonWebServicesOidcAccount`, `None`, `SshKeyPair`, `Token`, or `UsernamePassword`.",
 		ForceNew:    true,
 		Type:        schema.TypeString,
 		ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{
@@ -22,6 +22,7 @@ func getAccountTypeSchema(isRequired bool) *schema.Schema {
 			"SshKeyPair",
 			"Token",
 			"UsernamePassword",
+			"AmazonWebServicesOidcAccount",
 		}, false)),
 	}
 


### PR DESCRIPTION
The AWS oidc account type was missing from the account types list.

Account created from UI 
![image](https://github.com/user-attachments/assets/f02b0f26-f7ff-4a09-b3e9-62bba6748c0a)
