### PR TITLE
Update git credential datasource

### DIFF
--- a/docs/data-sources/git_credentials.md
+++ b/docs/data-sources/git_credentials.md
@@ -35,7 +35,6 @@ Read-Only:
 - `description` (String) The description of this Git Credential.
 - `id` (String) The unique ID for this resource.
 - `name` (String) The name of this Git Credential.
-- `password` (String, Sensitive) The password for the Git credential.
 - `space_id` (String) The space ID associated with this Git Credential.
 - `type` (String) The Git credential authentication type.
 - `username` (String) The username for the Git credential.

--- a/octopusdeploy_framework/datasource_git_credentials.go
+++ b/octopusdeploy_framework/datasource_git_credentials.go
@@ -27,14 +27,13 @@ type gitCredentialsDataSourceModel struct {
 	GitCredentials types.List   `tfsdk:"git_credentials"`
 }
 
-type GitCredentialModel struct {
+type GitCredentialDatasourceModel struct {
 	ID          types.String `tfsdk:"id"`
 	SpaceID     types.String `tfsdk:"space_id"`
 	Name        types.String `tfsdk:"name"`
 	Description types.String `tfsdk:"description"`
 	Type        types.String `tfsdk:"type"`
 	Username    types.String `tfsdk:"username"`
-	Password    types.String `tfsdk:"password"`
 }
 
 func NewGitCredentialsDataSource() datasource.DataSource {
@@ -73,7 +72,7 @@ func (g *gitCredentialsDataSource) Read(ctx context.Context, req datasource.Read
 		return
 	}
 
-	flattenedGitCredentials := make([]GitCredentialModel, 0, len(existingGitCredentials.Items))
+	flattenedGitCredentials := make([]GitCredentialDatasourceModel, 0, len(existingGitCredentials.Items))
 	for _, gitCredential := range existingGitCredentials.Items {
 		flattenedGitCredential := FlattenGitCredential(gitCredential)
 		flattenedGitCredentials = append(flattenedGitCredentials, *flattenedGitCredential)
@@ -99,16 +98,15 @@ func GetGitCredentialAttrTypes() map[string]attr.Type {
 		"description": types.StringType,
 		"type":        types.StringType,
 		"username":    types.StringType,
-		"password":    types.StringType,
 	}
 }
 
-func FlattenGitCredential(credential *credentials.Resource) *GitCredentialModel {
+func FlattenGitCredential(credential *credentials.Resource) *GitCredentialDatasourceModel {
 	if credential == nil {
 		return nil
 	}
 
-	model := &GitCredentialModel{
+	model := &GitCredentialDatasourceModel{
 		ID:          types.StringValue(credential.GetID()),
 		SpaceID:     types.StringValue(credential.SpaceID),
 		Name:        types.StringValue(credential.Name),

--- a/octopusdeploy_framework/schemas/gitCredential.go
+++ b/octopusdeploy_framework/schemas/gitCredential.go
@@ -55,14 +55,14 @@ func GetGitCredentialDataSourceSchema() datasourceSchema.Schema {
 				Computed:    true,
 				Description: "Provides information about existing GitCredentials.",
 				NestedObject: datasourceSchema.NestedAttributeObject{
-					Attributes: GetGitCredentialAttributes(),
+					Attributes: GetGitCredentialDatasourceAttributes(),
 				},
 			},
 		},
 	}
 }
 
-func GetGitCredentialAttributes() map[string]datasourceSchema.Attribute {
+func GetGitCredentialDatasourceAttributes() map[string]datasourceSchema.Attribute {
 	return map[string]datasourceSchema.Attribute{
 		"id":          util.DataSourceString().Computed().Description("The unique ID for this resource.").Build(),
 		"space_id":    util.DataSourceString().Computed().Description("The space ID associated with this Git Credential.").Build(),
@@ -70,6 +70,5 @@ func GetGitCredentialAttributes() map[string]datasourceSchema.Attribute {
 		"description": util.DataSourceString().Computed().Description("The description of this Git Credential.").Build(),
 		"type":        util.DataSourceString().Computed().Description("The Git credential authentication type.").Build(),
 		"username":    util.DataSourceString().Computed().Description("The username for the Git credential.").Build(),
-		"password":    util.DataSourceString().Computed().Sensitive().Description("The password for the Git credential.").Build(),
 	}
 }


### PR DESCRIPTION
The GitCredentials data source includes a password field. This is never actually sent down to the client and is a redundant field. This PR removes it from the data source.

![image](https://github.com/user-attachments/assets/fb22834a-65d2-472d-bdf1-bf69d1313983)
