### PR TITLE
fix: octopusdeploy_aws_openid_connect_account crash when setting session_duration

### DIFF
--- a/octopusdeploy/schema_amazon_web_services_openid_connect_account.go
+++ b/octopusdeploy/schema_amazon_web_services_openid_connect_account.go
@@ -7,6 +7,7 @@ import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"strconv"
 )
 
 func expandAmazonWebServicesOpenIDConnectAccount(d *schema.ResourceData) *accounts.AwsOIDCAccount {
@@ -53,7 +54,7 @@ func expandAmazonWebServicesOpenIDConnectAccount(d *schema.ResourceData) *accoun
 	}
 
 	if v, ok := d.GetOk("session_duration"); ok {
-		account.SessionDuration = v.(string)
+		account.SessionDuration = strconv.Itoa(v.(int))
 	}
 
 	return account


### PR DESCRIPTION
Value read as int was trying to be cast as string, causes crash.

fixes #629 