### PR TITLE
Update environment resource testing

### DIFF
--- a/octopusdeploy_framework/resource_environment.go
+++ b/octopusdeploy_framework/resource_environment.go
@@ -123,6 +123,7 @@ func (r *environmentTypeResource) Update(ctx context.Context, req resource.Updat
 	updatedEnv.AllowDynamicInfrastructure = data.AllowDynamicInfrastructure.ValueBool()
 	updatedEnv.UseGuidedFailure = data.UseGuidedFailure.ValueBool()
 	updatedEnv.SortOrder = util.GetNumber(data.SortOrder)
+	updatedEnv.SpaceID = data.SpaceID.ValueString()
 	if len(data.JiraExtensionSettings.Elements()) > 0 {
 		jiraExtensionSettings := mapJiraExtensionSettings(data.JiraExtensionSettings)
 		if jiraExtensionSettings != nil {


### PR DESCRIPTION
Note: This "fix" is redundant because we don't handle environments moving across spaces. That said it brings the behaviour in line with the old provider and is required to eventually support this behaviour.

Changing an Environments SpaceId in the older provider throws this error
![image](https://github.com/user-attachments/assets/f1e12651-db52-4e1b-874c-d2e0e16e3572)

New provider fails with the SpaceId changing
![image](https://github.com/user-attachments/assets/44b1f02e-da68-4c54-b4ec-6d3afc182460)

After "Fix"
![image](https://github.com/user-attachments/assets/1137740c-9bc0-4767-9dc8-556e77ec6fc6)