### PR TITLE
DO NOT MERGE: chore: convert team resource to TF framework 

### DIFF
--- a/octopusdeploy/provider.go
+++ b/octopusdeploy/provider.go
@@ -62,9 +62,8 @@ func Provider() *schema.Provider {
 			"octopusdeploy_ssh_connection_deployment_target":               resourceSSHConnectionDeploymentTarget(),
 			"octopusdeploy_ssh_key_account":                                resourceSSHKeyAccount(),
 			"octopusdeploy_static_worker_pool":                             resourceStaticWorkerPool(),
-			//"octopusdeploy_team":                                           resourceTeam(),
-			"octopusdeploy_token_account": resourceTokenAccount(),
-			"octopusdeploy_user_role":     resourceUserRole(),
+			"octopusdeploy_token_account":                                  resourceTokenAccount(),
+			"octopusdeploy_user_role":                                      resourceUserRole(),
 		},
 		Schema: map[string]*schema.Schema{
 			"address": {

--- a/octopusdeploy/provider.go
+++ b/octopusdeploy/provider.go
@@ -27,7 +27,7 @@ func Provider() *schema.Provider {
 			"octopusdeploy_offline_package_drop_deployment_targets":         dataSourceOfflinePackageDropDeploymentTargets(),
 			"octopusdeploy_polling_tentacle_deployment_targets":             dataSourcePollingTentacleDeploymentTargets(),
 			"octopusdeploy_ssh_connection_deployment_targets":               dataSourceSSHConnectionDeploymentTargets(),
-			
+
 			"octopusdeploy_user_roles":   dataSourceUserRoles(),
 			"octopusdeploy_worker_pools": dataSourceWorkerPools(),
 		},
@@ -62,9 +62,9 @@ func Provider() *schema.Provider {
 			"octopusdeploy_ssh_connection_deployment_target":               resourceSSHConnectionDeploymentTarget(),
 			"octopusdeploy_ssh_key_account":                                resourceSSHKeyAccount(),
 			"octopusdeploy_static_worker_pool":                             resourceStaticWorkerPool(),
-			"octopusdeploy_team":                                           resourceTeam(),
-			"octopusdeploy_token_account":                                  resourceTokenAccount(),
-			"octopusdeploy_user_role":                                      resourceUserRole(),
+			//"octopusdeploy_team":                                           resourceTeam(),
+			"octopusdeploy_token_account": resourceTokenAccount(),
+			"octopusdeploy_user_role":     resourceUserRole(),
 		},
 		Schema: map[string]*schema.Schema{
 			"address": {

--- a/octopusdeploy/provider.go
+++ b/octopusdeploy/provider.go
@@ -27,9 +27,9 @@ func Provider() *schema.Provider {
 			"octopusdeploy_offline_package_drop_deployment_targets":         dataSourceOfflinePackageDropDeploymentTargets(),
 			"octopusdeploy_polling_tentacle_deployment_targets":             dataSourcePollingTentacleDeploymentTargets(),
 			"octopusdeploy_ssh_connection_deployment_targets":               dataSourceSSHConnectionDeploymentTargets(),
-			"octopusdeploy_teams":                                           dataSourceTeams(),
-			"octopusdeploy_user_roles":                                      dataSourceUserRoles(),
-			"octopusdeploy_worker_pools":                                    dataSourceWorkerPools(),
+			
+			"octopusdeploy_user_roles":   dataSourceUserRoles(),
+			"octopusdeploy_worker_pools": dataSourceWorkerPools(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"octopusdeploy_aws_account":                                    resourceAmazonWebServicesAccount(),

--- a/octopusdeploy_framework/data_source_teams.go
+++ b/octopusdeploy_framework/data_source_teams.go
@@ -1,0 +1,87 @@
+package octopusdeploy_framework
+
+import (
+	"context"
+	"fmt"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/teams"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"time"
+)
+
+type teamDataSource struct {
+	*Config
+}
+
+type teamsDataSourceModel struct {
+	ID            types.String                      `tfsdk:"id"`
+	IDs           types.List                        `tfsdk:"ids"`
+	IncludeSystem types.Bool                        `tfsdk:"include_system"`
+	PartialName   types.String                      `tfsdk:"partial_name"`
+	Spaces        types.List                        `tfsdk:"spaces"`
+	Skip          types.Int64                       `tfsdk:"skip"`
+	Take          types.Int64                       `tfsdk:"take"`
+	Teams         []schemas.TeamTypeDatasourceModel `tfsdk:"teams"`
+}
+
+var _ datasource.DataSource = &teamDataSource{}
+
+func NewTeamsDataSource() datasource.DataSource {
+	return &teamDataSource{}
+}
+
+func (t *teamDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = util.GetTypeName("teams")
+}
+
+func (t *teamDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schemas.TeamSchema{}.GetDatasourceSchema()
+}
+
+func (t *teamDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	t.Config = DataSourceConfiguration(req, resp)
+}
+
+func (t *teamDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var err error
+	var data teamsDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	query := teams.TeamsQuery{
+		IDs:           util.GetIds(data.IDs),
+		IncludeSystem: data.IncludeSystem.ValueBool(),
+		PartialName:   data.PartialName.ValueString(),
+		Spaces:        util.ExpandStringList(data.Spaces),
+		Skip:          util.GetNumber(data.Skip),
+		Take:          util.GetNumber(data.Take),
+	}
+
+	util.DatasourceReading(ctx, "teams", query)
+
+	existingTeams, err := t.Client.Teams.Get(query)
+
+	if err != nil {
+		diag.FromErr(err)
+		return
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("users returned from API: %#v", existingTeams))
+
+	data.Teams = make([]schemas.TeamTypeDatasourceModel, 0, len(existingTeams.Items))
+	for _, team := range existingTeams.Items {
+		data.Teams = append(data.Teams, schemas.MapToTeamsDatasourceModel(team))
+	}
+
+	util.DatasourceResultCount(ctx, "teams", len(data.Teams))
+
+	data.ID = types.StringValue("Teams " + time.Now().UTC().String())
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/octopusdeploy_framework/framework_provider.go
+++ b/octopusdeploy_framework/framework_provider.go
@@ -86,6 +86,7 @@ func (p *octopusDeployFrameworkProvider) DataSources(ctx context.Context) []func
 		NewUsersDataSource,
 		NewServiceAccountOIDCIdentityDataSource,
 		NewWorkersDataSource,
+		NewTeamsDataSource,
 	}
 }
 

--- a/octopusdeploy_framework/framework_provider.go
+++ b/octopusdeploy_framework/framework_provider.go
@@ -127,6 +127,7 @@ func (p *octopusDeployFrameworkProvider) Resources(ctx context.Context) []func()
 		NewScriptModuleResource,
 		NewUserResource,
 		NewServiceAccountOIDCIdentity,
+		NewTeamResource,
 	}
 }
 

--- a/octopusdeploy_framework/resource_team.go
+++ b/octopusdeploy_framework/resource_team.go
@@ -1,0 +1,317 @@
+package octopusdeploy_framework
+
+import (
+	"context"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/teams"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/userroles"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/users"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/internal/errors"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"log"
+)
+
+var _ resource.ResourceWithImportState = &teamTypeResource{}
+
+type teamTypeResource struct {
+	*Config
+}
+
+func NewTeamResource() resource.Resource { return &teamTypeResource{} }
+
+func (r *teamTypeResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = util.GetTypeName("team")
+}
+
+func (r *teamTypeResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schemas.TeamSchema{}.GetResourceSchema()
+}
+
+func (r *teamTypeResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	r.Config = ResourceConfiguration(req, resp)
+}
+
+func (r *teamTypeResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func (r *teamTypeResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data schemas.TeamTypeResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	newTeam := teams.NewTeam(data.Name.ValueString())
+	newTeam.CanBeDeleted = data.CanBeDeleted.ValueBool()
+	newTeam.CanBeRenamed = data.CanBeRenamed.ValueBool()
+	newTeam.CanChangeMembers = data.CanChangeMembers.ValueBool()
+	newTeam.CanChangeRoles = data.CanChangeRoles.ValueBool()
+	newTeam.Description = data.Description.ValueString()
+	newTeam.SpaceID = data.SpaceId.ValueString()
+	newTeam.Description = data.Description.ValueString()
+
+	var userIds []string
+	data.Users.ElementsAs(ctx, &userIds, false)
+
+	newTeam.MemberUserIDs = userIds                                                        // TODO: Verify this is correct
+	newTeam.ExternalSecurityGroups = mapExternalSecurityGroup(data.ExternalSecurityGroups) // TODO: Verify this is correct
+
+	team, err := r.Config.Client.Teams.Add(newTeam)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to create team", err.Error())
+		return
+	}
+
+	// Octopus doesn't allow creating inactive users. To mimic creating an inactive user, we need to update the newly created user.
+	//if !data.IsActive.ValueBool() {
+	//	user.IsActive = data.IsActive.ValueBool()
+	//	user, err = users.Update(r.Config.Client, user)
+	//}
+
+	err = resourceTeamUpdateUserRoles(r.Client, ctx, data, team)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to create roles", err.Error())
+		return
+	}
+
+	roles := data.UserRole
+	data = schemas.MapToTeamsResourceModel(team)
+
+	data.UserRole = roles
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func resourceTeamUpdateUserRoles(client *client.Client, ctx context.Context, d schemas.TeamTypeResourceModel, team *teams.Team) error {
+	log.Printf("[INFO] updating team user roles (%s)", d.ID)
+	//if d.UserRole.Equal(team.UserRoles) {
+	//	log.Printf("[INFO] user role has changes (%s)", d.ID)
+	//	o, n := d.GetChange("user_role")
+	//	if o == nil {
+	//		o = new(schema.Set)
+	//	}
+	//	if n == nil {
+	//		n = new(schema.Set)
+	//	}
+	//
+	//	os := o.(*schema.Set)
+	//	ns := n.(*schema.Set)
+	//	remove := expandUserRoles(team, os.Difference(ns).List())
+	//	add := expandUserRoles(team, ns.Difference(os).List())
+	//
+	//	if len(remove) > 0 || len(add) > 0 {
+	//		log.Printf("[INFO] user role found diff (%s)", d.ID)
+	//		//client := m.(*client.Client)
+	//		if len(remove) > 0 {
+	//			log.Printf("[INFO] removing user roles from team (%s)", d.ID)
+	//			for _, userRole := range remove {
+	//				if userRole.ID != "" {
+	//					err := client.ScopedUserRoles.DeleteByID(userRole.ID)
+	//					if err != nil {
+	//						apiError := err.(*core.APIError)
+	//						if apiError.StatusCode != 404 {
+	//							// It's already been deleted, maybe mixing with the independent resource?
+	//							return fmt.Errorf("error removing user role %s from team %s: %s", userRole.ID, team.ID, err)
+	//						}
+	//					}
+	//				}
+	//			}
+	//		}
+	//		if len(add) > 0 {
+	//			log.Printf("[INFO] adding new user roles to team (%s)", d.ID)
+	//			for _, userRole := range add {
+	//				_, err := client.ScopedUserRoles.Add(userRole)
+	//				if err != nil {
+	//					return fmt.Errorf("error creating user role for team %s: %s", team.ID, err)
+	//				}
+	//			}
+	//		}
+	//	}
+	//}
+	return nil
+}
+
+func expandUserRoles(team *teams.Team, userRoles []interface{}) []*userroles.ScopedUserRole {
+	values := make([]*userroles.ScopedUserRole, 0, len(userRoles))
+	for _, rawUserRole := range userRoles {
+		userRole := rawUserRole.(map[string]interface{})
+		scopedUserRole := userroles.NewScopedUserRole(userRole["user_role_id"].(string))
+		scopedUserRole.TeamID = team.ID
+		scopedUserRole.SpaceID = userRole["space_id"].(string)
+
+		if v, ok := userRole["id"]; ok {
+			scopedUserRole.ID = v.(string)
+		} else {
+			scopedUserRole.ID = ""
+		}
+
+		if v, ok := userRole["environment_ids"]; ok {
+			scopedUserRole.EnvironmentIDs = getSliceFromTerraformTypeList(v)
+		}
+
+		if v, ok := userRole["project_group_ids"]; ok {
+			scopedUserRole.ProjectGroupIDs = getSliceFromTerraformTypeList(v)
+		}
+
+		if v, ok := userRole["project_ids"]; ok {
+			scopedUserRole.ProjectIDs = getSliceFromTerraformTypeList(v)
+		}
+
+		if v, ok := userRole["tenant_ids"]; ok {
+			scopedUserRole.TenantIDs = getSliceFromTerraformTypeList(v)
+		}
+		values = append(values, scopedUserRole)
+	}
+	return values
+}
+
+func getSliceFromTerraformTypeList(list interface{}) []string {
+	if list == nil {
+		return nil
+	}
+
+	if v, ok := list.([]string); ok {
+		return v
+	}
+
+	terraformList, ok := list.([]interface{})
+	if !ok {
+		terraformSet, ok := list.(*schema.Set)
+		if ok {
+			terraformList = terraformSet.List()
+		} else {
+			// It's not a list or set type
+			return nil
+		}
+	}
+	var newSlice []string
+	for _, v := range terraformList {
+		if v != nil {
+			newSlice = append(newSlice, v.(string))
+		}
+	}
+	return newSlice
+}
+
+//func mapIdentities(identities types.Set) []users.Identity {
+//	result := make([]users.Identity, 0, len(identities.Elements()))
+//	for _, identityElem := range identities.Elements() {
+//		identityObj := identityElem.(types.Object)
+//		identityAttrs := identityObj.Attributes()
+//
+//		identity := users.Identity{}
+//		if v, ok := identityAttrs["provider"].(types.String); ok && !v.IsNull() {
+//			identity.IdentityProviderName = v.ValueString()
+//		}
+//
+//		if v, ok := identityAttrs["claim"].(types.Set); ok && !v.IsNull() {
+//			identity.Claims = mapIdentityClaims(v)
+//		}
+//		result = append(result, identity)
+//	}
+//
+//	return result
+//}
+
+func mapExternalSecurityGroup(externalSecurityGroups types.List) []core.NamedReferenceItem {
+	expandedExternalSecurityGroups := make([]core.NamedReferenceItem, 0, len(externalSecurityGroups.Elements()))
+	for _, externalSecurityGroupElem := range externalSecurityGroups.Elements() {
+		groupObj := externalSecurityGroupElem.(types.Object)
+		groupAttrs := groupObj.Attributes()
+
+		group := core.NamedReferenceItem{}
+
+		if v, ok := groupAttrs["display_id_and_name"].(types.Bool); ok && !v.IsNull() {
+			group.DisplayIDAndName = v.ValueBool()
+		}
+
+		if v, ok := groupAttrs["display_name"].(types.String); ok && !v.IsNull() {
+			group.DisplayName = v.ValueString()
+		}
+
+		if v, ok := groupAttrs["id"].(types.String); ok && !v.IsNull() {
+			group.ID = v.ValueString()
+		}
+
+		expandedExternalSecurityGroups = append(expandedExternalSecurityGroups, group)
+	}
+	return expandedExternalSecurityGroups
+}
+
+func (r *teamTypeResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data schemas.TeamTypeResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	team, err := r.Client.Teams.GetByID(data.ID.ValueString())
+	if err != nil {
+		if err := errors.ProcessApiErrorV2(ctx, resp, data, err, "team"); err != nil {
+			resp.Diagnostics.AddError("unable to load team", err.Error())
+		}
+		return
+	}
+
+	updateTeam(&data, team)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func updateTeam(s *schemas.TeamTypeResourceModel, team *teams.Team) {
+
+}
+
+func (r *teamTypeResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data, state schemas.UserTypeResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	user, err := users.GetByID(r.Config.Client, data.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("unable to load user", err.Error())
+		return
+	}
+
+	updatedUser := users.NewUser(data.Username.ValueString(), data.DisplayName.ValueString())
+	updatedUser.ID = user.ID
+	updatedUser.Password = data.Password.ValueString()
+	updatedUser.EmailAddress = data.EmailAddress.ValueString()
+	updatedUser.IsActive = data.IsActive.ValueBool()
+	updatedUser.IsRequestor = data.IsRequestor.ValueBool()
+	updatedUser.IsService = data.IsService.ValueBool()
+	if len(data.Identity.Elements()) > 0 {
+		updatedUser.Identities = mapIdentities(data.Identity)
+	}
+
+	updatedUser, err = users.Update(r.Config.Client, updatedUser)
+	if err != nil {
+		resp.Diagnostics.AddError("unable to update user", err.Error())
+		return
+	}
+
+	updateUser(&data, updatedUser)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *teamTypeResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data schemas.TeamTypeResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.Client.Teams.DeleteByID(data.ID.ValueString()); err != nil {
+		resp.Diagnostics.AddError("unable to delete team", err.Error())
+		return
+	}
+}

--- a/octopusdeploy_framework/schemas/team.go
+++ b/octopusdeploy_framework/schemas/team.go
@@ -7,7 +7,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	datasourceSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	resourceSchema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -20,30 +23,32 @@ func (l TeamSchema) GetResourceSchema() resourceSchema.Schema {
 	return resourceSchema.Schema{
 		Description: "This resource manages lifecycles in Octopus Deploy.",
 		Attributes: map[string]resourceSchema.Attribute{
-			"can_be_deleted":          util.ResourceBool().Computed().Optional().Build(),
-			"can_be_renamed":          util.ResourceBool().Computed().Optional().Build(),
-			"can_change_members":      util.ResourceBool().Computed().Optional().Build(),
-			"can_change_roles":        util.ResourceBool().Computed().Optional().Build(),
+			"can_be_deleted":          util.ResourceBool().Computed().Optional().PlanModifiers(boolplanmodifier.UseStateForUnknown()).Build(),
+			"can_be_renamed":          util.ResourceBool().Computed().Optional().PlanModifiers(boolplanmodifier.UseStateForUnknown()).Build(),
+			"can_change_members":      util.ResourceBool().Computed().Optional().PlanModifiers(boolplanmodifier.UseStateForUnknown()).Build(),
+			"can_change_roles":        util.ResourceBool().Computed().Optional().PlanModifiers(boolplanmodifier.UseStateForUnknown()).Build(),
 			"description":             util.ResourceString().Optional().Description("The user-friendly description of this team.").Build(),
 			"external_security_group": getExternalSecurityGroupsAttributeResourceSchema(),
-			"id":                      util.ResourceString().Computed().Optional().Description("The unique ID for this resource.").Build(),
+			"id":                      util.ResourceString().Computed().Optional().PlanModifiers(stringplanmodifier.UseStateForUnknown()).Description("The unique ID for this resource.").Build(),
 			"name":                    util.ResourceString().Required().Description("The name of this team.").Build(),
-			"space_id":                util.ResourceString().Computed().Optional().Description("The space associated with this team.").Build(),
-			"users":                   util.ResourceSet(types.StringType).Computed().Optional().Description("A list of user IDs designated to be members of this team.").Build(),
+			"space_id":                util.ResourceString().Computed().Optional().PlanModifiers(stringplanmodifier.UseStateForUnknown()).Description("The space associated with this team.").Build(),
+			"users":                   util.ResourceSet(types.StringType).Computed().Optional().PlanModifiers(setplanmodifier.UseStateForUnknown()).Description("A list of user IDs designated to be members of this team.").Build(),
 		},
 		Blocks: map[string]resourceSchema.Block{
 			"user_role": resourceSchema.SetNestedBlock{
 				Description: "The user roles associated with the team.",
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.UseStateForUnknown(),
+				},
 				NestedObject: resourceSchema.NestedBlockObject{
 					Attributes: map[string]resourceSchema.Attribute{
-						"id": util.ResourceString().Computed().Build(),
-						//"id":                util.ResourceString().Optional().Computed().PlanModifiers(stringplanmodifier.UseStateForUnknown()).Description("The ID of the template parameter.").Build(),
+						"id":                util.ResourceString().Computed().PlanModifiers(stringplanmodifier.UseStateForUnknown()).Build(),
 						"environment_ids":   util.ResourceSet(types.StringType).Optional().Computed().PlanModifiers(setplanmodifier.UseStateForUnknown()).Build(),
-						"project_group_ids": util.ResourceSet(types.StringType).Optional().Computed().PlanModifiers(setplanmodifier.UseStateForUnknown()).Build(),
-						"project_ids":       util.ResourceSet(types.StringType).Optional().Computed().PlanModifiers(setplanmodifier.UseStateForUnknown()).Build(),
+						"project_group_ids": util.ResourceSet(types.StringType).Optional().PlanModifiers(setplanmodifier.UseStateForUnknown()).Build(),
+						"project_ids":       util.ResourceSet(types.StringType).Optional().PlanModifiers(setplanmodifier.UseStateForUnknown()).Build(),
 						"space_id":          util.ResourceString().Required().Build(),
-						"team_id":           util.ResourceString().Computed().Build(),
-						"tenant_ids":        util.ResourceSet(types.StringType).Optional().Computed().PlanModifiers(setplanmodifier.UseStateForUnknown()).Build(),
+						"team_id":           util.ResourceString().Computed().PlanModifiers(stringplanmodifier.UseStateForUnknown()).Build(),
+						"tenant_ids":        util.ResourceSet(types.StringType).Optional().PlanModifiers(setplanmodifier.UseStateForUnknown()).Build(),
 						"user_role_id":      util.ResourceString().Required().Build(),
 					},
 				},

--- a/octopusdeploy_framework/schemas/team.go
+++ b/octopusdeploy_framework/schemas/team.go
@@ -9,6 +9,7 @@ import (
 	resourceSchema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
 var _ EntitySchema = TeamSchema{}
@@ -64,7 +65,7 @@ func getTeamsAttribute() datasourceSchema.ListNestedAttribute {
 				"id":                      util.DataSourceString().Computed().Optional().Description("The unique ID for this resource.").Build(),
 				"name":                    util.DataSourceString().Required().Description("The name of this team.").Build(),
 				"space_id":                util.DataSourceString().Computed().Optional().Description("The space associated with this team.").Build(),
-				"users":                   util.DataSourceList(types.StringType).Computed().Optional().Description("A list of user IDs designated to be members of this team.").Build(),
+				"users":                   util.DataSourceSet(types.StringType).Computed().Optional().Description("A list of user IDs designated to be members of this team.").Build(),
 			},
 		},
 	}
@@ -94,7 +95,7 @@ func MapToTeamsDatasourceModel(t *teams.Team) TeamTypeDatasourceModel {
 	team.ExternalSecurityGroups = MapToExternalSecurityGroupsDatasourceModel(t.ExternalSecurityGroups)
 	team.Name = types.StringValue(t.Name)
 	team.SpaceId = types.StringValue(t.SpaceID)
-	team.Users = util.FlattenStringList(t.MemberUserIDs)
+	team.Users = basetypes.SetValue(util.FlattenStringList(t.MemberUserIDs))
 
 	team.ID = types.StringValue(t.ID)
 	return team
@@ -131,7 +132,7 @@ type TeamTypeDatasourceModel struct {
 	ExternalSecurityGroups types.List   `tfsdk:"external_security_group"`
 	Name                   types.String `tfsdk:"name"`
 	SpaceId                types.String `tfsdk:"space_id"`
-	Users                  types.List   `tfsdk:"users"`
+	Users                  types.Set    `tfsdk:"users"`
 	ResourceModel
 }
 

--- a/octopusdeploy_framework/schemas/team.go
+++ b/octopusdeploy_framework/schemas/team.go
@@ -1,0 +1,143 @@
+package schemas
+
+import (
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/teams"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	datasourceSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	resourceSchema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ EntitySchema = TeamSchema{}
+
+type TeamSchema struct{}
+
+func (l TeamSchema) GetResourceSchema() resourceSchema.Schema {
+	return resourceSchema.Schema{
+		Description: "This resource manages lifecycles in Octopus Deploy.",
+		Attributes: map[string]resourceSchema.Attribute{
+			"id":          GetIdResourceSchema(),
+			"space_id":    util.ResourceString().Optional().Computed().Description("The space ID associated with this resource.").PlanModifiers(stringplanmodifier.UseStateForUnknown()).Build(),
+			"name":        util.ResourceString().Required().Description("The name of this resource.").Build(),
+			"description": util.ResourceString().Optional().Computed().Default("").Description("The description of this lifecycle.").Build(),
+		},
+		Blocks: map[string]resourceSchema.Block{
+			"phase":                     getResourcePhaseBlockSchema(),
+			"release_retention_policy":  getResourceRetentionPolicyBlockSchema(),
+			"tentacle_retention_policy": getResourceRetentionPolicyBlockSchema(),
+		},
+	}
+}
+
+func (l TeamSchema) GetDatasourceSchema() datasourceSchema.Schema {
+	return datasourceSchema.Schema{
+		Description: "Provides information about existing teams.",
+		Attributes: map[string]datasourceSchema.Attribute{
+			"id":             util.DataSourceString().Computed().Description("An auto-generated identifier that includes the timestamp when this data source was last modified.").Build(),
+			"ids":            util.DataSourceList(types.StringType).Optional().Description("A filter to search by a list of IDs..").Build(),
+			"include_system": util.DataSourceBool().Optional().Description("A filter to include system teams.").Build(),
+			"partial_name":   util.DataSourceString().Optional().Description("A filter to search by the partial match of a name.").Build(),
+			"spaces":         util.DataSourceList(types.StringType).Optional().Description("A filter to search by a list of space IDs.").Build(),
+			"skip":           util.DataSourceInt64().Optional().Description("A filter to specify the number of items to skip in the response.").Build(),
+			"take":           util.DataSourceInt64().Optional().Description("A filter to specify the number of items to take (or return) in the response.").Build(),
+			"teams":          getTeamsAttribute(),
+		},
+	}
+}
+
+func getTeamsAttribute() datasourceSchema.ListNestedAttribute {
+	return datasourceSchema.ListNestedAttribute{
+		Computed:    true,
+		Description: "A list of teams that match the filter(s).",
+		Optional:    false,
+		NestedObject: datasourceSchema.NestedAttributeObject{
+			Attributes: map[string]datasourceSchema.Attribute{
+				"can_be_deleted":          util.DataSourceBool().Computed().Optional().Build(),
+				"can_be_renamed":          util.DataSourceBool().Computed().Optional().Build(),
+				"can_change_members":      util.DataSourceBool().Computed().Optional().Build(),
+				"can_change_roles":        util.DataSourceBool().Computed().Optional().Build(),
+				"description":             util.DataSourceString().Optional().Description("The user-friendly description of this team.").Build(),
+				"external_security_group": getExternalSecurityGroupsAttribute(),
+				"id":                      util.DataSourceString().Computed().Optional().Description("The unique ID for this resource.").Build(),
+				"name":                    util.DataSourceString().Required().Description("The name of this team.").Build(),
+				"space_id":                util.DataSourceString().Computed().Optional().Description("The space associated with this team.").Build(),
+				"users":                   util.DataSourceList(types.StringType).Computed().Optional().Description("A list of user IDs designated to be members of this team.").Build(),
+			},
+		},
+	}
+}
+
+func getExternalSecurityGroupsAttribute() datasourceSchema.ListNestedAttribute {
+	return datasourceSchema.ListNestedAttribute{
+		Computed: false,
+		Optional: true,
+		NestedObject: datasourceSchema.NestedAttributeObject{
+			Attributes: map[string]datasourceSchema.Attribute{
+				"display_id_and_name": util.DataSourceBool().Computed().Optional().Build(),
+				"display_name":        util.DataSourceString().Computed().Optional().Build(),
+				"id":                  util.DataSourceString().Computed().Optional().Description("The unique ID for this resource.").Build(),
+			},
+		},
+	}
+}
+
+func MapToTeamsDatasourceModel(t *teams.Team) TeamTypeDatasourceModel {
+	var team TeamTypeDatasourceModel
+	team.CanBeDeleted = types.BoolValue(t.CanBeDeleted)
+	team.CanBeRenamed = types.BoolValue(t.CanBeRenamed)
+	team.CanChangeMembers = types.BoolValue(t.CanChangeMembers)
+	team.CanChangeRoles = types.BoolValue(t.CanChangeRoles)
+	team.Description = types.StringValue(t.Description)
+	team.ExternalSecurityGroups = MapToExternalSecurityGroupsDatasourceModel(t.ExternalSecurityGroups)
+	team.Name = types.StringValue(t.Name)
+	team.SpaceId = types.StringValue(t.SpaceID)
+	team.Users = util.FlattenStringList(t.MemberUserIDs)
+
+	team.ID = types.StringValue(t.ID)
+	return team
+}
+
+func MapToExternalSecurityGroupsDatasourceModel(es []core.NamedReferenceItem) types.List {
+	groups := make([]attr.Value, 0, len(es))
+	for _, g := range es {
+		group := map[string]attr.Value{
+			"display_id_and_name": types.BoolValue(g.DisplayIDAndName),
+			"display_name":        types.StringValue(g.DisplayName),
+			"id":                  types.StringValue(g.ID),
+		}
+		groups = append(groups, types.ObjectValueMust(getExternalSecurityGroupsAttrTypes(), group))
+	}
+
+	return types.ListValueMust(types.ObjectType{AttrTypes: getExternalSecurityGroupsAttrTypes()}, groups)
+}
+
+func getExternalSecurityGroupsAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"display_id_and_name": types.BoolType,
+		"display_name":        types.StringType,
+		"id":                  types.StringType,
+	}
+}
+
+type TeamTypeDatasourceModel struct {
+	CanBeDeleted           types.Bool   `tfsdk:"can_be_deleted"`
+	CanBeRenamed           types.Bool   `tfsdk:"can_be_renamed"`
+	CanChangeMembers       types.Bool   `tfsdk:"can_change_members"`
+	CanChangeRoles         types.Bool   `tfsdk:"can_change_roles"`
+	Description            types.String `tfsdk:"description"`
+	ExternalSecurityGroups types.List   `tfsdk:"external_security_group"`
+	Name                   types.String `tfsdk:"name"`
+	SpaceId                types.String `tfsdk:"space_id"`
+	Users                  types.List   `tfsdk:"users"`
+	ResourceModel
+}
+
+type TeamExternalSecurityGroupTypeDatasourceModel struct {
+	DisplayIdAndName types.Bool   `tfsdk:"display_id_and_name"`
+	DisplayName      types.String `tfsdk:"display_name"`
+
+	ResourceModel
+}

--- a/octopusdeploy_framework/util/resource_attribute_builder.go
+++ b/octopusdeploy_framework/util/resource_attribute_builder.go
@@ -180,7 +180,7 @@ func (b *AttributeBuilder[T]) Default(defaultValue interface{}) *AttributeBuilde
 	case *schema.ListAttribute:
 		a.Default = listdefault.StaticValue(types.List{})
 	case *schema.SetAttribute:
-		a.Default = setdefault.StaticValue(types.Set{})
+		a.Default = setdefault.StaticValue(defaultValue.(types.Set))
 	case *schema.MapAttribute:
 		a.Default = mapdefault.StaticValue(types.Map{})
 	}


### PR DESCRIPTION
This PR should not be merged and is only here to be the basis of converting the teams resource in the future. The reason this was abandoned is because the sub objects (User roles?)  do not have an ID and the framework can't track the correct object and wants to delete and recreate the object every time. 

*notes* This contains the initial changes of #838 so the datasource changes can be ignored.