### PR TITLE
docs: breaking changes list section fix

### DIFF
--- a/docs/guides/breaking-changes-list.md
+++ b/docs/guides/breaking-changes-list.md
@@ -1,6 +1,6 @@
 ---
 page_title: "Breaking Changes List"
-subcategory: "Upgrades & Migrations""
+subcategory: "Upgrades & Migrations"
 ---
 
 # Breaking Changes

--- a/templates/guides/breaking-changes-list.md.tmpl
+++ b/templates/guides/breaking-changes-list.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "Breaking Changes List"
-subcategory: "Upgrades & Migrations""
+subcategory: "Upgrades & Migrations"
 ---
 
 # Breaking Changes


### PR DESCRIPTION
One more tiny fix to the nav structure of the docs

From this:
<img width="343" alt="image" src="https://github.com/user-attachments/assets/46b36442-16b4-418c-83eb-9e212e1ef590" />

To this:
<img width="341" alt="image" src="https://github.com/user-attachments/assets/a45461e6-1914-485f-b32e-053dc75c98bc" />
