### PR TITLE
chore: fix template ids for project 

### DIFF
--- a/octopusdeploy_framework/resource_project_expand.go
+++ b/octopusdeploy_framework/resource_project_expand.go
@@ -139,7 +139,7 @@ func expandProject(ctx context.Context, model projectResourceModel) *projects.Pr
 }
 
 func expandGitLibraryPersistenceSettings(ctx context.Context, model gitLibraryPersistenceSettingsModel) projects.GitPersistenceSettings {
-	url, _ := url.Parse(model.URL.ValueString())
+	gitUrl, _ := url.Parse(model.URL.ValueString())
 	var protectedBranches []string
 	model.ProtectedBranches.ElementsAs(ctx, &protectedBranches, false)
 
@@ -150,12 +150,12 @@ func expandGitLibraryPersistenceSettings(ctx context.Context, model gitLibraryPe
 		},
 		model.DefaultBranch.ValueString(),
 		protectedBranches,
-		url,
+		gitUrl,
 	)
 }
 
 func expandGitUsernamePasswordPersistenceSettings(ctx context.Context, model gitUsernamePasswordPersistenceSettingsModel) projects.GitPersistenceSettings {
-	url, _ := url.Parse(model.URL.ValueString())
+	gitUrl, _ := url.Parse(model.URL.ValueString())
 	var protectedBranches []string
 	model.ProtectedBranches.ElementsAs(ctx, &protectedBranches, false)
 
@@ -169,12 +169,12 @@ func expandGitUsernamePasswordPersistenceSettings(ctx context.Context, model git
 		usernamePasswordCredential,
 		model.DefaultBranch.ValueString(),
 		protectedBranches,
-		url,
+		gitUrl,
 	)
 }
 
 func expandGitAnonymousPersistenceSettings(ctx context.Context, model gitAnonymousPersistenceSettingsModel) projects.GitPersistenceSettings {
-	url, _ := url.Parse(model.URL.ValueString())
+	gitUrl, _ := url.Parse(model.URL.ValueString())
 	var protectedBranches []string
 	model.ProtectedBranches.ElementsAs(ctx, &protectedBranches, false)
 
@@ -183,7 +183,7 @@ func expandGitAnonymousPersistenceSettings(ctx context.Context, model gitAnonymo
 		&credentials.Anonymous{},
 		model.DefaultBranch.ValueString(),
 		protectedBranches,
-		url,
+		gitUrl,
 	)
 }
 

--- a/octopusdeploy_framework/resource_project_expand.go
+++ b/octopusdeploy_framework/resource_project_expand.go
@@ -10,6 +10,7 @@ import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"net/url"
 )
 
@@ -50,9 +51,9 @@ func expandProject(ctx context.Context, model projectResourceModel) *projects.Pr
 		var gitLibrarySettingsList []gitLibraryPersistenceSettingsModel
 		diags := model.GitLibraryPersistenceSettings.ElementsAs(ctx, &gitLibrarySettingsList, false)
 		if diags.HasError() {
-			fmt.Printf("Error converting Git library persistence settings: %v\n", diags)
+			tflog.Error(ctx, fmt.Sprintf("Error converting Git library persistence settings: %v\n", diags))
 		} else {
-			fmt.Printf("Number of Git library persistence settings: %d\n", len(gitLibrarySettingsList))
+			tflog.Debug(ctx, fmt.Sprintf("Number of Git library persistence settings: %d\n", len(gitLibrarySettingsList)))
 			if len(gitLibrarySettingsList) > 0 {
 				project.PersistenceSettings = expandGitLibraryPersistenceSettings(ctx, gitLibrarySettingsList[0])
 				project.IsVersionControlled = true
@@ -62,9 +63,9 @@ func expandProject(ctx context.Context, model projectResourceModel) *projects.Pr
 		var gitUsernamePasswordSettingsList []gitUsernamePasswordPersistenceSettingsModel
 		diags := model.GitUsernamePasswordPersistenceSettings.ElementsAs(ctx, &gitUsernamePasswordSettingsList, false)
 		if diags.HasError() {
-			fmt.Printf("Error converting Git username/password persistence settings: %v\n", diags)
+			tflog.Error(ctx, fmt.Sprintf("Error converting Git username/password persistence settings: %v\n", diags))
 		} else {
-			fmt.Printf("Number of Git username/password persistence settings: %d\n", len(gitUsernamePasswordSettingsList))
+			tflog.Debug(ctx, fmt.Sprintf("Number of Git username/password persistence settings: %d\n", len(gitUsernamePasswordSettingsList)))
 			if len(gitUsernamePasswordSettingsList) > 0 {
 				project.PersistenceSettings = expandGitUsernamePasswordPersistenceSettings(ctx, gitUsernamePasswordSettingsList[0])
 				project.IsVersionControlled = true
@@ -74,9 +75,9 @@ func expandProject(ctx context.Context, model projectResourceModel) *projects.Pr
 		var gitAnonymousSettingsList []gitAnonymousPersistenceSettingsModel
 		diags := model.GitAnonymousPersistenceSettings.ElementsAs(ctx, &gitAnonymousSettingsList, false)
 		if diags.HasError() {
-			fmt.Printf("Error converting Git anonymous persistence settings: %v\n", diags)
+			tflog.Error(ctx, fmt.Sprintf("Error converting Git anonymous persistence settings: %v\n", diags))
 		} else {
-			fmt.Printf("Number of Git anonymous persistence settings: %d\n", len(gitAnonymousSettingsList))
+			tflog.Debug(ctx, fmt.Sprintf("Number of Git anonymous persistence settings: %d\n", len(gitAnonymousSettingsList)))
 			if len(gitAnonymousSettingsList) > 0 {
 				project.PersistenceSettings = expandGitAnonymousPersistenceSettings(ctx, gitAnonymousSettingsList[0])
 				project.IsVersionControlled = true
@@ -116,13 +117,13 @@ func expandProject(ctx context.Context, model projectResourceModel) *projects.Pr
 		var templates []templateModel
 		diags := model.Template.ElementsAs(ctx, &templates, false)
 		if diags.HasError() {
-			fmt.Printf("Error converting templates: %v\n", diags)
+			tflog.Error(ctx, fmt.Sprintf("Error converting templates: %v\n", diags))
 		} else {
-			fmt.Printf("Number of templates: %d\n", len(templates))
+			tflog.Info(ctx, fmt.Sprintf("Number of templates: %d\n", len(templates)))
 			project.Templates = expandTemplates(templates)
 		}
 	} else {
-		fmt.Println("Template is null")
+		tflog.Debug(ctx, "Template is null")
 		project.Templates = []actiontemplates.ActionTemplateParameter{}
 	}
 

--- a/octopusdeploy_framework/resource_tenant_test.go
+++ b/octopusdeploy_framework/resource_tenant_test.go
@@ -62,7 +62,7 @@ func testAccTenantBasic(lifecycleLocalName string, lifecycleName string, project
 	sortOrder := acctest.RandIntRange(0, 10)
 	useGuidedFailure := false
 
-	return fmt.Sprintf(testAccProjectBasic(lifecycleLocalName, lifecycleName, projectGroupLocalName, projectGroupName, projectLocalName, projectName, projectDescription)+"\n"+
+	return fmt.Sprintf(testAccProjectBasic(lifecycleLocalName, lifecycleName, projectGroupLocalName, projectGroupName, projectLocalName, projectName, projectDescription, 2)+"\n"+
 		testAccEnvironment(environmentLocalName, environmentName, environmentDescription, allowDynamicInfrastructure, sortOrder, useGuidedFailure)+"\n"+`
 	resource "octopusdeploy_tenant" "%s" {
 		description = "%s"

--- a/octopusdeploy_framework/schemas/project.go
+++ b/octopusdeploy_framework/schemas/project.go
@@ -129,7 +129,7 @@ func GetProjectResourceSchema() resourceSchema.Schema {
 			"template": resourceSchema.ListNestedBlock{
 				NestedObject: resourceSchema.NestedBlockObject{
 					Attributes: map[string]resourceSchema.Attribute{
-						"id":            util.ResourceString().Optional().Computed().Description("The ID of the template parameter.").Build(),
+						"id":            util.ResourceString().Optional().Computed().PlanModifiers(stringplanmodifier.UseStateForUnknown()).Description("The ID of the template parameter.").Build(),
 						"name":          util.ResourceString().Required().Description("The name of the variable set by the parameter. The name can contain letters, digits, dashes and periods.").Build(),
 						"label":         util.ResourceString().Optional().Description("The label shown beside the parameter when presented in the deployment process.").Build(),
 						"help_text":     util.ResourceString().Optional().Description("The help presented alongside the parameter input.").Build(),


### PR DESCRIPTION
This fixes the IDs on the templates attached to a project from getting new guid ID values everytime they are changed.

before: 
<img width="1297" alt="image" src="https://github.com/user-attachments/assets/232862b6-b1b5-48e1-b7af-0c08a5cf2159">


after:
<img width="1244" alt="image" src="https://github.com/user-attachments/assets/3efd9747-9442-4364-9ffe-146853b8547b">
