### PR TITLE
added debug logging to datasources

### DIFF
--- a/octopusdeploy_framework/data_source_library_variable_sets.go
+++ b/octopusdeploy_framework/data_source_library_variable_sets.go
@@ -66,7 +66,7 @@ func (l *libraryVariableSetDataSource) Read(ctx context.Context, req datasource.
 		Take:        int(data.Take.ValueInt64()),
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Reading library variable set with query: %+v", query))
+	util.DatasourceReading(ctx, "library variable set", query)
 
 	existingLibraryVariableSets, err := libraryvariablesets.Get(l.Config.Client, data.SpaceID.ValueString(), query)
 	if err != nil {
@@ -74,7 +74,7 @@ func (l *libraryVariableSetDataSource) Read(ctx context.Context, req datasource.
 		return
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Read library variable set returned %d items", len(existingLibraryVariableSets.Items)))
+	util.DatasourceResultCount(ctx, "library variable set", len(existingLibraryVariableSets.Items))
 
 	data.LibraryVariableSets = flattenLibraryVariableSets(existingLibraryVariableSets.Items)
 

--- a/octopusdeploy_framework/data_source_library_variable_sets.go
+++ b/octopusdeploy_framework/data_source_library_variable_sets.go
@@ -66,11 +66,15 @@ func (l *libraryVariableSetDataSource) Read(ctx context.Context, req datasource.
 		Take:        int(data.Take.ValueInt64()),
 	}
 
+	tflog.Debug(ctx, fmt.Sprintf("Reading library variable set with query: %+v", query))
+
 	existingLibraryVariableSets, err := libraryvariablesets.Get(l.Config.Client, data.SpaceID.ValueString(), query)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read library variable sets, got error: %s", err))
 		return
 	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Read library variable set returned %d items", len(existingLibraryVariableSets.Items)))
 
 	data.LibraryVariableSets = flattenLibraryVariableSets(existingLibraryVariableSets.Items)
 
@@ -94,5 +98,6 @@ func flattenLibraryVariableSets(items []*variables.LibraryVariableSet) types.Lis
 		}
 		libraryVariableSetList = append(libraryVariableSetList, types.ObjectValueMust(schemas.GetLibraryVariableSetObjectType(), libraryVariableSetMap))
 	}
+
 	return types.ListValueMust(types.ObjectType{AttrTypes: schemas.GetLibraryVariableSetObjectType()}, libraryVariableSetList)
 }

--- a/octopusdeploy_framework/data_source_script_modules.go
+++ b/octopusdeploy_framework/data_source_script_modules.go
@@ -54,6 +54,8 @@ func (l *scriptModulesDataSource) Read(ctx context.Context, req datasource.ReadR
 		Take:        int(data.Take.ValueInt64()),
 	}
 
+	tflog.Debug(ctx, fmt.Sprintf("Reading script modules data source query: %+v", query))
+
 	spaceID := data.SpaceID.ValueString()
 	existingScriptModules, err := scriptmodules.Get(l.Config.Client, spaceID, query)
 	if err != nil {
@@ -70,5 +72,6 @@ func (l *scriptModulesDataSource) Read(ctx context.Context, req datasource.ReadR
 		flattenedScriptModules)
 	data.ID = types.StringValue("Script Modules " + time.Now().UTC().String())
 
+	tflog.Debug(ctx, fmt.Sprintf("Read script modules data source returned %d items", len(existingScriptModules.Items)))
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/octopusdeploy_framework/data_source_script_modules.go
+++ b/octopusdeploy_framework/data_source_script_modules.go
@@ -54,7 +54,7 @@ func (l *scriptModulesDataSource) Read(ctx context.Context, req datasource.ReadR
 		Take:        int(data.Take.ValueInt64()),
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Reading script modules data source query: %+v", query))
+	util.DatasourceReading(ctx, "script modules", query)
 
 	spaceID := data.SpaceID.ValueString()
 	existingScriptModules, err := scriptmodules.Get(l.Config.Client, spaceID, query)
@@ -72,6 +72,6 @@ func (l *scriptModulesDataSource) Read(ctx context.Context, req datasource.ReadR
 		flattenedScriptModules)
 	data.ID = types.StringValue("Script Modules " + time.Now().UTC().String())
 
-	tflog.Debug(ctx, fmt.Sprintf("Read script modules data source returned %d items", len(existingScriptModules.Items)))
+	util.DatasourceResultCount(ctx, "script modules", len(existingScriptModules.Items))
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/octopusdeploy_framework/datasource_environments.go
+++ b/octopusdeploy_framework/datasource_environments.go
@@ -84,6 +84,8 @@ func (e *environmentDataSource) Read(ctx context.Context, req datasource.ReadReq
 		Take:        util.GetNumber(data.Take),
 	}
 
+	tflog.Debug(ctx, fmt.Sprintf("Reading environments with query %+v", query))
+
 	existingEnvironments, err := environments.Get(e.Client, data.SpaceID.ValueString(), query)
 	if err != nil {
 		resp.Diagnostics.AddError("unable to load environments", err.Error())
@@ -108,6 +110,8 @@ func (e *environmentDataSource) Read(ctx context.Context, req datasource.ReadReq
 			mappedEnvironments = append(mappedEnvironments, schemas.MapFromEnvironment(ctx, matchedEnvironment))
 		}
 	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Reading environments data source returned %d items", len(mappedEnvironments)))
 
 	data.Environments, _ = types.ListValueFrom(ctx, types.ObjectType{AttrTypes: schemas.EnvironmentObjectType()}, mappedEnvironments)
 	data.ID = types.StringValue("Environments " + time.Now().UTC().String())

--- a/octopusdeploy_framework/datasource_environments.go
+++ b/octopusdeploy_framework/datasource_environments.go
@@ -84,7 +84,7 @@ func (e *environmentDataSource) Read(ctx context.Context, req datasource.ReadReq
 		Take:        util.GetNumber(data.Take),
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Reading environments with query %+v", query))
+	util.DatasourceReading(ctx, "environments", query)
 
 	existingEnvironments, err := environments.Get(e.Client, data.SpaceID.ValueString(), query)
 	if err != nil {
@@ -111,7 +111,7 @@ func (e *environmentDataSource) Read(ctx context.Context, req datasource.ReadReq
 		}
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Reading environments data source returned %d items", len(mappedEnvironments)))
+	util.DatasourceResultCount(ctx, "environments", len(mappedEnvironments))
 
 	data.Environments, _ = types.ListValueFrom(ctx, types.ObjectType{AttrTypes: schemas.EnvironmentObjectType()}, mappedEnvironments)
 	data.ID = types.StringValue("Environments " + time.Now().UTC().String())

--- a/octopusdeploy_framework/datasource_feeds.go
+++ b/octopusdeploy_framework/datasource_feeds.go
@@ -60,12 +60,14 @@ func (e *feedsDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		Take:        util.GetNumber(data.Take),
 	}
 
+	tflog.Debug(ctx, fmt.Sprintf("Reading feeds with query %+v", query))
+
 	existingFeeds, err := feeds.Get(e.Client, data.SpaceID.ValueString(), query)
 	if err != nil {
 		resp.Diagnostics.AddError("unable to load feeds", err.Error())
 		return
 	}
-	tflog.Debug(ctx, fmt.Sprintf("environments returned from API: %#v", existingFeeds))
+	tflog.Debug(ctx, fmt.Sprintf("Reading feeds returned %d items", len(existingFeeds.Items)))
 
 	flattenedFeeds := []interface{}{}
 	for _, feed := range existingFeeds.Items {

--- a/octopusdeploy_framework/datasource_feeds.go
+++ b/octopusdeploy_framework/datasource_feeds.go
@@ -2,13 +2,11 @@ package octopusdeploy_framework
 
 import (
 	"context"
-	"fmt"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	datasourceSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"time"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/feeds"
@@ -60,14 +58,15 @@ func (e *feedsDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		Take:        util.GetNumber(data.Take),
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Reading feeds with query %+v", query))
+	util.DatasourceReading(ctx, "feeds", query)
 
 	existingFeeds, err := feeds.Get(e.Client, data.SpaceID.ValueString(), query)
 	if err != nil {
 		resp.Diagnostics.AddError("unable to load feeds", err.Error())
 		return
 	}
-	tflog.Debug(ctx, fmt.Sprintf("Reading feeds returned %d items", len(existingFeeds.Items)))
+
+	util.DatasourceResultCount(ctx, "feeds", len(existingFeeds.Items))
 
 	flattenedFeeds := []interface{}{}
 	for _, feed := range existingFeeds.Items {

--- a/octopusdeploy_framework/datasource_git_credentials.go
+++ b/octopusdeploy_framework/datasource_git_credentials.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"time"
 )
 
@@ -66,7 +65,7 @@ func (g *gitCredentialsDataSource) Read(ctx context.Context, req datasource.Read
 		Take: int(data.Take.ValueInt64()),
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Reading git credentials with query %+v", query))
+	util.DatasourceReading(ctx, "git credentials", query)
 
 	spaceID := data.SpaceID.ValueString()
 
@@ -76,7 +75,7 @@ func (g *gitCredentialsDataSource) Read(ctx context.Context, req datasource.Read
 		return
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Reading git credentials returned %d items", len(existingGitCredentials.Items)))
+	util.DatasourceResultCount(ctx, "git credentials", len(existingGitCredentials.Items))
 
 	flattenedGitCredentials := make([]GitCredentialDatasourceModel, 0, len(existingGitCredentials.Items))
 	for _, gitCredential := range existingGitCredentials.Items {

--- a/octopusdeploy_framework/datasource_git_credentials.go
+++ b/octopusdeploy_framework/datasource_git_credentials.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"time"
 )
 
@@ -64,6 +65,9 @@ func (g *gitCredentialsDataSource) Read(ctx context.Context, req datasource.Read
 		Skip: int(data.Skip.ValueInt64()),
 		Take: int(data.Take.ValueInt64()),
 	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Reading git credentials with query %+v", query))
+
 	spaceID := data.SpaceID.ValueString()
 
 	existingGitCredentials, err := credentials.Get(g.Client, spaceID, query)
@@ -71,6 +75,8 @@ func (g *gitCredentialsDataSource) Read(ctx context.Context, req datasource.Read
 		resp.Diagnostics.AddError("Unable to query git credentials", err.Error())
 		return
 	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Reading git credentials returned %d items", len(existingGitCredentials.Items)))
 
 	flattenedGitCredentials := make([]GitCredentialDatasourceModel, 0, len(existingGitCredentials.Items))
 	for _, gitCredential := range existingGitCredentials.Items {

--- a/octopusdeploy_framework/datasource_lifecycle.go
+++ b/octopusdeploy_framework/datasource_lifecycle.go
@@ -62,11 +62,15 @@ func (l *lifecyclesDataSource) Read(ctx context.Context, req datasource.ReadRequ
 		Take:        int(data.Take.ValueInt64()),
 	}
 
+	tflog.Debug(ctx, fmt.Sprintf("Reading lifecycles with query: %+v", query))
+
 	lifecyclesResult, err := lifecycles.Get(l.Config.Client, data.SpaceID.ValueString(), query)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read lifecycles, got error: %s", err))
 		return
 	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Reading lifecycles returned %d items", len(lifecyclesResult.Items)))
 
 	data.Lifecycles = flattenLifecycles(lifecyclesResult.Items)
 	data.ID = types.StringValue("Lifecycles " + time.Now().UTC().String())

--- a/octopusdeploy_framework/datasource_lifecycle.go
+++ b/octopusdeploy_framework/datasource_lifecycle.go
@@ -62,7 +62,7 @@ func (l *lifecyclesDataSource) Read(ctx context.Context, req datasource.ReadRequ
 		Take:        int(data.Take.ValueInt64()),
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Reading lifecycles with query: %+v", query))
+	util.DatasourceReading(ctx, "lifecycles", query)
 
 	lifecyclesResult, err := lifecycles.Get(l.Config.Client, data.SpaceID.ValueString(), query)
 	if err != nil {
@@ -70,7 +70,7 @@ func (l *lifecyclesDataSource) Read(ctx context.Context, req datasource.ReadRequ
 		return
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Reading lifecycles returned %d items", len(lifecyclesResult.Items)))
+	util.DatasourceResultCount(ctx, "lifecycles", len(lifecyclesResult.Items))
 
 	data.Lifecycles = flattenLifecycles(lifecyclesResult.Items)
 	data.ID = types.StringValue("Lifecycles " + time.Now().UTC().String())

--- a/octopusdeploy_framework/datasource_project.go
+++ b/octopusdeploy_framework/datasource_project.go
@@ -8,6 +8,7 @@ import (
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"time"
 )
 
@@ -62,6 +63,8 @@ func (p *projectsDataSource) Read(ctx context.Context, req datasource.ReadReques
 		Take:                int(data.Take.ValueInt64()),
 	}
 
+	tflog.Debug(ctx, fmt.Sprintf("Reading projects with query %+v", query))
+
 	if !data.IDs.IsNull() {
 		var ids []string
 		resp.Diagnostics.Append(data.IDs.ElementsAs(ctx, &ids, false)...)
@@ -78,6 +81,8 @@ func (p *projectsDataSource) Read(ctx context.Context, req datasource.ReadReques
 		resp.Diagnostics.AddError("Unable to query projects", err.Error())
 		return
 	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Reading projects returned %d items", len(existingProjects.Items)))
 
 	data.Projects = make([]projectResourceModel, 0, len(existingProjects.Items))
 	for _, project := range existingProjects.Items {

--- a/octopusdeploy_framework/datasource_project.go
+++ b/octopusdeploy_framework/datasource_project.go
@@ -8,7 +8,6 @@ import (
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"time"
 )
 
@@ -63,7 +62,7 @@ func (p *projectsDataSource) Read(ctx context.Context, req datasource.ReadReques
 		Take:                int(data.Take.ValueInt64()),
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Reading projects with query %+v", query))
+	util.DatasourceReading(ctx, "projects", query)
 
 	if !data.IDs.IsNull() {
 		var ids []string
@@ -82,7 +81,7 @@ func (p *projectsDataSource) Read(ctx context.Context, req datasource.ReadReques
 		return
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Reading projects returned %d items", len(existingProjects.Items)))
+	util.DatasourceResultCount(ctx, "projects", len(existingProjects.Items))
 
 	data.Projects = make([]projectResourceModel, 0, len(existingProjects.Items))
 	for _, project := range existingProjects.Items {

--- a/octopusdeploy_framework/datasource_project_groups.go
+++ b/octopusdeploy_framework/datasource_project_groups.go
@@ -104,6 +104,8 @@ func (p *projectGroupsDataSource) Read(ctx context.Context, req datasource.ReadR
 	}
 	spaceID := data.SpaceID.ValueString()
 
+	util.DatasourceReading(ctx, "project groups", query)
+
 	existingProjectGroups, err := projectgroups.Get(p.Client, spaceID, query)
 	if err != nil {
 		resp.Diagnostics.AddError("unable to load project groups", err.Error())
@@ -121,7 +123,8 @@ func (p *projectGroupsDataSource) Read(ctx context.Context, req datasource.ReadR
 		newGroups = append(newGroups, g)
 	}
 
-	//groups, _ := types.ObjectValueFrom(ctx, types.ObjectType{AttrTypes: getNestedGroupAttributes()}, newGroups)
+	util.DatasourceResultCount(ctx, "project groups", len(newGroups))
+
 	for _, projectGroup := range newGroups {
 		tflog.Debug(ctx, "mapped group "+projectGroup.Name.ValueString())
 	}

--- a/octopusdeploy_framework/datasource_space.go
+++ b/octopusdeploy_framework/datasource_space.go
@@ -48,7 +48,7 @@ func (b *spaceDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 	// construct query
 	query := spaces.SpacesQuery{PartialName: data.Name.ValueString()}
 
-	tflog.Debug(ctx, fmt.Sprintf("Reading space with query %+v", query))
+	util.DatasourceReading(ctx, "space", query)
 
 	spacesResult, err := spaces.Get(b.Client, query)
 

--- a/octopusdeploy_framework/datasource_space.go
+++ b/octopusdeploy_framework/datasource_space.go
@@ -3,6 +3,7 @@ package octopusdeploy_framework
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"strings"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/spaces"
@@ -46,6 +47,9 @@ func (b *spaceDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 
 	// construct query
 	query := spaces.SpacesQuery{PartialName: data.Name.ValueString()}
+
+	tflog.Debug(ctx, fmt.Sprintf("Reading space with query %+v", query))
+
 	spacesResult, err := spaces.Get(b.Client, query)
 
 	if err != nil {
@@ -63,6 +67,8 @@ func (b *spaceDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		resp.Diagnostics.AddError(fmt.Sprintf("unable to find space with name %s", data.Name.ValueString()), "")
 		return
 	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Reading space returned ID %s", matchedSpace.ID))
 
 	mapSpaceToState(ctx, &data, matchedSpace)
 

--- a/octopusdeploy_framework/datasource_spaces.go
+++ b/octopusdeploy_framework/datasource_spaces.go
@@ -2,12 +2,14 @@ package octopusdeploy_framework
 
 import (
 	"context"
+	"fmt"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/spaces"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"time"
 )
 
@@ -74,6 +76,8 @@ func (b *spacesDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		Take:        schemas.GetNumber(data.Take),
 	}
 
+	tflog.Debug(ctx, fmt.Sprintf("Reading Spaces with query %+v", query))
+
 	existingSpaces, err := spaces.Get(b.Client, query)
 	if err != nil {
 		resp.Diagnostics.AddError("unable to load spaces", err.Error())
@@ -86,6 +90,8 @@ func (b *spacesDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		mapSpaceToState(ctx, &s, space)
 		mappedSpaces = append(mappedSpaces, s)
 	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Reading spaces returned %d items", len(mappedSpaces)))
 
 	data.Spaces, _ = types.ListValueFrom(ctx, schemas.GetSpaceTypeAttributes(), mappedSpaces)
 	data.ID = types.StringValue("Spaces " + time.Now().UTC().String())

--- a/octopusdeploy_framework/datasource_spaces.go
+++ b/octopusdeploy_framework/datasource_spaces.go
@@ -2,14 +2,12 @@ package octopusdeploy_framework
 
 import (
 	"context"
-	"fmt"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/spaces"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"time"
 )
 
@@ -76,7 +74,7 @@ func (b *spacesDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		Take:        schemas.GetNumber(data.Take),
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Reading Spaces with query %+v", query))
+	util.DatasourceReading(ctx, "spaces", query)
 
 	existingSpaces, err := spaces.Get(b.Client, query)
 	if err != nil {
@@ -91,7 +89,7 @@ func (b *spacesDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		mappedSpaces = append(mappedSpaces, s)
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Reading spaces returned %d items", len(mappedSpaces)))
+	util.DatasourceResultCount(ctx, "spaces", len(mappedSpaces))
 
 	data.Spaces, _ = types.ListValueFrom(ctx, schemas.GetSpaceTypeAttributes(), mappedSpaces)
 	data.ID = types.StringValue("Spaces " + time.Now().UTC().String())

--- a/octopusdeploy_framework/datasource_tag_sets.go
+++ b/octopusdeploy_framework/datasource_tag_sets.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"time"
 )
 
@@ -49,7 +48,7 @@ func (t *tagSetsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		Take:        int(data.Take.ValueInt64()),
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Reading tag sets %+v", query))
+	util.DatasourceReading(ctx, "tag sets", query)
 
 	spaceID := data.SpaceID.ValueString()
 
@@ -59,7 +58,7 @@ func (t *tagSetsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		return
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Reading tag sets returned %d items", len(existingTagSets.Items)))
+	util.DatasourceResultCount(ctx, "tag sets", len(existingTagSets.Items))
 
 	data.TagSets = flattenTagSets(existingTagSets.Items)
 	data.ID = types.StringValue(fmt.Sprintf("TagSets-%s", time.Now().UTC().String()))

--- a/octopusdeploy_framework/datasource_tag_sets.go
+++ b/octopusdeploy_framework/datasource_tag_sets.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"time"
 )
 
@@ -47,6 +48,9 @@ func (t *tagSetsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		Skip:        int(data.Skip.ValueInt64()),
 		Take:        int(data.Take.ValueInt64()),
 	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Reading tag sets %+v", query))
+
 	spaceID := data.SpaceID.ValueString()
 
 	existingTagSets, err := tagsets.Get(t.Client, spaceID, query)
@@ -55,8 +59,9 @@ func (t *tagSetsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		return
 	}
 
-	data.TagSets = flattenTagSets(existingTagSets.Items)
+	tflog.Debug(ctx, fmt.Sprintf("Reading tag sets returned %d items", len(existingTagSets.Items)))
 
+	data.TagSets = flattenTagSets(existingTagSets.Items)
 	data.ID = types.StringValue(fmt.Sprintf("TagSets-%s", time.Now().UTC().String()))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/octopusdeploy_framework/datasource_tenants.go
+++ b/octopusdeploy_framework/datasource_tenants.go
@@ -2,12 +2,14 @@ package octopusdeploy_framework
 
 import (
 	"context"
+	"fmt"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/tenants"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	datasourceSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"time"
 )
 
@@ -62,6 +64,8 @@ func (b *tenantsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		Take:               int(data.Take.ValueInt64()),
 	}
 
+	tflog.Debug(ctx, fmt.Sprintf("Reading tenats with query: %+v", query))
+
 	existingTenants, err := tenants.Get(b.Client, data.SpaceID.ValueString(), query)
 	if err != nil {
 		resp.Diagnostics.AddError("unable to load tenants", err.Error())
@@ -72,6 +76,8 @@ func (b *tenantsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	for _, tenant := range existingTenants.Items {
 		flattenedTenants = append(flattenedTenants, schemas.FlattenTenant(tenant))
 	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Reading tenants returned %d items", len(flattenedTenants)))
 
 	data.ID = types.StringValue("Tenants " + time.Now().UTC().String())
 	data.Tenants, _ = types.ListValueFrom(ctx, types.ObjectType{AttrTypes: schemas.TenantObjectType()}, flattenedTenants)

--- a/octopusdeploy_framework/datasource_tenants.go
+++ b/octopusdeploy_framework/datasource_tenants.go
@@ -2,14 +2,12 @@ package octopusdeploy_framework
 
 import (
 	"context"
-	"fmt"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/tenants"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	datasourceSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"time"
 )
 
@@ -64,7 +62,7 @@ func (b *tenantsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		Take:               int(data.Take.ValueInt64()),
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Reading tenats with query: %+v", query))
+	util.DatasourceReading(ctx, "tenants", query)
 
 	existingTenants, err := tenants.Get(b.Client, data.SpaceID.ValueString(), query)
 	if err != nil {
@@ -77,7 +75,7 @@ func (b *tenantsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		flattenedTenants = append(flattenedTenants, schemas.FlattenTenant(tenant))
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("Reading tenants returned %d items", len(flattenedTenants)))
+	util.DatasourceResultCount(ctx, "tenants", len(flattenedTenants))
 
 	data.ID = types.StringValue("Tenants " + time.Now().UTC().String())
 	data.Tenants, _ = types.ListValueFrom(ctx, types.ObjectType{AttrTypes: schemas.TenantObjectType()}, flattenedTenants)

--- a/octopusdeploy_framework/util/logging.go
+++ b/octopusdeploy_framework/util/logging.go
@@ -3,7 +3,6 @@ package util
 import (
 	"context"
 	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
@@ -25,6 +24,14 @@ func Deleted(ctx context.Context, resource string, v ...any) {
 
 func Reading(ctx context.Context, resource string, v ...any) {
 	tflog.Info(ctx, fmt.Sprintf("reading %s: %#v", resource, v))
+}
+
+func DatasourceReading(ctx context.Context, resource string, v ...any) {
+	tflog.Debug(ctx, fmt.Sprintf("reading %s data source with query: %+v", resource, v))
+}
+
+func DatasourceResultCount(ctx context.Context, resource string, count int) {
+	tflog.Debug(ctx, fmt.Sprintf("reading %s returned %d items", resource, count))
 }
 
 func Read(ctx context.Context, resource string, v ...any) {


### PR DESCRIPTION
Adds debug logging to existing migrated data sources:

```
Reading environments with query {IDs:[] Name: PartialName:env Skip:0 Take:30}
Reading environments data source returned 27 items
```