### PR TITLE
Update AGF example

### DIFF
--- a/docs/resources/artifactory_generic_feed.md
+++ b/docs/resources/artifactory_generic_feed.md
@@ -14,7 +14,7 @@ This resource manages a Artifactory Generic feed in Octopus Deploy.
 
 ```terraform
 resource "octopusdeploy_artifactory_generic_feed" "example" {
-  feed_uri                       = "https://example.jfrog.io/"
+  feed_uri                       = "https://example.jfrog.io"
   password                       = "test-password"
   name                           = "Test Artifactory Generic Feed (OK to Delete)"
   username                       = "test-username"

--- a/examples/resources/octopusdeploy_artifactory_generic_feed/resource.tf
+++ b/examples/resources/octopusdeploy_artifactory_generic_feed/resource.tf
@@ -1,5 +1,5 @@
 resource "octopusdeploy_artifactory_generic_feed" "example" {
-  feed_uri                       = "https://example.jfrog.io/"
+  feed_uri                       = "https://example.jfrog.io"
   password                       = "test-password"
   name                           = "Test Artifactory Generic Feed (OK to Delete)"
   username                       = "test-username"


### PR DESCRIPTION
Minor docs update for the AGF example. There's an issue where we trim trailing slashes in Urls. This means the configuration posted vs returned changes. Since this is a required attribute Plan Modifiers do not help.