### PR TITLE
fix: correct space id support for creating variables

### DIFF
--- a/migration-readme.md
+++ b/migration-readme.md
@@ -161,7 +161,10 @@ func (b *blahResource) Create(ctx context.Context, request resource.CreateReques
     newResource := ...
 
     // call client for create
-    blah := blahResources.Add(b.Client, util.GetSpace(), newResource)
+	// the space id here should come from the plan. 
+	// If the user doesn't provide a space_id on the plan, this will return an empty string, which the client will replace with the 
+	// space_id configured on the provider, otherwise the API will assume the default space.
+    blah := blahResources.Add(b.Client, plan.SpaceID.ValueString(), newResource)
 
     // map result to state
     plan.Name := types.StringValue(blah.Name)

--- a/octopusdeploy_framework/resource_variable.go
+++ b/octopusdeploy_framework/resource_variable.go
@@ -90,7 +90,7 @@ func (r *variableTypeResource) Create(ctx context.Context, req resource.CreateRe
 
 	tflog.Info(ctx, fmt.Sprintf("creating variable: %#v", newVariable))
 
-	variableSet, err := variables.AddSingle(r.Config.Client, r.Config.SpaceID, variableOwnerId.ValueString(), newVariable)
+	variableSet, err := variables.AddSingle(r.Config.Client, data.SpaceID.ValueString(), variableOwnerId.ValueString(), newVariable)
 	if err != nil {
 		resp.Diagnostics.AddError("create variable failed", err.Error())
 		return


### PR DESCRIPTION
fixes #771 

before: 
```
Plan: 1 to add, 0 to change, 0 to destroy.
octopusdeploy_variable.string: Creating...
╷
│ Error: create variable failed
│ 
│   with octopusdeploy_variable.string,
│   on main.tf line 31, in resource "octopusdeploy_variable" "string":
│   31: resource "octopusdeploy_variable" "string" {
│ 
│ Octopus API error: Resource is not found or it doesn't exist in the current space context. Please contact your administrator for more information. [] 
```

after:
```
Plan: 1 to add, 0 to change, 0 to destroy.
octopusdeploy_variable.string: Creating...
octopusdeploy_variable.string: Creation complete after 0s [id=9e0fcce6-1fe3-4fe3-a8ab-7455247be95d]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```