### PR TITLE
fix: granted space permissions forcing UI order

### DIFF
--- a/docs/data-sources/user_roles.md
+++ b/docs/data-sources/user_roles.md
@@ -44,7 +44,7 @@ Read-Only:
 
 - `can_be_deleted` (Boolean)
 - `description` (String)
-- `granted_space_permissions` (List of String)
+- `granted_space_permissions` (Set of String)
 - `granted_system_permissions` (List of String)
 - `id` (String)
 - `name` (String)

--- a/docs/resources/user_role.md
+++ b/docs/resources/user_role.md
@@ -38,7 +38,7 @@ resource "octopusdeploy_user_role" "example" {
 
 - `can_be_deleted` (Boolean)
 - `description` (String) The description of this user role.
-- `granted_space_permissions` (List of String)
+- `granted_space_permissions` (Set of String)
 - `granted_system_permissions` (List of String)
 - `id` (String) The unique ID for this resource.
 - `space_permission_descriptions` (List of String)

--- a/octopusdeploy/schema_user_role.go
+++ b/octopusdeploy/schema_user_role.go
@@ -101,7 +101,7 @@ func getUserRoleSchema() map[string]*schema.Schema {
 		"granted_space_permissions": {
 			Elem:     &schema.Schema{Type: schema.TypeString},
 			Optional: true,
-			Type:     schema.TypeList,
+			Type:     schema.TypeSet,
 		},
 		"granted_system_permissions": {
 			Elem:     &schema.Schema{Type: schema.TypeString},


### PR DESCRIPTION
fixes #539 

I could not get this resource to migrate to framework while maintain backwards compatibility. In addition because of the way our API works a resource like this would not work well in framework. This is because if the granted space permission are invalid instead of throwing an error the API would automatically include the "missing" permission causing terraform plugin framework to always complain the plan does not match the outcome.

This is a fix stop reordering in SDK, in the future we can consider a new resource framework that would not need to carry over the legacy of this resource. Creating the new resource now would have little benefit over this fix.

Despite the schema changes, no migration is needed.