### PR TITLE
Variables.GetByID return null variable when api error.

### DIFF
--- a/octopusdeploy_framework/resource_variable.go
+++ b/octopusdeploy_framework/resource_variable.go
@@ -127,8 +127,12 @@ func (r *variableTypeResource) Read(ctx context.Context, req resource.ReadReques
 	variable, err := variables.GetByID(r.Config.Client, data.SpaceID.ValueString(), variableOwnerID.ValueString(), data.ID.ValueString())
 
 	if err != nil {
-		if err := errors.ProcessApiErrorV2(ctx, resp, data, err, schemas.VariableResourceDescription); err != nil {
-			resp.Diagnostics.AddError("unable to load variable", err.Error())
+		apiError := errors.ProcessApiErrorV2(ctx, resp, data, err, schemas.VariableResourceDescription)
+		if apiError != nil {
+			resp.Diagnostics.AddError("unable to load variable", apiError.Error())
+		} else {
+			// If this is a non-API error
+			resp.Diagnostics.AddError(fmt.Sprintf("Error loading %s", schemas.VariableResourceDescription), err.Error())
 		}
 		return
 	}


### PR DESCRIPTION
Variables.GetByID return null variable when api error which cause provider to panic when try to set variable.SpaceId

[Fixes 783](https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/issues/783)