### PR TITLE
Chore!: fix lvs datasource unexpected changes and resource Known After Apply differences.

### DIFF
--- a/docs/resources/library_variable_set.md
+++ b/docs/resources/library_variable_set.md
@@ -25,10 +25,10 @@ This resource manages library variable sets in Octopus Deploy.
 - `id` (String) The unique ID for this resource.
 - `space_id` (String) The space ID associated with this library variable set.
 - `template` (Block List) (see [below for nested schema](#nestedblock--template))
-- `template_ids` (Map of String)
 
 ### Read-Only
 
+- `template_ids` (Map of String)
 - `variable_set_id` (String)
 
 <a id="nestedblock--template"></a>

--- a/octopusdeploy_framework/schemas/library_variable_set.go
+++ b/octopusdeploy_framework/schemas/library_variable_set.go
@@ -135,7 +135,7 @@ func MapToLibraryVariableSet(data *LibraryVariableSetResourceModel) *variables.L
 
 func FlattenTemplates(actionTemplateParameters []actiontemplates.ActionTemplateParameter) types.List {
 	if len(actionTemplateParameters) == 0 {
-		return types.ListNull(types.ObjectType{AttrTypes: TemplateObjectType()})
+		return types.ListValueMust(types.ObjectType{AttrTypes: TemplateObjectType()}, []attr.Value{})
 	}
 	actionTemplateList := make([]attr.Value, 0, len(actionTemplateParameters))
 
@@ -143,7 +143,7 @@ func FlattenTemplates(actionTemplateParameters []actiontemplates.ActionTemplateP
 		attrs := map[string]attr.Value{
 			"default_value":    util.Ternary(actionTemplateParams.DefaultValue.Value != "", types.StringValue(actionTemplateParams.DefaultValue.Value), types.StringNull()),
 			"display_settings": flattenDisplaySettingsMap(actionTemplateParams.DisplaySettings),
-			"help_text":        util.Ternary(actionTemplateParams.HelpText != "", types.StringValue(actionTemplateParams.HelpText), types.StringNull()),
+			"help_text":        util.Ternary(actionTemplateParams.HelpText != "", types.StringValue(actionTemplateParams.HelpText), types.StringValue("")),
 			"id":               types.StringValue(actionTemplateParams.GetID()),
 			"label":            util.Ternary(actionTemplateParams.Label != "", types.StringValue(actionTemplateParams.Label), types.StringNull()),
 			"name":             types.StringValue(actionTemplateParams.Name),

--- a/octopusdeploy_framework/schemas/library_variable_set.go
+++ b/octopusdeploy_framework/schemas/library_variable_set.go
@@ -7,6 +7,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	datasourceSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	resourceSchema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	types "github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -93,10 +96,15 @@ func GetLibraryVariableSetResourceSchema() resourceSchema.Schema {
 			"template_ids": resourceSchema.MapAttribute{
 				ElementType: types.StringType,
 				Computed:    true,
-				Optional:    true,
+				PlanModifiers: []planmodifier.Map{
+					mapplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"variable_set_id": resourceSchema.StringAttribute{
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 		},
 		Description: "This resource manages library variable sets in Octopus Deploy.",

--- a/octopusdeploy_framework/schemas/library_variable_set.go
+++ b/octopusdeploy_framework/schemas/library_variable_set.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	datasourceSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	resourceSchema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	types "github.com/hashicorp/terraform-plugin-framework/types"
@@ -96,9 +95,6 @@ func GetLibraryVariableSetResourceSchema() resourceSchema.Schema {
 			"template_ids": resourceSchema.MapAttribute{
 				ElementType: types.StringType,
 				Computed:    true,
-				PlanModifiers: []planmodifier.Map{
-					mapplanmodifier.UseStateForUnknown(),
-				},
 			},
 			"variable_set_id": resourceSchema.StringAttribute{
 				Computed: true,

--- a/octopusdeploy_framework/schemas/schema.go
+++ b/octopusdeploy_framework/schemas/schema.go
@@ -2,6 +2,8 @@ package schemas
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -145,6 +147,9 @@ func GetIdResourceSchema() resourceSchema.Attribute {
 		Description: "The unique ID for this resource.",
 		Computed:    true,
 		Optional:    true,
+		PlanModifiers: []planmodifier.String{
+			stringplanmodifier.UseStateForUnknown(),
+		},
 	}
 }
 
@@ -153,6 +158,9 @@ func GetSpaceIdResourceSchema(resourceDescription string) resourceSchema.Attribu
 		Description: "The space ID associated with this " + resourceDescription + ".",
 		Computed:    true,
 		Optional:    true,
+		PlanModifiers: []planmodifier.String{
+			stringplanmodifier.UseStateForUnknown(),
+		},
 	}
 }
 


### PR DESCRIPTION
This fixes the following two issues found in testing:

Fixes [] => null on templates and "" -> null on display settings.
```
Changes to Outputs:
  ~ lvs  = {
      ~ id                    = "Library Variables Sets 2024-08-15 02:14:22.495669 +0000 UTC" -> "Library Variables Sets 2024-08-15 02:23:27.676669 +0000 UTC"
      ~ library_variable_sets = [
          ~ {
                id              = "LibraryVariableSets-81"
                name            = "Another Variable Set"
              ~ template        = [] -> null
                # (4 unchanged attributes hidden)
            },
        ]
        # (6 unchanged attributes hidden)
    }
  ~ sms  = {
      ~ id                    = "Library Variables Sets 2024-08-15 02:14:22.498898 +0000 UTC" -> "Library Variables Sets 2024-08-15 02:23:27.675886 +0000 UTC"
      ~ library_variable_sets = [
          ~ {
                id              = "LibraryVariableSets-82"
                name            = "Hello"
              ~ template        = [] -> null
                # (4 unchanged attributes hidden)
            },
        ]
        # (6 unchanged attributes hidden)
    }
```

Unexpected changes, only `display_settings ` has been changed.
```
  # octopusdeploy_library_variable_set.newvariableset will be updated in-place
  ~ resource "octopusdeploy_library_variable_set" "newvariableset" {
      ~ id              = "LibraryVariableSets-85" -> (known after apply)
        name            = "Library Variable Set test (OK to Delete)"
      ~ space_id        = "Spaces-1" -> (known after apply)
      ~ template_ids    = {
          - "AnotherTemplate" = "234c7e65-a1eb-4d77-94e3-eb231e2978ac"
          - "TheTemplate"     = "687ed66c-ea94-42ce-9348-753112a3c730"
        } -> (known after apply)
      ~ variable_set_id = "variableset-LibraryVariableSets-85" -> (known after apply)
        # (1 unchanged attribute hidden)

      ~ template {
          ~ display_settings = {
              ~ "Octopus.ControlType" = "Sensitive" -> "SingleLineText"
            }
            id               = "687ed66c-ea94-42ce-9348-753112a3c730"
            name             = "TheTemplate"
            # (3 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```