### PR TITLE
Fix the tenants datasource blocks

### DIFF
--- a/docs/data-sources/tenants.md
+++ b/docs/data-sources/tenants.md
@@ -31,9 +31,9 @@ Provides information about existing tenants.
 ### Read-Only
 
 - `id` (String) The unique ID for this resource.
-- `tenants` (Block List) A list of tenants that match the filter(s). (see [below for nested schema](#nestedblock--tenants))
+- `tenants` (Attributes List) (see [below for nested schema](#nestedatt--tenants))
 
-<a id="nestedblock--tenants"></a>
+<a id="nestedatt--tenants"></a>
 ### Nested Schema for `tenants`
 
 Read-Only:

--- a/octopusdeploy_framework/datasource_tenants.go
+++ b/octopusdeploy_framework/datasource_tenants.go
@@ -31,14 +31,6 @@ func (*tenantsDataSource) Schema(_ context.Context, req datasource.SchemaRequest
 	resp.Schema = datasourceSchema.Schema{
 		Description: "Provides information about existing tenants.",
 		Attributes:  schemas.GetTenantsDataSourceSchema(),
-		Blocks: map[string]datasourceSchema.Block{
-			"tenants": datasourceSchema.ListNestedBlock{
-				Description: "A list of tenants that match the filter(s).",
-				NestedObject: datasourceSchema.NestedBlockObject{
-					Attributes: schemas.GetTenantDataSourceSchema(),
-				},
-			},
-		},
 	}
 }
 

--- a/octopusdeploy_framework/schemas/tenant.go
+++ b/octopusdeploy_framework/schemas/tenant.go
@@ -90,6 +90,13 @@ func GetTenantsDataSourceSchema() map[string]datasourceSchema.Attribute {
 		"tags":     util.GetQueryDatasourceTags(),
 		"space_id": GetSpaceIdDatasourceSchema("tenants", false),
 		"take":     util.GetQueryTakeDatasourceSchema(),
+		"tenants": datasourceSchema.ListNestedAttribute{
+			Computed: true,
+			Optional: false,
+			NestedObject: datasourceSchema.NestedAttributeObject{
+				Attributes: GetTenantDataSourceSchema(),
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
Given the following configuration, which forces a [deferred read](https://developer.hashicorp.com/terraform/language/data-sources#data-source-lifecycle):

```
terraform {

  required_providers {
    octopusdeploy = { source = "OctopusDeployLabs/octopusdeploy", version = "0.30.0-beta6" }
    external = {
      source = "hashicorp/external"
      version = "2.3.3"
    }
  }

  required_version = ">= 1.6.0"
}


provider "external" {
  # Configuration options
}



provider "octopusdeploy" {
  address  = "${trimspace(var.octopus_server)}"
  api_key  = "${trimspace(var.octopus_apikey)}"
  space_id = "${trimspace(var.octopus_space_id)}"
}

variable "octopus_server" {
  type        = string
  nullable    = false
  sensitive   = false
  description = "The URL of the Octopus server e.g. https://myinstance.octopus.app."
}
variable "octopus_apikey" {
  type        = string
  nullable    = false
  sensitive   = true
  description = "The API key used to access the Octopus server. See https://octopus.com/docs/octopus-rest-api/how-to-create-an-api-key for details on creating an API key."
}
variable "octopus_space_id" {
  type        = string
  nullable    = false
  sensitive   = false
  description = "The ID of the Octopus space to populate."
}

resource "octopusdeploy_space" "octopus_space_new" {
  name                        = "MyTestSpace"
  is_default                  = false
  is_task_queue_stopped       = false
  space_managers_team_members = null
  space_managers_teams        = ["Teams-41"]
}

variable "TP_CLIENT" {}

# The space ID is technically known as it is always "Spaces-282". However, we do reference
# the ID of the newly created space, which can not be known at plan time, so this forces
# a deferred read.
data "octopusdeploy_tenants" "tp_partners" {
  tags     = ["TPClients/${var.TP_CLIENT}"]
  take     = 1
  skip     = 0
  space_id = octopusdeploy_space.octopus_space_new.id
}

data "external" "example_deferred_read" {
  program = ["pwsh", "-Command", "echo @{\"Key\"=\"Value\"} | ConvertTo-Json"]

  query = {    
    space_id = octopusdeploy_space.octopus_space_new.id
  }
}

data "external" "example" {
  program = ["pwsh",  "-Command", "echo @{\"Key\"=\"Value\"} | ConvertTo-Json"]

  query = {    
   
  }
}


output "tp_partners" {
  value = data.octopusdeploy_tenants.tp_partners
}

output "example_deferred_read" {
  value = data.external.example_deferred_read
}

output "external_data" {
  value = data.external.example
}
```

The output of a plan command like `terraform plan -var=octopus_server=https://mattc.octopus.app -var=octopus_apikey=API-xxxxx -var=octopus_space_id=Spaces-282` is this:

```
Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + example_deferred_read = {
      + id          = (known after apply)
      + program     = [
          + "pwsh",
          + "-Command",
          + "echo @{\"Key\"=\"Value\"} | ConvertTo-Json",
        ]
      + query       = {
          + space_id = (known after apply)
        }
      + result      = (known after apply)
      + working_dir = null
    }
  + external_data         = {
      + id          = "-"
      + program     = [
          + "pwsh",
          + "-Command",
          + "echo @{\"Key\"=\"Value\"} | ConvertTo-Json",
        ]
      + query       = {}
      + result      = {
          + Key = "Value"
        }
      + working_dir = null
    }
  + tp_partners           = {
      + cloned_from_tenant_id = null
      + id                    = (known after apply)
      + ids                   = null
      + is_clone              = null
      + name                  = null
      + partial_name          = null
      + project_id            = null
      + skip                  = 0
      + space_id              = (known after apply)
      + tags                  = [
          + "TPClients/k",
        ]
      + take                  = 1
      + tenants               = []
    }
```

Note the output `tenants               = []`. This is incorrect as the list of tenants must not be empty but rather deferred.

This PR uses the migration strategy documented [here](https://developer.hashicorp.com/terraform/plugin/framework/migrating/attributes-blocks/blocks-computed#framework) to define a computed block on a data source.

The end result of planning this change is this:

```
Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + example_deferred_read = {
      + id          = (known after apply)
      + program     = [
          + "pwsh",
          + "-Command",
          + "echo @{\"Key\"=\"Value\"} | ConvertTo-Json",
        ]
      + query       = {
          + space_id = (known after apply)
        }
      + result      = (known after apply)
      + working_dir = null
    }
  + external_data         = {
      + id          = "-"
      + program     = [
          + "pwsh",
          + "-Command",
          + "echo @{\"Key\"=\"Value\"} | ConvertTo-Json",
        ]
      + query       = {}
      + result      = {
          + Key = "Value"
        }
      + working_dir = null
    }
  + tp_partners           = {
      + cloned_from_tenant_id = null
      + id                    = (known after apply)
      + ids                   = null
      + is_clone              = null
      + name                  = null
      + partial_name          = null
      + project_id            = null
      + skip                  = 0
      + space_id              = (known after apply)
      + tags                  = [
          + "TPClients/a",
        ]
      + take                  = 1
      + tenants               = (known after apply)
    }
```

Note `tenants               = (known after apply)`. This is the correct behaviour.

Note I have only fixed one data source in this PR - all other data sources will need to be updated to implement this change.