### PR TITLE
fix: map access_token through properly from provider config

### DIFF
--- a/octopusdeploy_framework/framework_provider.go
+++ b/octopusdeploy_framework/framework_provider.go
@@ -49,6 +49,7 @@ func (p *octopusDeployFrameworkProvider) Configure(ctx context.Context, req prov
 	if config.ApiKey == "" {
 		config.ApiKey = os.Getenv("OCTOPUS_API_KEY")
 	}
+	config.AccessToken = providerData.AccessToken.ValueString()
 	if config.AccessToken == "" {
 		config.AccessToken = os.Getenv("OCTOPUS_ACCESS_TOKEN")
 	}


### PR DESCRIPTION
Hadn't properly mapped the value through for the framework provider config, but seems that sdk should be fine.

fixes #853