### PR TITLE
fix: panic using project_verisoning_strategy without donorpackage

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -99,7 +99,7 @@ jobs:
           OCTOTESTRETRYCOUNT: 1
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: junit-test-summary-${{ matrix.index }}
           path: node-summary.xml
@@ -117,7 +117,7 @@ jobs:
       - uses: actions/setup-node@v3
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: Install junit-report-merger
         run: npm install -g junit-report-merger
@@ -142,7 +142,7 @@ jobs:
           "junit-test-summary-14/*.xml"
 
       - name: Upload test artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: junit-test-summary
           path: ./junit-test-summary.xml

--- a/docs/resources/project_versioning_strategy.md
+++ b/docs/resources/project_versioning_strategy.md
@@ -60,7 +60,21 @@ resource "octopusdeploy_deployment_process" "process" {
   depends_on  = [octopusdeploy_project.tp]
 }
 
-resource "octopusdeploy_project_versioning_strategy" "tp" {
+######
+# NOTE: You can use either template or donor_package, not both
+######
+resource "octopusdeploy_project_versioning_strategy" "using_template" {
+  project_id = octopusdeploy_project.tp.id
+  space_id = octopusdeploy_project.tp.space_id
+  # See https://octopus.com/docs/releases/release-versioning for variable syntax
+  template = "#{Octopus.Version.LastMajor}.#{Octopus.Version.NextMinor}-alpha"
+  depends_on = [
+    octopusdeploy_project_group.tp,
+    octopusdeploy_deployment_process.process
+  ]
+}
+
+resource "octopusdeploy_project_versioning_strategy" "using_donor_package" {
   project_id = octopusdeploy_project.tp.id
   space_id = octopusdeploy_project.tp.space_id
   donor_package_step_id = octopusdeploy_deployment_process.process.step[0].run_script_action[0].id
@@ -80,19 +94,19 @@ resource "octopusdeploy_project_versioning_strategy" "tp" {
 
 ### Required
 
-- `donor_package` (Attributes) Donor Packages. (see [below for nested schema](#nestedatt--donor_package))
 - `project_id` (String) The associated project ID.
-- `space_id` (String) Space ID of the associated project.
 
 ### Optional
 
+- `donor_package` (Attributes) Donor Packages. (see [below for nested schema](#nestedatt--donor_package))
 - `donor_package_step_id` (String) The associated donor package step ID.
+- `space_id` (String) Space ID of the associated project.
 - `template` (String)
 
 <a id="nestedatt--donor_package"></a>
 ### Nested Schema for `donor_package`
 
-Optional:
+Required:
 
 - `deployment_action` (String) Deployment action.
 - `package_reference` (String) Package reference.

--- a/examples/resources/octopusdeploy_project_versioning_strategy/resource.tf
+++ b/examples/resources/octopusdeploy_project_versioning_strategy/resource.tf
@@ -45,7 +45,21 @@ resource "octopusdeploy_deployment_process" "process" {
   depends_on  = [octopusdeploy_project.tp]
 }
 
-resource "octopusdeploy_project_versioning_strategy" "tp" {
+######
+# NOTE: You can use either template or donor_package, not both
+######
+resource "octopusdeploy_project_versioning_strategy" "using_template" {
+  project_id = octopusdeploy_project.tp.id
+  space_id = octopusdeploy_project.tp.space_id
+  # See https://octopus.com/docs/releases/release-versioning for variable syntax
+  template = "#{Octopus.Version.LastMajor}.#{Octopus.Version.NextMinor}-alpha"
+  depends_on = [
+    octopusdeploy_project_group.tp,
+    octopusdeploy_deployment_process.process
+  ]
+}
+
+resource "octopusdeploy_project_versioning_strategy" "using_donor_package" {
   project_id = octopusdeploy_project.tp.id
   space_id = octopusdeploy_project.tp.space_id
   donor_package_step_id = octopusdeploy_deployment_process.process.step[0].run_script_action[0].id

--- a/octopusdeploy_framework/resource_project_versioning_strategy.go
+++ b/octopusdeploy_framework/resource_project_versioning_strategy.go
@@ -2,6 +2,9 @@ package octopusdeploy_framework
 
 import (
 	"context"
+	"log"
+	"net/http"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/packages"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
@@ -9,8 +12,6 @@ import (
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"log"
-	"net/http"
 )
 
 var _ resource.Resource = &projectVersioningStrategyResource{}
@@ -184,7 +185,11 @@ func mapProjectVersioningStrategyToState(versioningStrategy *projects.Versioning
 	if versioningStrategy.DonorPackageStepID != nil {
 		state.DonorPackageStepID = types.StringValue(*versioningStrategy.DonorPackageStepID)
 	}
+	// Template and Donor Package are mutually exclusive options. We won't always have DonorPackage information.
 	state.Template = types.StringValue(versioningStrategy.Template)
-	state.DonorPackage.PackageReference = types.StringValue(versioningStrategy.DonorPackage.PackageReference)
-	state.DonorPackage.DeploymentAction = types.StringValue(versioningStrategy.DonorPackage.DeploymentAction)
+
+	if !(versioningStrategy.DonorPackage == nil) {
+		state.DonorPackage.PackageReference = types.StringValue(versioningStrategy.DonorPackage.PackageReference)
+		state.DonorPackage.DeploymentAction = types.StringValue(versioningStrategy.DonorPackage.DeploymentAction)
+	}
 }

--- a/octopusdeploy_framework/schemas/entity_schema.go
+++ b/octopusdeploy_framework/schemas/entity_schema.go
@@ -2,10 +2,16 @@ package schemas
 
 import (
 	datasourceSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	resourceSchema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 )
 
 type EntitySchema interface {
 	GetResourceSchema() resourceSchema.Schema
 	GetDatasourceSchema() datasourceSchema.Schema
+}
+
+type EntitySchemaWithResourceValidators interface {
+	EntitySchema
+	GetResourceConfigValidators() []resource.ConfigValidator
 }

--- a/octopusdeploy_framework/schemas/project_versioning_strategy.go
+++ b/octopusdeploy_framework/schemas/project_versioning_strategy.go
@@ -2,7 +2,10 @@ package schemas
 
 import (
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
+	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	datasourceSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
 	resourceSchema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -10,7 +13,7 @@ import (
 
 type ProjectVersioningStrategySchema struct{}
 
-var _ EntitySchema = ProjectVersioningStrategySchema{}
+var _ EntitySchemaWithResourceValidators = ProjectVersioningStrategySchema{}
 
 const ProjectVersioningStrategyResourceName = "project_versioning_strategy"
 
@@ -24,7 +27,7 @@ func (p ProjectVersioningStrategySchema) GetResourceSchema() resourceSchema.Sche
 				Build(),
 			"space_id": util.ResourceString().
 				Description("Space ID of the associated project.").
-				Required().
+				Optional().
 				Build(),
 			"donor_package_step_id": util.ResourceString().
 				Description("The associated donor package step ID.").
@@ -35,20 +38,37 @@ func (p ProjectVersioningStrategySchema) GetResourceSchema() resourceSchema.Sche
 				Computed().
 				Build(),
 			"donor_package": resourceSchema.SingleNestedAttribute{
-				Required:    true,
+				Optional:    true,
 				Description: "Donor Packages.",
 				Attributes: map[string]resourceSchema.Attribute{
 					"deployment_action": util.ResourceString().
 						Description("Deployment action.").
-						Optional().
+						Required().
 						Build(),
 					"package_reference": util.ResourceString().
 						Description("Package reference.").
-						Optional().
+						Required().
 						Build(),
 				},
 			},
 		},
+	}
+}
+
+func (p ProjectVersioningStrategySchema) GetResourceConfigValidators() []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		resourcevalidator.RequiredTogether(
+			path.MatchRoot("donor_package"),
+			path.MatchRoot("donor_package_step_id"),
+		),
+		resourcevalidator.Conflicting(
+			path.MatchRoot("template"),
+			path.MatchRoot("donor_package"),
+		),
+		resourcevalidator.Conflicting(
+			path.MatchRoot("template"),
+			path.MatchRoot("donor_package_step_id"),
+		),
 	}
 }
 
@@ -58,11 +78,11 @@ func (p ProjectVersioningStrategySchema) GetDatasourceSchema() datasourceSchema.
 }
 
 type ProjectVersioningStrategyModel struct {
-	ProjectID          types.String      `tfsdk:"project_id"`
-	SpaceID            types.String      `tfsdk:"space_id"`
-	DonorPackageStepID types.String      `tfsdk:"donor_package_step_id"`
-	Template           types.String      `tfsdk:"template"`
-	DonorPackage       DonorPackageModel `tfsdk:"donor_package"`
+	ProjectID          types.String       `tfsdk:"project_id"`
+	SpaceID            types.String       `tfsdk:"space_id"`
+	DonorPackageStepID types.String       `tfsdk:"donor_package_step_id"`
+	Template           types.String       `tfsdk:"template"`
+	DonorPackage       *DonorPackageModel `tfsdk:"donor_package"`
 }
 
 type DonorPackageModel struct {


### PR DESCRIPTION
The Template and DonorPackage on a Project Versioning Strategy are mutually exclusive options, but this isn't reflected in the schema or our internal translation logic between TF State and API Resources.

Our mapping logic between the TF State and the API Resource didn't account for this, which causes #855 - the provider works fine if the `donor_package` approach is used, but crashes if the `template` approach is used. 

I took the opportunity to also fix up the schema, validation, docs and examples to better represent the actual valid inputs from the Octopus Server perspective:

* Changed `donor_package` in the schema from Required to Optional
* Changed child attributes of `donor_package` to be required, when `donor_package` is present
* Added new validation that checks that:
  1. Both `donor_package` and `donor_package_step_id` must be present together
  2. Only one of `template` or `donor_package` can be used 
* Updated documentation with clearer examples of the two approaches

Fixes #855

*Note*: These updates are _not_ a breaking change, because even though it was previously possible from a TF perspective to specify both `donor_package` and `template` in a config, Octopus Server API has a server-side check that prevents such a strategy from being applied, and fails the `terraform apply`, so it's not possible for any customers to have a config that will break with this change. If that server-side check hadn't existed, we would have had to mark this as breaking due to the stricter requirements on the mutual-exclusivity.