### PR TITLE
Fix project persistence settings

### DIFF
--- a/octopusdeploy_framework/resource_project_expand.go
+++ b/octopusdeploy_framework/resource_project_expand.go
@@ -3,6 +3,8 @@ package octopusdeploy_framework
 import (
 	"context"
 	"fmt"
+	"net/url"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/actiontemplates"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/credentials"
@@ -11,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"net/url"
 )
 
 func expandProject(ctx context.Context, model projectResourceModel) *projects.Project {
@@ -143,6 +144,10 @@ func expandGitLibraryPersistenceSettings(ctx context.Context, model gitLibraryPe
 	var protectedBranches []string
 	model.ProtectedBranches.ElementsAs(ctx, &protectedBranches, false)
 
+	if protectedBranches == nil {
+		protectedBranches = []string{}
+	}
+
 	return projects.NewGitPersistenceSettings(
 		model.BasePath.ValueString(),
 		credentials.NewReference(model.GitCredentialID.ValueString()),
@@ -156,6 +161,10 @@ func expandGitUsernamePasswordPersistenceSettings(ctx context.Context, model git
 	gitUrl, _ := url.Parse(model.URL.ValueString())
 	var protectedBranches []string
 	model.ProtectedBranches.ElementsAs(ctx, &protectedBranches, false)
+
+	if protectedBranches == nil {
+		protectedBranches = []string{}
+	}
 
 	return projects.NewGitPersistenceSettings(
 		model.BasePath.ValueString(),
@@ -173,6 +182,10 @@ func expandGitAnonymousPersistenceSettings(ctx context.Context, model gitAnonymo
 	gitUrl, _ := url.Parse(model.URL.ValueString())
 	var protectedBranches []string
 	model.ProtectedBranches.ElementsAs(ctx, &protectedBranches, false)
+
+	if protectedBranches == nil {
+		protectedBranches = []string{}
+	}
 
 	return projects.NewGitPersistenceSettings(
 		model.BasePath.ValueString(),

--- a/octopusdeploy_framework/schemas/project.go
+++ b/octopusdeploy_framework/schemas/project.go
@@ -78,7 +78,7 @@ func (p ProjectSchema) GetResourceSchema() resourceSchema.Schema {
 				NestedObject: resourceSchema.NestedBlockObject{
 					Attributes: map[string]resourceSchema.Attribute{
 						"url":                util.ResourceString().Required().Description("The URL associated with these version control settings.").Build(),
-						"base_path":          util.ResourceString().Optional().Description("The base path associated with these version control settings.").Build(),
+						"base_path":          util.ResourceString().Optional().Computed().Default(".octopus").Description("The base path associated with these version control settings.").Build(),
 						"default_branch":     util.ResourceString().Optional().Description("The default branch associated with these version control settings.").Build(),
 						"protected_branches": util.ResourceSet(types.StringType).Optional().Computed().PlanModifiers(setplanmodifier.UseStateForUnknown()).Description("A list of protected branch patterns.").Build(),
 					},
@@ -90,7 +90,7 @@ func (p ProjectSchema) GetResourceSchema() resourceSchema.Schema {
 					Attributes: map[string]resourceSchema.Attribute{
 						"git_credential_id":  util.ResourceString().Required().Build(),
 						"url":                util.ResourceString().Required().Description("The URL associated with these version control settings.").Build(),
-						"base_path":          util.ResourceString().Optional().Description("The base path associated with these version control settings.").Build(),
+						"base_path":          util.ResourceString().Optional().Computed().Default(".octopus").Description("The base path associated with these version control settings.").Build(),
 						"default_branch":     util.ResourceString().Optional().Description("The default branch associated with these version control settings.").Build(),
 						"protected_branches": util.ResourceSet(types.StringType).Optional().Computed().PlanModifiers(setplanmodifier.UseStateForUnknown()).Description("A list of protected branch patterns.").Build(),
 					},
@@ -103,7 +103,7 @@ func (p ProjectSchema) GetResourceSchema() resourceSchema.Schema {
 						"url":                util.ResourceString().Required().Description("The URL associated with these version control settings.").Build(),
 						"username":           util.ResourceString().Required().Description("The username for the Git credential.").Build(),
 						"password":           util.ResourceString().Sensitive().Required().Description("The password for the Git credential").Build(), //util.GetPasswordResourceSchema(false),
-						"base_path":          util.ResourceString().Optional().Description("The base path associated with these version control settings.").Build(),
+						"base_path":          util.ResourceString().Optional().Computed().Default(".octopus").Description("The base path associated with these version control settings.").Build(),
 						"default_branch":     util.ResourceString().Optional().Description("The default branch associated with these version control settings.").Build(),
 						"protected_branches": util.ResourceSet(types.StringType).Optional().Computed().PlanModifiers(setplanmodifier.UseStateForUnknown()).Description("A list of protected branch patterns.").Build(),
 					},

--- a/octopusdeploy_framework/schemas/project.go
+++ b/octopusdeploy_framework/schemas/project.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -79,7 +80,7 @@ func (p ProjectSchema) GetResourceSchema() resourceSchema.Schema {
 						"url":                util.ResourceString().Required().Description("The URL associated with these version control settings.").Build(),
 						"base_path":          util.ResourceString().Optional().Description("The base path associated with these version control settings.").Build(),
 						"default_branch":     util.ResourceString().Optional().Description("The default branch associated with these version control settings.").Build(),
-						"protected_branches": util.ResourceSet(types.StringType).Optional().Description("A list of protected branch patterns.").Build(),
+						"protected_branches": util.ResourceSet(types.StringType).Optional().Computed().PlanModifiers(setplanmodifier.UseStateForUnknown()).Description("A list of protected branch patterns.").Build(),
 					},
 				},
 				Description: "Provides Git-related persistence settings for a version-controlled project.",
@@ -91,7 +92,7 @@ func (p ProjectSchema) GetResourceSchema() resourceSchema.Schema {
 						"url":                util.ResourceString().Required().Description("The URL associated with these version control settings.").Build(),
 						"base_path":          util.ResourceString().Optional().Description("The base path associated with these version control settings.").Build(),
 						"default_branch":     util.ResourceString().Optional().Description("The default branch associated with these version control settings.").Build(),
-						"protected_branches": util.ResourceSet(types.StringType).Optional().Description("A list of protected branch patterns.").Build(),
+						"protected_branches": util.ResourceSet(types.StringType).Optional().Computed().PlanModifiers(setplanmodifier.UseStateForUnknown()).Description("A list of protected branch patterns.").Build(),
 					},
 				},
 				Description: "Provides Git-related persistence settings for a version-controlled project.",
@@ -104,7 +105,7 @@ func (p ProjectSchema) GetResourceSchema() resourceSchema.Schema {
 						"password":           util.ResourceString().Sensitive().Required().Description("The password for the Git credential").Build(), //util.GetPasswordResourceSchema(false),
 						"base_path":          util.ResourceString().Optional().Description("The base path associated with these version control settings.").Build(),
 						"default_branch":     util.ResourceString().Optional().Description("The default branch associated with these version control settings.").Build(),
-						"protected_branches": util.ResourceSet(types.StringType).Optional().Description("A list of protected branch patterns.").Build(),
+						"protected_branches": util.ResourceSet(types.StringType).Optional().Computed().PlanModifiers(setplanmodifier.UseStateForUnknown()).Description("A list of protected branch patterns.").Build(),
 					},
 				},
 				Description: "Provides Git-related persistence settings for a version-controlled project.",


### PR DESCRIPTION
Fixes https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/issues/787


Also fixes an issue where a default value for a basepath is not set when not provided. This is a regression from https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/commit/cb9c42156a4759a0f3f9a5e9f41cc3761155b9bd as the [default value of ".octopus" was provided](https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/blame/7fca508203e39f6e7437657b92369cd5c9c8ab89/octopusdeploy/schema_project.go#L293) before.

(I can't seem to create an issue, so I wasn't able to create an issue for the second issue).