### PR TITLE
Suppress non-functional difference of URI value

### DIFF
--- a/octopusdeploy/resource_kubernetes_agent_deployment_target.go
+++ b/octopusdeploy/resource_kubernetes_agent_deployment_target.go
@@ -16,7 +16,7 @@ func resourceKubernetesAgentDeploymentTarget() *schema.Resource {
 		Description:   "This resource manages Kubernetes agent deployment targets in Octopus Deploy.",
 		Importer:      getImporter(),
 		ReadContext:   resourceKubernetesAgentDeploymentTargetRead,
-		Schema:        getKubernetesAgentDeploymentTargetSchema(),
+		Schema:        getKubernetesAgentDeploymentTargetSchemaForResource(),
 		UpdateContext: resourceKubernetesAgentDeploymentTargetUpdate,
 	}
 }


### PR DESCRIPTION
Resource `octopusdeploy_kubernetes_agent_deployment_target` stores `uri` value as 'Uri' type which is, when returned by the server, is represented as lowercase string. When provided `uri` value has different casing, this is causing Terraform state drift. 

We can "ignore" casing difference by applying `DiffSuppressFunc` to the attribute

Fixes: https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/issues/718

