### PR TITLE
Add admin_login attribute to azure authentication block

### DIFF
--- a/docs/data-sources/kubernetes_cluster_deployment_targets.md
+++ b/docs/data-sources/kubernetes_cluster_deployment_targets.md
@@ -110,6 +110,7 @@ Read-Only:
 Read-Only:
 
 - `account_id` (String)
+- `admin_login` (String)
 - `cluster_name` (String)
 - `cluster_resource_group` (String)
 

--- a/docs/resources/kubernetes_cluster_deployment_target.md
+++ b/docs/resources/kubernetes_cluster_deployment_target.md
@@ -109,6 +109,10 @@ Required:
 - `cluster_name` (String)
 - `cluster_resource_group` (String)
 
+Optional:
+
+- `admin_login` (String)
+
 
 <a id="nestedblock--certificate_authentication"></a>
 ### Nested Schema for `certificate_authentication`

--- a/octopusdeploy/schema_kubernetes_azure_authentication.go
+++ b/octopusdeploy/schema_kubernetes_azure_authentication.go
@@ -14,6 +14,8 @@ func expandKubernetesAzureAuthentication(values interface{}) *machines.Kubernete
 	authentication.AuthenticationType = "KubernetesAzure"
 	authentication.ClusterName = flattenedAuthentication["cluster_name"].(string)
 	authentication.ClusterResourceGroup = flattenedAuthentication["cluster_resource_group"].(string)
+	authentication.AdminLogin = flattenedAuthentication["admin_login"].(string)
+
 	return authentication
 }
 
@@ -26,6 +28,7 @@ func flattenKubernetesAzureAuthentication(kubernetesAzureAuthentication *machine
 		"account_id":             kubernetesAzureAuthentication.AccountID,
 		"cluster_name":           kubernetesAzureAuthentication.ClusterName,
 		"cluster_resource_group": kubernetesAzureAuthentication.ClusterResourceGroup,
+		"admin_login":            kubernetesAzureAuthentication.AdminLogin,
 	}}
 }
 
@@ -41,6 +44,10 @@ func getKubernetesAzureAuthenticationSchema() map[string]*schema.Schema {
 		},
 		"cluster_resource_group": {
 			Required: true,
+			Type:     schema.TypeString,
+		},
+		"admin_login": {
+			Optional: true,
 			Type:     schema.TypeString,
 		},
 	}


### PR DESCRIPTION
Affected resource: `octopusdeploy_kubernetes_cluster_deployment_target`
`admin_login` attribute is specific to `azure_service_principal_authentication`, but available only on endpoint's authentication block, which is flattened representation of different authentication types, and not getting mapped to the azure authentication.

This PR adds new attribute `admin_login` to `azure_service_principal_authentication`.

Fixes: https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/issues/341