### PR TITLE
Add 'Block Deployments' attribute to manual intervention step

### DIFF
--- a/docs/resources/deployment_process.md
+++ b/docs/resources/deployment_process.md
@@ -801,6 +801,7 @@ Required:
 Optional:
 
 - `action_template` (Block Set, Max: 1) Represents the template that is associated with this action. (see [below for nested schema](#nestedblock--step--manual_intervention_action--action_template))
+- `block_deployments` (String) Should other deployments be blocked while this manual intervention is awaiting action.
 - `can_be_used_for_project_versioning` (Boolean)
 - `channels` (List of String) The channels associated with this deployment action.
 - `condition` (String) The condition associated with this deployment action.

--- a/docs/resources/runbook_process.md
+++ b/docs/resources/runbook_process.md
@@ -679,6 +679,7 @@ Required:
 Optional:
 
 - `action_template` (Block Set, Max: 1) Represents the template that is associated with this action. (see [below for nested schema](#nestedblock--step--manual_intervention_action--action_template))
+- `block_deployments` (String) Should other deployments be blocked while this manual intervention is awaiting action.
 - `can_be_used_for_project_versioning` (Boolean)
 - `channels` (List of String) The channels associated with this deployment action.
 - `condition` (String) The condition associated with this deployment action.

--- a/octopusdeploy/schema_action_manual_intervention_test.go
+++ b/octopusdeploy/schema_action_manual_intervention_test.go
@@ -35,6 +35,7 @@ func testAccManualInterventionAction() string {
 			sort_order = 1
 			instructions = "Approve Me"
 			responsible_teams = "A Team"
+			block_deployments = true
 		}
 	`)
 }
@@ -58,6 +59,10 @@ func testAccCheckManualInterventionAction() resource.TestCheckFunc {
 
 		if action.Properties["Octopus.Action.Manual.ResponsibleTeamIds"].Value != "A Team" {
 			return fmt.Errorf("ResponsibleTeamIds is incorrect: %s", action.Properties["Octopus.Action.Manual.ResponsibleTeamIds"].Value)
+		}
+
+		if action.Properties["Octopus.Action.Manual.BlockConcurrentDeployments"].Value != "True" {
+			return fmt.Errorf("expected BlockConcurrentDeployments to be 'True' but got '%s'", action.Properties["Octopus.Action.Manual.BlockConcurrentDeployments"].Value)
 		}
 
 		return nil

--- a/octopusdeploy/schema_action_manual_intervention_test.go
+++ b/octopusdeploy/schema_action_manual_intervention_test.go
@@ -35,7 +35,7 @@ func testAccManualInterventionAction() string {
 			sort_order = 1
 			instructions = "Approve Me"
 			responsible_teams = "A Team"
-			block_deployments = true
+			block_deployments = "True"
 		}
 	`)
 }

--- a/octopusdeploy/schema_manual_intervention_action.go
+++ b/octopusdeploy/schema_manual_intervention_action.go
@@ -13,6 +13,8 @@ func flattenManualIntervention(actionMap map[string]interface{}, properties map[
 			actionMap["instructions"] = propertyValue.Value
 		case "Octopus.Action.Manual.ResponsibleTeamIds":
 			actionMap["responsible_teams"] = propertyValue.Value
+		case "Octopus.Action.Manual.BlockConcurrentDeployments":
+			actionMap["block_deployments"] = propertyValue.Value
 		}
 	}
 }
@@ -39,6 +41,12 @@ func getManualInterventionActionSchema() *schema.Schema {
 		Optional:    true,
 	}
 
+	element.Schema["block_deployments"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Description: "Should other deployments be blocked while this manual intervention is awaiting action.",
+		Optional:    true,
+	}
+
 	return actionSchema
 }
 
@@ -50,6 +58,11 @@ func expandManualInterventionAction(tfAction map[string]interface{}) *deployment
 	responsibleTeams := tfAction["responsible_teams"]
 	if responsibleTeams != nil {
 		resource.Properties["Octopus.Action.Manual.ResponsibleTeamIds"] = core.NewPropertyValue(responsibleTeams.(string), false)
+	}
+
+	if blockDeployments, ok := tfAction["block_deployments"]; ok {
+		value := formatAsBoolOrBoundedValueForActionProperty(blockDeployments.(string))
+		resource.Properties["Octopus.Action.Manual.BlockConcurrentDeployments"] = core.NewPropertyValue(value, false)
 	}
 
 	return resource

--- a/octopusdeploy/util.go
+++ b/octopusdeploy/util.go
@@ -3,6 +3,7 @@ package octopusdeploy
 import (
 	"hash/crc32"
 	"log"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -118,4 +119,17 @@ func formatBoolForActionProperty(b bool) string {
 		return "True"
 	}
 	return "False"
+}
+
+func formatAsBoolOrBoundedValueForActionProperty(value string) string {
+	if strings.Contains(value, "#{") {
+		return value
+	}
+
+	boolValue, err := strconv.ParseBool(value)
+	if err == nil {
+		return formatBoolForActionProperty(boolValue)
+	}
+
+	return value
 }


### PR DESCRIPTION
`manual_intervention_action` block was missing attribute to prevent concurrent deployments during intervention, because it's value was set to 'false" by default.

Fixes: https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/issues/242

