### PR TITLE
fix: only append SubstituteInFiles to EnabledFeatures if its not there

### DIFF
--- a/octopusdeploy/schema_action_run_script.go
+++ b/octopusdeploy/schema_action_run_script.go
@@ -2,6 +2,7 @@ package octopusdeploy
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/deployments"
@@ -74,7 +75,7 @@ func expandRunScriptAction(flattenedAction map[string]interface{}) *deployments.
 
 		if len(action.Properties["Octopus.Action.EnabledFeatures"].Value) == 0 {
 			action.Properties["Octopus.Action.EnabledFeatures"] = core.NewPropertyValue("Octopus.Features.SubstituteInFiles", false)
-		} else {
+		} else if !strings.Contains(action.Properties["Octopus.Action.EnabledFeatures"].Value, "Octopus.Features.SubstituteInFiles") {
 			actionProperty := action.Properties["Octopus.Action.EnabledFeatures"].Value + ",Octopus.Features.SubstituteInFiles"
 			action.Properties["Octopus.Action.EnabledFeatures"] = core.NewPropertyValue(actionProperty, false)
 		}


### PR DESCRIPTION
Updates deployment action to only add `SubstituteInFiles` to the `EnabledFeatures` when it is not already there.

This will ensure that `SubstituteInFiles` will not be in the `EnabledFeatures` list multiple times when updating the deployment action.

Fixes https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/issues/641