### PR TITLE
fix: empty datasource results should be empty arrays

### DIFF
--- a/octopusdeploy_framework/datasource_environments.go
+++ b/octopusdeploy_framework/datasource_environments.go
@@ -69,7 +69,7 @@ func (e *environmentDataSource) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	var mappedEnvironments []schemas.EnvironmentTypeResourceModel
+	mappedEnvironments := []schemas.EnvironmentTypeResourceModel{}
 	if data.Name.IsNull() {
 		tflog.Debug(ctx, fmt.Sprintf("environments returned from API: %#v", existingEnvironments))
 		for _, environment := range existingEnvironments.Items {

--- a/octopusdeploy_framework/datasource_project_groups.go
+++ b/octopusdeploy_framework/datasource_project_groups.go
@@ -90,7 +90,7 @@ func (p *projectGroupsDataSource) Read(ctx context.Context, req datasource.ReadR
 		return
 	}
 
-	var newGroups []schemas.ProjectGroupTypeResourceModel
+	newGroups := []schemas.ProjectGroupTypeResourceModel{}
 	for _, projectGroup := range existingProjectGroups.Items {
 		tflog.Debug(ctx, "loaded group "+projectGroup.Name)
 		var g schemas.ProjectGroupTypeResourceModel

--- a/octopusdeploy_framework/datasource_spaces.go
+++ b/octopusdeploy_framework/datasource_spaces.go
@@ -62,7 +62,7 @@ func (b *spacesDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		return
 	}
 
-	var mappedSpaces []schemas.SpaceModel
+	mappedSpaces := []schemas.SpaceModel{}
 	for _, space := range existingSpaces.Items {
 		var s schemas.SpaceModel
 		mapSpaceToState(ctx, &s, space)

--- a/octopusdeploy_framework/datasource_tag_sets.go
+++ b/octopusdeploy_framework/datasource_tag_sets.go
@@ -60,15 +60,16 @@ func (t *tagSetsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 
 	util.DatasourceResultCount(ctx, "tag sets", len(existingTagSets.Items))
 
-	data.TagSets = flattenTagSets(existingTagSets.Items)
+	data.TagSets = flattenTagSets(ctx, existingTagSets.Items)
 	data.ID = types.StringValue(fmt.Sprintf("TagSets-%s", time.Now().UTC().String()))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func flattenTagSets(tagSets []*tagsets.TagSet) types.List {
+func flattenTagSets(ctx context.Context, tagSets []*tagsets.TagSet) types.List {
 	if len(tagSets) == 0 {
-		return types.ListNull(types.ObjectType{AttrTypes: schemas.GetTagSetAttrTypes()})
+		emptyList, _ := types.ListValueFrom(ctx, types.ObjectType{AttrTypes: schemas.GetTagSetAttrTypes()}, tagSets)
+		return emptyList
 	}
 
 	tfList := make([]attr.Value, len(tagSets))


### PR DESCRIPTION
[sc-92171]

Fixes: https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/issues/779

environments before:
```
  + env_output = {
      + environments = null
      + id           = "Environments 2024-09-10 01:49:17.322748 +0000 UTC"
      + ids          = null
      + name         = null
      + partial_name = "broken"
      + skip         = null
      + space_id     = null
      + take         = null
    }
```

environments after:
```
  + output     = {
      + environments = []
      + id           = "Environments 2024-09-10 02:43:19.719235 +0000 UTC"
      + ids          = null
      + name         = null
      + partial_name = "broken"
      + skip         = null
      + space_id     = "Spaces-982"
      + take         = null
    }
```

tag sets before:
```
  + output     = {
      + id           = "TagSets-2024-09-10 02:33:49.32293 +0000 UTC"
      + ids          = null
      + partial_name = "broken"
      + skip         = null
      + space_id     = null
      + tag_sets     = null
      + take         = null
    }
```

tag sets after:
```
  + output     = {
      + id           = "TagSets-2024-09-10 02:37:56.355514 +0000 UTC"
      + ids          = null
      + partial_name = "broken"
      + skip         = null
      + space_id     = null
      + tag_sets     = []
      + take         = null
    }
```
