### PR TITLE
fix: remove account datasource deprecated message

### DIFF
--- a/octopusdeploy/data_source_accounts.go
+++ b/octopusdeploy/data_source_accounts.go
@@ -12,10 +12,9 @@ import (
 
 func dataSourceAccounts() *schema.Resource {
 	return &schema.Resource{
-		DeprecationMessage: "Use an account-specific resource instead (i.e. octopusdeploy_aws_account, octopusdeploy_azure_service_principal, octopusdeploy_azure_subscription_account, octopusdeploy_ssh_key_account, octopusdeploy_token_account, octopusdeploy_username_password_account).",
-		Description:        "Provides information about existing accounts.",
-		ReadContext:        dataSourceAccountsRead,
-		Schema:             getAccountResourceDataSchema(),
+		Description: "Provides information about existing accounts.",
+		ReadContext: dataSourceAccountsRead,
+		Schema:      getAccountResourceDataSchema(),
 	}
 }
 


### PR DESCRIPTION
This message was only intended for the resource not the datasource. We have no alternative provided.

closes #789 