### PR TITLE
fix: log when tenant not associated to common variable template

### DIFF
--- a/octopusdeploy_framework/resource_tenant_common_variable.go
+++ b/octopusdeploy_framework/resource_tenant_common_variable.go
@@ -252,7 +252,7 @@ func checkIfCommonVariableIsSensitive(tenantVariables *variables.TenantVariables
 }
 
 func checkIfCandidateVariableRequiredForTenant(tenant *tenants.Tenant, tenantVariables *variables.TenantVariables, plan tenantCommonVariableResourceModel) error {
-	if tenant.ProjectEnvironments == nil || len(tenant.ProjectEnvironments) == 0 {
+	if len(tenant.ProjectEnvironments) == 0 {
 		return fmt.Errorf("tenant not connected to any projects")
 	}
 

--- a/octopusdeploy_framework/resource_tenant_common_variable.go
+++ b/octopusdeploy_framework/resource_tenant_common_variable.go
@@ -72,6 +72,12 @@ func (t *tenantCommonVariableResource) Create(ctx context.Context, req resource.
 		return
 	}
 
+	tenantNeedsAValueForThisVariable, err := checkIfCandidateVariableRequiredForTenant(tenant, tenantVariables, plan)
+	if !tenantNeedsAValueForThisVariable && err != nil {
+		resp.Diagnostics.AddError("Tenant doesn't need a value for this Common Variable", "Tenants must be connected to a Project with an included Library Variable Set that defines Common Variable templates, before common variable values can be provided ("+err.Error()+")")
+		return
+	}
+
 	isSensitive, err := checkIfCommonVariableIsSensitive(tenantVariables, plan)
 	if err != nil {
 		resp.Diagnostics.AddError("Error checking if variable is sensitive", err.Error())
@@ -243,6 +249,24 @@ func checkIfCommonVariableIsSensitive(tenantVariables *variables.TenantVariables
 		}
 	}
 	return false, fmt.Errorf("unable to find template for tenant variable")
+}
+
+func checkIfCandidateVariableRequiredForTenant(tenant *tenants.Tenant, tenantVariables *variables.TenantVariables, plan tenantCommonVariableResourceModel) (bool, error) {
+	if tenant.ProjectEnvironments == nil || len(tenant.ProjectEnvironments) == 0 {
+		return false, fmt.Errorf("tenant not connected to any projects")
+	}
+
+	if libraryVariable, ok := tenantVariables.LibraryVariables[plan.LibraryVariableSetID.ValueString()]; ok {
+		for _, template := range libraryVariable.Templates {
+			if template.GetID() == plan.TemplateID.ValueString() {
+				return true, nil
+			}
+		}
+	} else {
+		return false, fmt.Errorf("tenant not connected to a project that includes variable set " + plan.LibraryVariableSetID.ValueString())
+	}
+
+	return false, fmt.Errorf("common template " + plan.TemplateID.ValueString() + " not found in variable set " + plan.LibraryVariableSetID.ValueString())
 }
 
 func updateTenantCommonVariable(tenantVariables *variables.TenantVariables, plan tenantCommonVariableResourceModel, isSensitive bool) error {

--- a/octopusdeploy_framework/resource_tenant_common_variable.go
+++ b/octopusdeploy_framework/resource_tenant_common_variable.go
@@ -263,10 +263,10 @@ func checkIfCandidateVariableRequiredForTenant(tenant *tenants.Tenant, tenantVar
 			}
 		}
 	} else {
-		return fmt.Errorf("tenant not connected to a project that includes variable set " + plan.LibraryVariableSetID.ValueString())
+		return fmt.Errorf("tenant not connected to a project that includes variable set %s", plan.LibraryVariableSetID)
 	}
 
-	return fmt.Errorf("common template " + plan.TemplateID.ValueString() + " not found in variable set " + plan.LibraryVariableSetID.ValueString())
+	return fmt.Errorf("common template %s not found in variable set %s", plan.TemplateID, plan.LibraryVariableSetID)
 }
 
 func updateTenantCommonVariable(tenantVariables *variables.TenantVariables, plan tenantCommonVariableResourceModel, isSensitive bool) error {


### PR DESCRIPTION
Add better detection and a better error message when trying to provide a value for a Common Variable Template, but the Tenant has not yet been connected to a Project that includes the Library Set that defines the template.

fixes #790

## How to review
* Detection logic feels pretty unstreamlined and verbose; happy for suggestions on more canonical `golang` or a better approach.
* I don't understand why the compiler warning requries error messages to start with a lower-case, that feels a bit uncivilized to me. Am I doing the error message approach wrong?