### PR TITLE
fix: respect machine policy id in kubernetes agent deployment target

### DIFF
--- a/octopusdeploy/schema_kubernetes_agent_deployment_target.go
+++ b/octopusdeploy/schema_kubernetes_agent_deployment_target.go
@@ -1,11 +1,12 @@
 package octopusdeploy
 
 import (
+	"net/url"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/machines"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"net/url"
 )
 
 func expandKubernetesAgentDeploymentTarget(kubernetesAgent *schema.ResourceData) *machines.DeploymentTarget {
@@ -29,6 +30,8 @@ func expandKubernetesAgentDeploymentTarget(kubernetesAgent *schema.ResourceData)
 	deploymentTarget.TenantIDs = expandArray(kubernetesAgent.Get("tenants").([]interface{}))
 	deploymentTarget.TenantTags = expandArray(kubernetesAgent.Get("tenant_tags").([]interface{}))
 	deploymentTarget.SpaceID = kubernetesAgent.Get("space_id").(string)
+
+	deploymentTarget.MachinePolicyID = kubernetesAgent.Get("machine_policy_id").(string)
 
 	return deploymentTarget
 }

--- a/octopusdeploy/schema_kubernetes_agent_worker.go
+++ b/octopusdeploy/schema_kubernetes_agent_worker.go
@@ -1,10 +1,11 @@
 package octopusdeploy
 
 import (
+	"net/url"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/machines"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"net/url"
 )
 
 func expandKubernetesAgentWorker(kubernetesAgent *schema.ResourceData) *machines.Worker {
@@ -23,6 +24,8 @@ func expandKubernetesAgentWorker(kubernetesAgent *schema.ResourceData) *machines
 	Worker.WorkerPoolIDs = getSliceFromTerraformTypeList(kubernetesAgent.Get("worker_pool_ids"))
 
 	Worker.SpaceID = kubernetesAgent.Get("space_id").(string)
+
+	Worker.MachinePolicyID = kubernetesAgent.Get("machine_policy_id").(string)
 
 	return Worker
 }


### PR DESCRIPTION
`machine_policy_id` doesn't get set when creating or updating `octopusdeploy_kubernetes_agent_deployment_target`

Fixes https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/issues/806