### PR TITLE
Fix tenant tags producing inconsistent result after apply after updating to plugin framework

### DIFF
--- a/docs/data-sources/tenants.md
+++ b/docs/data-sources/tenants.md
@@ -43,6 +43,6 @@ Read-Only:
 - `id` (String) The unique ID for this resource.
 - `name` (String) The name of this resource.
 - `space_id` (String) The space ID associated with this tenant.
-- `tenant_tags` (List of String) A list of tenant tags associated with this resource.
+- `tenant_tags` (Set of String) A list of tenant tags associated with this resource.
 
 

--- a/docs/resources/tenant.md
+++ b/docs/resources/tenant.md
@@ -21,7 +21,7 @@ This resource manages tenants in Octopus Deploy.
 - `cloned_from_tenant_id` (String) The ID of the tenant from which this tenant was cloned.
 - `description` (String) The description of this tenant.
 - `space_id` (String) The space ID associated with this tenant.
-- `tenant_tags` (List of String) A list of tenant tags associated with this resource.
+- `tenant_tags` (Set of String) A list of tenant tags associated with this resource.
 
 ### Read-Only
 

--- a/octopusdeploy_framework/resource_tenant_migration_test.go
+++ b/octopusdeploy_framework/resource_tenant_migration_test.go
@@ -2,14 +2,15 @@ package octopusdeploy_framework
 
 import (
 	"fmt"
+	"os"
+	"sort"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stretchr/testify/assert"
-	"os"
-	"sort"
-	"testing"
 )
 
 func TestTenantResource_UpgradeFromSDK_ToPluginFramework(t *testing.T) {


### PR DESCRIPTION
**Background**
Our terraform provider creates invalid plans for a lot of the resources because we are using lists that are intended to be ordered. This is fine with other resources, because it is "tolerated because of the legacy plugin SDK".

There has been a recent update on this resource to use the newer terraform framework - and we no longer have this exemption. This PR addresses this.

Fixes https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/issues/802

[sc-97302]