### PR TITLE
fix: update octopus go client to populate script syntax and body

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22
 toolchain go1.22.3
 
 require (
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.64.0
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.64.2
 	github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v0.0.0-20241206032352-dbc62b2d16cf
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200723130312-85980079f637

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/OctopusDeploy/go-octodiff v1.0.0 h1:U+ORg6azniwwYo+O44giOw6TiD5USk8S4
 github.com/OctopusDeploy/go-octodiff v1.0.0/go.mod h1:Mze0+EkOWTgTmi8++fyUc6r0aLZT7qD9gX+31t8MmIU=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.64.0 h1:NWqQ/7JLUfEJQ8QHrkek7AfePuN121+f6+tUi3xP6vE=
 github.com/OctopusDeploy/go-octopusdeploy/v2 v2.64.0/go.mod h1:ggvOXzMnq+w0pLg6C9zdjz6YBaHfO3B3tqmmB7JQdaw=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.64.2 h1:soRQnNPMLFiTm8tSH6fx3znFvTYOyGnTFYPAfpJH9e0=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.64.2/go.mod h1:ggvOXzMnq+w0pLg6C9zdjz6YBaHfO3B3tqmmB7JQdaw=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v0.0.0-20241206032352-dbc62b2d16cf h1:wuUJ6DbSZEHE4a3SfSJIcoeTQCSI6lbQ+i46ibY14+Q=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v0.0.0-20241206032352-dbc62b2d16cf/go.mod h1:xVv8DvYhhwxtQUQQDfOYA6CY8KTkHXccxQ2RfRj6IJ0=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2 h1:bkyFVUP+ROOARdgCiJzNQo2V2kiB97LyUpzH9P6Hrlg=

--- a/octopusdeploy_framework/resource_script_module_test.go
+++ b/octopusdeploy_framework/resource_script_module_test.go
@@ -2,14 +2,15 @@ package octopusdeploy_framework
 
 import (
 	"fmt"
+	"path/filepath"
+	"testing"
+
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/variables"
 	"github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework/octoclient"
 	"github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework/test"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"path/filepath"
-	"testing"
 )
 
 func TestAccOctopusDeployScriptModuleBasic(t *testing.T) {
@@ -102,7 +103,7 @@ func TestScriptModuleResource(t *testing.T) {
 		Take:        1,
 	}
 
-	resources, err := client.LibraryVariableSets.Get(query)
+	resources, err := client.ScriptModules.Get(query)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -114,6 +115,14 @@ func TestScriptModuleResource(t *testing.T) {
 
 	if resource.Description != "Test script module" {
 		t.Fatal("The library variable set must be have a description of \"Test script module\" (was \"" + resource.Description + "\")")
+	}
+
+	if resource.Syntax != "PowerShell" {
+		t.Fatal("The script module must have a syntax of \"PowerShell\" (was \"" + resource.Syntax + "\")")
+	}
+
+	if resource.ScriptBody != "echo \"hi\"" {
+		t.Fatal("The script module must have a script body of \"echo \"hi\"\" (was \"" + resource.ScriptBody + "\")")
 	}
 
 	variables, err := client.Variables.GetAll(resource.ID)

--- a/octopusdeploy_framework/resource_script_module_test.go
+++ b/octopusdeploy_framework/resource_script_module_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/scriptmodules"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/variables"
 	"github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework/octoclient"
 	"github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework/test"
@@ -103,7 +104,7 @@ func TestScriptModuleResource(t *testing.T) {
 		Take:        1,
 	}
 
-	resources, err := client.ScriptModules.Get(query)
+	resources, err := scriptmodules.Get(client, newSpaceId, query)
 	if err != nil {
 		t.Fatal(err.Error())
 	}


### PR DESCRIPTION
<img width="1307" alt="image" src="https://github.com/user-attachments/assets/4f4e02b3-ff07-4e61-801f-4d3c824dbdde" />

```terraform
data "octopusdeploy_script_modules" "example" {
  skip         = 0
}

output "data_lookup" {
  value = data.octopusdeploy_script_modules.example.script_modules[0]
}
```

## Before
```terraform
+ data_lookup = {
  + description     = ""
  + id              = "LibraryVariableSets-82"
  + name            = "Hello"
  + script          = [
      + {
          + body   = ""
          + syntax = ""
        },
    ]
  + space_id        = "Spaces-1"
  + variable_set_id = "variableset-LibraryVariableSets-82"
}
```

## After
```terraform
+ data_lookup = {
  + description     = ""
  + id              = "LibraryVariableSets-82"
  + name            = "Hello"
  + script          = [
      + {
          + body   = <<-EOT
                function Say-Hello()
                {
                    Write-Output "Hello, Octopus!"
                }
            EOT
          + syntax = "PowerShell"
        },
    ]
  + space_id        = "Spaces-1"
  + variable_set_id = "variableset-LibraryVariableSets-82"
}
```

[sc-103152]