### PR TITLE
Quoted provider value

### DIFF
--- a/docs/guides/2-provider-configuration.md
+++ b/docs/guides/2-provider-configuration.md
@@ -15,7 +15,7 @@ subcategory: "Guides"
 terraform {
     required_providers {
         octopusdeploy = {
-            source = OctopusDeployLabs/octopusdeploy
+            source = "OctopusDeployLabs/octopusdeploy"
         }
     }
 }
@@ -39,7 +39,7 @@ The environment variable fallback values that the Terraform Provider search for 
 terraform {
     required_providers {
         octopusdeploy = {
-            source = OctopusDeployLabs/octopusdeploy
+            source = "OctopusDeployLabs/octopusdeploy"
         }
     }
 }

--- a/templates/guides/2-provider-configuration.md.tmpl
+++ b/templates/guides/2-provider-configuration.md.tmpl
@@ -15,7 +15,7 @@ subcategory: "Guides"
 terraform {
     required_providers {
         octopusdeploy = {
-            source = OctopusDeployLabs/octopusdeploy
+            source = "OctopusDeployLabs/octopusdeploy"
         }
     }
 }
@@ -39,7 +39,7 @@ The environment variable fallback values that the Terraform Provider search for 
 terraform {
     required_providers {
         octopusdeploy = {
-            source = OctopusDeployLabs/octopusdeploy
+            source = "OctopusDeployLabs/octopusdeploy"
         }
     }
 }


### PR DESCRIPTION
When I used the example I got:

```
│ Error: Invalid source
│
│   on main.tf line 4, in terraform:
│    4:       source = OctopusDeployLabs/octopusdeploy
│
│ Source must be specified as a string.
```

It seems in most other places it's already quoted.