### PR TITLE
fix: read the space id from the plan rather than the state for a variable

### DIFF
--- a/docs/resources/variable.md
+++ b/docs/resources/variable.md
@@ -104,7 +104,6 @@ resource "octopusdeploy_variable" "prompted_variable" {
 - `is_editable` (Boolean) Indicates whether or not this variable is considered editable.
 - `is_sensitive` (Boolean) Indicates whether or not this resource is considered sensitive and should be kept secret.
 - `owner_id` (String)
-- `pgp_key` (String, Sensitive)
 - `project_id` (String, Deprecated)
 - `prompt` (Block List) (see [below for nested schema](#nestedblock--prompt))
 - `scope` (Block List) (see [below for nested schema](#nestedblock--scope))
@@ -114,9 +113,7 @@ resource "octopusdeploy_variable" "prompted_variable" {
 
 ### Read-Only
 
-- `encrypted_value` (String)
 - `id` (String) The unique ID for this resource.
-- `key_fingerprint` (String)
 
 <a id="nestedblock--prompt"></a>
 ### Nested Schema for `prompt`

--- a/octopusdeploy_framework/resource_variable.go
+++ b/octopusdeploy_framework/resource_variable.go
@@ -270,6 +270,7 @@ func validateVariable(variableSet *variables.VariableSet, newVariable *variables
 }
 
 func mapVariableToState(data *schemas.VariableTypeResourceModel, variable *variables.Variable) {
+	data.SpaceID = types.StringValue(variable.SpaceID)
 	data.Name = types.StringValue(variable.Name)
 	data.Description = types.StringValue(variable.Description)
 	if !data.IsEditable.IsNull() {
@@ -295,7 +296,9 @@ func mapVariableToState(data *schemas.VariableTypeResourceModel, variable *varia
 		)
 	}
 
-	if !data.Scope.IsNull() {
+	if variable.Scope.IsEmpty() {
+		data.Scope = types.ListNull(types.ObjectType{AttrTypes: schemas.VariableScopeObjectType()})
+	} else {
 		data.Scope = types.ListValueMust(
 			types.ObjectType{AttrTypes: schemas.VariableScopeObjectType()},
 			[]attr.Value{schemas.MapFromVariableScope(variable.Scope)},

--- a/octopusdeploy_framework/resource_variable.go
+++ b/octopusdeploy_framework/resource_variable.go
@@ -141,41 +141,41 @@ func (r *variableTypeResource) Update(ctx context.Context, req resource.UpdateRe
 	internal.Mutex.Lock()
 	defer internal.Mutex.Unlock()
 
-	var data, state schemas.VariableTypeResourceModel
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	var plan, state schemas.VariableTypeResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	tflog.Info(ctx, fmt.Sprintf("updating variable (%s)", data.ID))
+	tflog.Info(ctx, fmt.Sprintf("updating variable (%s)", plan.ID))
 
-	variableOwnerId, err := getVariableOwnerID(&data)
+	variableOwnerId, err := getVariableOwnerID(&plan)
 	if err != nil {
 		resp.Diagnostics.AddError("invalid resource configuration", err.Error())
 		return
 	}
 
-	name := data.Name.ValueString()
+	name := plan.Name.ValueString()
 	updatedVariable := variables.NewVariable(name)
-	updatedVariable.Description = data.Description.ValueString()
-	updatedVariable.IsEditable = data.IsEditable.ValueBool()
-	updatedVariable.IsSensitive = data.IsSensitive.ValueBool()
-	updatedVariable.Type = data.Type.ValueString()
-	updatedVariable.Scope = schemas.MapToVariableScope(data.Scope)
-	updatedVariable.Prompt = schemas.MapToVariablePromptOptions(data.Prompt)
-	updatedVariable.SpaceID = state.SpaceID.ValueString()
+	updatedVariable.Description = plan.Description.ValueString()
+	updatedVariable.IsEditable = plan.IsEditable.ValueBool()
+	updatedVariable.IsSensitive = plan.IsSensitive.ValueBool()
+	updatedVariable.Type = plan.Type.ValueString()
+	updatedVariable.Scope = schemas.MapToVariableScope(plan.Scope)
+	updatedVariable.Prompt = schemas.MapToVariablePromptOptions(plan.Prompt)
+	updatedVariable.SpaceID = plan.SpaceID.ValueString()
 
 	if updatedVariable.IsSensitive {
 		updatedVariable.Type = schemas.VariableTypeNames.Sensitive
-		updatedVariable.Value = data.SensitiveValue.ValueString()
+		updatedVariable.Value = plan.SensitiveValue.ValueString()
 	} else {
-		updatedVariable.Value = data.Value.ValueString()
+		updatedVariable.Value = plan.Value.ValueString()
 	}
 
 	updatedVariable.ID = state.ID.ValueString()
 
-	variableSet, err := variables.UpdateSingle(r.Config.Client, state.SpaceID.ValueString(), variableOwnerId.ValueString(), updatedVariable)
+	variableSet, err := variables.UpdateSingle(r.Config.Client, plan.SpaceID.ValueString(), variableOwnerId.ValueString(), updatedVariable)
 	if err != nil {
 		resp.Diagnostics.AddError("update variable failed", err.Error())
 		return
@@ -187,10 +187,10 @@ func (r *variableTypeResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	tflog.Info(ctx, fmt.Sprintf("variable updated (%s)", data.ID))
+	tflog.Info(ctx, fmt.Sprintf("variable updated (%s)", plan.ID))
 
-	mapVariableToState(&data, updatedVariable)
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	mapVariableToState(&plan, updatedVariable)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
 func (r *variableTypeResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
@@ -270,7 +270,6 @@ func validateVariable(variableSet *variables.VariableSet, newVariable *variables
 }
 
 func mapVariableToState(data *schemas.VariableTypeResourceModel, variable *variables.Variable) {
-	data.SpaceID = types.StringValue(variable.SpaceID)
 	data.Name = types.StringValue(variable.Name)
 	data.Description = types.StringValue(variable.Description)
 	if !data.IsEditable.IsNull() {
@@ -302,9 +301,6 @@ func mapVariableToState(data *schemas.VariableTypeResourceModel, variable *varia
 			[]attr.Value{schemas.MapFromVariableScope(variable.Scope)},
 		)
 	}
-
-	data.EncryptedValue = types.StringNull()
-	data.KeyFingerprint = types.StringNull()
 
 	data.ID = types.StringValue(variable.GetID())
 }

--- a/octopusdeploy_framework/schemas/variable.go
+++ b/octopusdeploy_framework/schemas/variable.go
@@ -9,8 +9,6 @@ import (
 	datasourceSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	resourceSchema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -36,9 +34,6 @@ var VariableSchemaAttributeNames = struct {
 	DisplayName     string
 	IsRequired      string
 	Label           string
-	EncryptedValue  string
-	KeyFingerprint  string
-	PgpKey          string
 }{
 	Prompt:          "prompt",
 	OwnerID:         "owner_id",
@@ -55,9 +50,6 @@ var VariableSchemaAttributeNames = struct {
 	DisplayName:     "display_name",
 	IsRequired:      "is_required",
 	Label:           "label",
-	EncryptedValue:  "encrypted_value",
-	KeyFingerprint:  "key_fingerprint",
-	PgpKey:          "pgp_key",
 }
 
 var VariableTypeNames = struct {
@@ -173,19 +165,6 @@ func (v VariableSchema) GetResourceSchema() resourceSchema.Schema {
 				"Indicates whether or not this resource is considered sensitive and should be kept secret.",
 				false,
 				true),
-			VariableSchemaAttributeNames.KeyFingerprint: resourceSchema.StringAttribute{
-				Computed: true,
-			},
-			VariableSchemaAttributeNames.PgpKey: resourceSchema.StringAttribute{
-				Optional:  true,
-				Sensitive: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
-			},
-			VariableSchemaAttributeNames.EncryptedValue: resourceSchema.StringAttribute{
-				Computed: true,
-			},
 			VariableSchemaAttributeNames.SensitiveValue: resourceSchema.StringAttribute{
 				Optional:  true,
 				Sensitive: true,
@@ -226,9 +205,6 @@ type VariableTypeResourceModel struct {
 	Type           types.String `tfsdk:"type"`
 	SensitiveValue types.String `tfsdk:"sensitive_value"`
 	Value          types.String `tfsdk:"value"`
-	PgpKey         types.String `tfsdk:"pgp_key"`
-	KeyFingerprint types.String `tfsdk:"key_fingerprint"`
-	EncryptedValue types.String `tfsdk:"encrypted_value"`
 	Prompt         types.List   `tfsdk:"prompt"`
 	Scope          types.List   `tfsdk:"scope"`
 	SpaceID        types.String `tfsdk:"space_id"`


### PR DESCRIPTION
fixes #775 

before:
```
# octopusdeploy_variable.string will be updated in-place
  ~ resource "octopusdeploy_variable" "string" {
      + encrypted_value = (known after apply)
        id              = "5a728184-0d52-4039-9897-58a7f6d63791"
      + key_fingerprint = (known after apply)
        name            = "stringvar"
      + space_id        = "Spaces-962"
        # (6 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
octopusdeploy_variable.string: Modifying... [id=5a728184-0d52-4039-9897-58a7f6d63791]
╷
│ Error: update variable failed
│ 
│   with octopusdeploy_variable.string,
│   on main.tf line 31, in resource "octopusdeploy_variable" "string":
│   31: resource "octopusdeploy_variable" "string" {
│ 
│ Octopus API error: Resource is not found or it doesn't exist in the current space context. Please contact your administrator for more information. [] 
╵
```

after:
```
Terraform will perform the following actions:

  # octopusdeploy_variable.string will be updated in-place
  ~ resource "octopusdeploy_variable" "string" {
      + encrypted_value = (known after apply)
        id              = "11f2295a-2f3b-428c-9dc8-36cf911088e4"
      + key_fingerprint = (known after apply)
        name            = "stringvar"
      + space_id        = "Spaces-963"
        # (6 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
octopusdeploy_variable.string: Modifying... [id=11f2295a-2f3b-428c-9dc8-36cf911088e4]
octopusdeploy_variable.string: Modifications complete after 0s [id=11f2295a-2f3b-428c-9dc8-36cf911088e4]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```