### PR TITLE
Add support for project deployment freezes

### DIFF
--- a/examples/resources/octopusdeploy_project_deployment_freeze/resource.tf
+++ b/examples/resources/octopusdeploy_project_deployment_freeze/resource.tf
@@ -1,0 +1,60 @@
+# basic freeze with no environment scopes
+resource "octopusdeploy_project_deployment_freeze" "freeze" {
+  owner_id = "Projects-123"
+  name = "Xmas"
+  start = "2024-12-25T00:00:00+10:00"
+  end = "2024-12-27T00:00:00+08:00"
+}
+
+# Freeze with different timezones and single environment scope
+resource "octopusdeploy_deployment_freeze" "freeze" {
+  owner_id = "Projects-123"
+  name = "Xmas"
+  start = "2024-12-25T00:00:00+10:00"
+  end = "2024-12-27T00:00:00+08:00"
+  environment_ids = ["Environments-123"]
+}
+
+# Freeze recurring freeze yearly on Xmas
+resource "octopusdeploy_deployment_freeze" "freeze" {
+  owner_id = "Projects-123"
+  name = "Xmas"
+  start = "2024-12-25T00:00:00+10:00"
+  end = "2024-12-27T00:00:00+08:00"
+  recurring_schedule = {
+    type    = "Annually"
+    unit    = 1
+    end_type = "Never"
+  }
+}
+
+resource "octopusdeploy_deployment_freeze_project" "project_freeze" {
+  deploymentfreeze_id= octopusdeploy_deployment_freeze.freeze.id
+  project_id = "Projects-123"
+  environment_ids = [ "Environments-123", "Environments-456" ]
+}
+
+# Freeze with ids sourced from resources.
+resource "octopusdeploy_deployment_freeze" "freeze" {
+  owner_id = resource.octopusdeploy_project.project1.id
+  name = "End of financial year shutdown"
+  start = "2025-06-30T00:00:00+10:00"
+  end = "2025-07-02T00:00:00+10:00"
+  environment_ids = [resource.octopusdeploy_environment.production.id]
+}
+
+# Freeze with tenant environment scope and ids sourced from datasources.
+resource "octopusdeploy_deployment_freeze" "freeze" {
+  owner_id = data.octopusdeploy_project.project1.id
+  name = "End of financial year shutdown"
+  start = "2025-06-30T00:00:00+10:00"
+  end = "2025-07-02T00:00:00+10:00"
+  environment_ids = [data.octopusdeploy_environments.default_environment.environments[0].id]
+}
+
+resource "octopusdeploy_deployment_freeze_tenant" "tenant_freeze" {
+  deploymentfreeze_id = octopusdeploy_deployment_freeze.freeze.id
+  tenant_id           = data.octopusdeploy_tenants.default_tenant.tenants[0].id
+  project_id          = data.octopusdeploy_project.project1.id
+  environment_id      = data.octopusdeploy_environments.default_environment.environments[0].id
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.5
 
 require (
-	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.65.3
+	github.com/OctopusDeploy/go-octopusdeploy/v2 v2.65.5
 	github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v0.0.0-20250307001652-0d83fd2b1e49
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200723130312-85980079f637

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/OctopusDeploy/go-octodiff v1.0.0 h1:U+ORg6azniwwYo+O44giOw6TiD5USk8S4VDhOQ0Ven0=
 github.com/OctopusDeploy/go-octodiff v1.0.0/go.mod h1:Mze0+EkOWTgTmi8++fyUc6r0aLZT7qD9gX+31t8MmIU=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.65.3 h1:qZfyylXCIXPKRwUwG3fsyhubQblKZBfxphQDJg5Uf/k=
-github.com/OctopusDeploy/go-octopusdeploy/v2 v2.65.3/go.mod h1:ZCOnCz9ae/uuOk7AIQ9NzjnzFbuN8Q7H3oj2Eq4QSgQ=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.65.5 h1:+jldC/wOEcDDU3HlW+c9wbahEngKk+oJ7XWk9qK3zlo=
+github.com/OctopusDeploy/go-octopusdeploy/v2 v2.65.5/go.mod h1:ZCOnCz9ae/uuOk7AIQ9NzjnzFbuN8Q7H3oj2Eq4QSgQ=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v0.0.0-20250307001652-0d83fd2b1e49 h1:yXSNfiTSlnR9dxVQBz6hi911yulxsZME8xD1vDf8l1M=
 github.com/OctopusSolutionsEngineering/OctopusTerraformTestFramework v0.0.0-20250307001652-0d83fd2b1e49/go.mod h1:UAZ9L//VwW/GcXW89n05pTpPSeLAXDf2A6SF4rz2PFA=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2 h1:bkyFVUP+ROOARdgCiJzNQo2V2kiB97LyUpzH9P6Hrlg=

--- a/octopusdeploy_framework/framework_provider.go
+++ b/octopusdeploy_framework/framework_provider.go
@@ -135,6 +135,7 @@ func (p *octopusDeployFrameworkProvider) Resources(ctx context.Context) []func()
 		NewDeploymentFreezeTenantResource,
 		NewGitTriggerResource,
 		NewBuiltInTriggerResource,
+		NewProjectDeploymentFreezeResource,
 	}
 }
 

--- a/octopusdeploy_framework/resource_project_deployment_freeze.go
+++ b/octopusdeploy_framework/resource_project_deployment_freeze.go
@@ -1,0 +1,291 @@
+package octopusdeploy_framework
+
+import (
+	"context"
+
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/deploymentfreezes"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/internal"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/internal/errors"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const projectDeploymentFreezeResourceName = "project_deployment_freeze"
+
+type projectDeploymentFreezeModel struct {
+	OwnerID        types.String `tfsdk:"owner_id"`
+	EnvironmentIDs types.List   `tfsdk:"environment_ids"`
+	deploymentFreezeModel
+}
+
+type projectDeploymentFreezeResource struct {
+	*Config
+}
+
+var _ resource.Resource = &projectDeploymentFreezeResource{}
+
+func NewProjectDeploymentFreezeResource() resource.Resource {
+	return &projectDeploymentFreezeResource{}
+}
+
+func (f *projectDeploymentFreezeResource) Metadata(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = util.GetTypeName(projectDeploymentFreezeResourceName)
+}
+
+func (f *projectDeploymentFreezeResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schemas.ProjectDeploymentFreezeSchema{}.GetResourceSchema()
+}
+
+func (f *projectDeploymentFreezeResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	f.Config = ResourceConfiguration(req, resp)
+}
+
+func (f *projectDeploymentFreezeResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	internal.Mutex.Lock()
+	defer internal.Mutex.Unlock()
+
+	var state *projectDeploymentFreezeModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	deploymentFreeze, err := deploymentfreezes.GetById(f.Config.Client, state.GetID())
+	if err != nil {
+		if err := errors.ProcessApiErrorV2(ctx, resp, state, err, "project deployment freeze"); err != nil {
+			resp.Diagnostics.AddError("unable to load project deployment freeze", err.Error())
+		}
+		return
+	}
+
+	mapFromProjectDeploymentFreezeToState(ctx, state, deploymentFreeze)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (f *projectDeploymentFreezeResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	internal.Mutex.Lock()
+	defer internal.Mutex.Unlock()
+
+	var plan *projectDeploymentFreezeModel
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	deploymentFreeze, diags := mapFromStateToProjectDeploymentFreeze(plan)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
+	createdFreeze, err := deploymentfreezes.Add(f.Config.Client, deploymentFreeze)
+	if err != nil {
+		resp.Diagnostics.AddError("error while creating project deployment freeze", err.Error())
+		return
+	}
+
+	diags.Append(mapFromProjectDeploymentFreezeToState(ctx, plan, createdFreeze)...)
+	if diags.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (f *projectDeploymentFreezeResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	internal.Mutex.Lock()
+	defer internal.Mutex.Unlock()
+
+	var plan *projectDeploymentFreezeModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	existingFreeze, err := deploymentfreezes.GetById(f.Config.Client, plan.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("unable to load project deployment freeze", err.Error())
+		return
+	}
+
+	updatedFreeze, diags := mapFromStateToProjectDeploymentFreeze(plan)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
+	// Preserve both project and tenant scopes from the existing freeze
+	updatedFreeze.ProjectEnvironmentScope = existingFreeze.ProjectEnvironmentScope
+	updatedFreeze.TenantProjectEnvironmentScope = existingFreeze.TenantProjectEnvironmentScope
+
+	updatedFreeze.SetID(existingFreeze.GetID())
+	updatedFreeze.Links = existingFreeze.Links
+
+	updatedFreeze, err = deploymentfreezes.Update(f.Config.Client, updatedFreeze)
+	if err != nil {
+		resp.Diagnostics.AddError("error while updating project deployment freeze", err.Error())
+		return
+	}
+
+	diags.Append(mapFromProjectDeploymentFreezeToState(ctx, plan, updatedFreeze)...)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (f *projectDeploymentFreezeResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	internal.Mutex.Lock()
+	defer internal.Mutex.Unlock()
+
+	var state *projectDeploymentFreezeModel
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	freeze, err := deploymentfreezes.GetById(f.Config.Client, state.GetID())
+	if err != nil {
+		resp.Diagnostics.AddError("unable to load project deployment freeze", err.Error())
+		return
+	}
+
+	err = deploymentfreezes.Delete(f.Config.Client, freeze)
+	if err != nil {
+		resp.Diagnostics.AddError("unable to delete project deployment freeze", err.Error())
+	}
+
+	resp.State.RemoveResource(ctx)
+}
+func mapFromStateToProjectDeploymentFreeze(state *projectDeploymentFreezeModel) (*deploymentfreezes.DeploymentFreeze, diag.Diagnostics) {
+	start, diags := state.Start.ValueRFC3339Time()
+	if diags.HasError() {
+		return nil, diags
+	}
+	start = start.UTC()
+
+	end, diags := state.End.ValueRFC3339Time()
+	if diags.HasError() {
+		return nil, diags
+	}
+	end = end.UTC()
+
+	freeze := deploymentfreezes.DeploymentFreeze{
+		OwnerId: state.OwnerID.ValueString(),
+		Name:    state.Name.ValueString(),
+		Start:   &start,
+		End:     &end,
+	}
+
+	if !state.EnvironmentIDs.IsNull() && !state.EnvironmentIDs.IsUnknown() {
+		projectEnvironments := map[string][]string{
+			state.OwnerID.ValueString(): util.ExpandStringList(state.EnvironmentIDs),
+		}
+		freeze.ProjectEnvironmentScope = projectEnvironments
+	}
+
+	if state.RecurringSchedule != nil {
+		var daysOfWeek []string
+
+		if !state.RecurringSchedule.DaysOfWeek.IsNull() {
+			diags.Append(state.RecurringSchedule.DaysOfWeek.ElementsAs(context.TODO(), &daysOfWeek, false)...)
+			if diags.HasError() {
+				return nil, diags
+			}
+		}
+
+		freeze.RecurringSchedule = &deploymentfreezes.RecurringSchedule{
+			Type:                deploymentfreezes.RecurringScheduleType(state.RecurringSchedule.Type.ValueString()),
+			Unit:                int(state.RecurringSchedule.Unit.ValueInt64()),
+			EndType:             deploymentfreezes.RecurringScheduleEndType(state.RecurringSchedule.EndType.ValueString()),
+			EndAfterOccurrences: util.GetOptionalIntValue(state.RecurringSchedule.EndAfterOccurrences),
+			MonthlyScheduleType: util.GetOptionalString(state.RecurringSchedule.MonthlyScheduleType),
+			DateOfMonth:         util.GetOptionalString(state.RecurringSchedule.DateOfMonth),
+			DayNumberOfMonth:    util.GetOptionalString(state.RecurringSchedule.DayNumberOfMonth),
+			DaysOfWeek:          daysOfWeek,
+			DayOfWeek:           util.GetOptionalString(state.RecurringSchedule.DayOfWeek),
+		}
+
+		if !state.RecurringSchedule.EndOnDate.IsNull() {
+			date, diagsDate := state.RecurringSchedule.EndOnDate.ValueRFC3339Time()
+			if diagsDate.HasError() {
+				diags.Append(diagsDate...)
+				return nil, diags
+			}
+			freeze.RecurringSchedule.EndOnDate = &date
+		}
+	}
+
+	freeze.ID = state.ID.String()
+	return &freeze, nil
+}
+
+func mapFromProjectDeploymentFreezeToState(ctx context.Context, state *projectDeploymentFreezeModel, deploymentFreeze *deploymentfreezes.DeploymentFreeze) diag.Diagnostics {
+	state.ID = types.StringValue(deploymentFreeze.ID)
+	state.OwnerID = types.StringValue(deploymentFreeze.OwnerId)
+	state.Name = types.StringValue(deploymentFreeze.Name)
+
+	updatedStart, diags := util.CalculateStateTime(ctx, state.Start, *deploymentFreeze.Start)
+	if diags.HasError() {
+		return diags
+	}
+	state.Start = updatedStart
+
+	updatedEnd, diags := util.CalculateStateTime(ctx, state.End, *deploymentFreeze.End)
+	if diags.HasError() {
+		return diags
+	}
+	state.End = updatedEnd
+
+	if deploymentFreeze.ProjectEnvironmentScope != nil {
+		state.EnvironmentIDs = util.FlattenStringList(deploymentFreeze.ProjectEnvironmentScope[state.OwnerID.ValueString()])
+	}
+
+	if deploymentFreeze.RecurringSchedule != nil {
+		var daysOfWeek types.List
+		if len(deploymentFreeze.RecurringSchedule.DaysOfWeek) > 0 {
+			elements := make([]attr.Value, len(deploymentFreeze.RecurringSchedule.DaysOfWeek))
+			for i, day := range deploymentFreeze.RecurringSchedule.DaysOfWeek {
+				elements[i] = types.StringValue(day)
+			}
+
+			var listDiags diag.Diagnostics
+			daysOfWeek, listDiags = types.ListValue(types.StringType, elements)
+			if listDiags.HasError() {
+				diags.Append(listDiags...)
+				return diags
+			}
+		} else {
+			daysOfWeek = types.ListNull(types.StringType)
+		}
+
+		state.RecurringSchedule = &recurringScheduleModel{
+			Type:                types.StringValue(string(deploymentFreeze.RecurringSchedule.Type)),
+			Unit:                types.Int64Value(int64(deploymentFreeze.RecurringSchedule.Unit)),
+			EndType:             types.StringValue(string(deploymentFreeze.RecurringSchedule.EndType)),
+			DaysOfWeek:          daysOfWeek,
+			MonthlyScheduleType: util.MapOptionalStringValue(deploymentFreeze.RecurringSchedule.MonthlyScheduleType),
+		}
+
+		if deploymentFreeze.RecurringSchedule.EndOnDate != nil {
+			state.RecurringSchedule.EndOnDate = timetypes.NewRFC3339TimeValue(*deploymentFreeze.RecurringSchedule.EndOnDate)
+		} else {
+			state.RecurringSchedule.EndOnDate = timetypes.NewRFC3339Null()
+		}
+
+		state.RecurringSchedule.EndAfterOccurrences = util.MapOptionalIntValue(deploymentFreeze.RecurringSchedule.EndAfterOccurrences)
+		state.RecurringSchedule.DateOfMonth = util.MapOptionalStringValue(deploymentFreeze.RecurringSchedule.DateOfMonth)
+		state.RecurringSchedule.DayNumberOfMonth = util.MapOptionalStringValue(deploymentFreeze.RecurringSchedule.DayNumberOfMonth)
+		state.RecurringSchedule.DayOfWeek = util.MapOptionalStringValue(deploymentFreeze.RecurringSchedule.DayOfWeek)
+	}
+
+	return nil
+}

--- a/octopusdeploy_framework/schemas/project_deployment_freeze.go
+++ b/octopusdeploy_framework/schemas/project_deployment_freeze.go
@@ -1,0 +1,227 @@
+package schemas
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	datasourceSchema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	resourceSchema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type ProjectDeploymentFreezeSchema struct{}
+
+func (d ProjectDeploymentFreezeSchema) GetResourceSchema() resourceSchema.Schema {
+	return resourceSchema.Schema{
+		Attributes: map[string]resourceSchema.Attribute{
+			"id": GetIdResourceSchema(),
+			"owner_id": resourceSchema.StringAttribute{
+				Description: "The Owner ID of the freeze",
+				Required:    true,
+			},
+			"name":  GetNameResourceSchema(true),
+			"start": GetDateTimeResourceSchema("The start time of the freeze, must be RFC3339 format", true),
+			"end":   GetDateTimeResourceSchema("The end time of the freeze, must be RFC3339 format", true),
+			"environment_ids": resourceSchema.ListAttribute{
+				Description: "The environment IDs associated with this project deployment freeze scope",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
+			"recurring_schedule": resourceSchema.SingleNestedAttribute{
+				Optional: true,
+				Validators: []validator.Object{
+					NewRecurringScheduleValidator(),
+				},
+				Attributes: map[string]resourceSchema.Attribute{
+					"type": resourceSchema.StringAttribute{
+						Description: "Type of recurring schedule (Daily, Weekly, Monthly, Annually)",
+						Required:    true,
+						Validators: []validator.String{
+							stringvalidator.OneOf("Daily", "Weekly", "Monthly", "Annually"),
+						},
+					},
+					"unit": resourceSchema.Int64Attribute{
+						Description: "The unit value for the schedule",
+						Required:    true,
+					},
+					"end_type": resourceSchema.StringAttribute{
+						Description: "When the recurring schedule should end (Never, OnDate, AfterOccurrences)",
+						Required:    true,
+						Validators: []validator.String{
+							stringvalidator.OneOf("Never", "OnDate", "AfterOccurrences"),
+						},
+					},
+					"end_on_date": GetDateTimeResourceSchema("The date when the recurring schedule should end", false),
+					"end_after_occurrences": resourceSchema.Int64Attribute{
+						Description: "Number of occurrences after which the schedule should end",
+						Optional:    true,
+					},
+					"monthly_schedule_type": resourceSchema.StringAttribute{
+						Description: "Type of monthly schedule (DayOfMonth, DateOfMonth)",
+						Optional:    true,
+						Validators: []validator.String{
+							stringvalidator.OneOf("DayOfMonth", "DateOfMonth"),
+						},
+					},
+					"date_of_month": resourceSchema.StringAttribute{
+						Description: "The date of the month for monthly schedules",
+						Optional:    true,
+					},
+					"day_number_of_month": resourceSchema.StringAttribute{
+						Description: "Specifies which weekday position in the month. Valid values: 1 (First), 2 (Second), 3 (Third), 4 (Fourth), L (Last). Used with day_of_week",
+						Optional:    true,
+						Validators: []validator.String{
+							stringvalidator.OneOf("1", "2", "3", "4", "L"),
+						},
+					},
+					"days_of_week": resourceSchema.ListAttribute{
+						Description: "List of days of the week for weekly schedules. Must follow order: Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday",
+						Optional:    true,
+						ElementType: types.StringType,
+						Validators: []validator.List{
+							NewDaysOfWeekValidator(),
+						},
+					},
+					"day_of_week": resourceSchema.StringAttribute{
+						Description: "The day of the week for monthly schedules when using DayOfMonth type",
+						Optional:    true,
+						Validators: []validator.String{
+							stringvalidator.OneOf("Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d ProjectDeploymentFreezeSchema) GetDatasourceSchema() datasourceSchema.Schema {
+	return datasourceSchema.Schema{
+		Description: "Provides information about deployment freezes",
+		Attributes: map[string]datasourceSchema.Attribute{
+			"id":           GetIdDatasourceSchema(true),
+			"ids":          GetQueryIDsDatasourceSchema(),
+			"skip":         GetQuerySkipDatasourceSchema(),
+			"take":         GetQueryTakeDatasourceSchema(),
+			"partial_name": GetQueryPartialNameDatasourceSchema(),
+			"project_ids": datasourceSchema.ListAttribute{
+				Description: "A filter to search by a list of project IDs",
+				ElementType: types.StringType,
+				Optional:    true,
+			},
+			"tenant_ids": datasourceSchema.ListAttribute{
+				Description: "A filter to search by a list of tenant IDs",
+				ElementType: types.StringType,
+				Optional:    true,
+			},
+			"environment_ids": datasourceSchema.ListAttribute{
+				Description: "A filter to search by a list of environment IDs",
+				ElementType: types.StringType,
+				Optional:    true,
+			},
+			"include_complete": GetBooleanDatasourceAttribute("Include deployment freezes that completed, default is true", true),
+			"status": datasourceSchema.StringAttribute{
+				Description: "Filter by the status of the deployment freeze, value values are Expired, Active, Scheduled (case-insensitive)",
+				Optional:    true,
+			},
+			"deployment_freezes": datasourceSchema.ListNestedAttribute{
+				NestedObject: datasourceSchema.NestedAttributeObject{
+					Attributes: map[string]datasourceSchema.Attribute{
+						"id": GetIdDatasourceSchema(true),
+						"owner_id": datasourceSchema.StringAttribute{
+							Optional:    false,
+							Computed:    true,
+							Description: "The Owner ID of the freeze.",
+						},
+						"name": GetReadonlyNameDatasourceSchema(),
+						"start": datasourceSchema.StringAttribute{
+							Description: "The start time of the freeze",
+							Optional:    false,
+							Computed:    true,
+						},
+						"end": datasourceSchema.StringAttribute{
+							Description: "The end time of the freeze",
+							Optional:    false,
+							Computed:    true,
+						},
+						"project_environment_scope": datasourceSchema.MapAttribute{
+							ElementType: types.ListType{ElemType: types.StringType},
+							Description: "The project environment scope of the deployment freeze",
+							Optional:    false,
+							Computed:    true,
+						},
+						"tenant_project_environment_scope": datasourceSchema.ListNestedAttribute{
+							Description: "The tenant project environment scope of the deployment freeze",
+							Optional:    false,
+							Computed:    true,
+							NestedObject: datasourceSchema.NestedAttributeObject{
+								Attributes: map[string]datasourceSchema.Attribute{
+									"tenant_id": datasourceSchema.StringAttribute{
+										Description: "The tenant ID",
+										Computed:    true,
+									},
+									"project_id": datasourceSchema.StringAttribute{
+										Description: "The project ID",
+										Computed:    true,
+									},
+									"environment_id": datasourceSchema.StringAttribute{
+										Description: "The environment ID",
+										Computed:    true,
+									},
+								},
+							},
+						},
+						"recurring_schedule": datasourceSchema.SingleNestedAttribute{
+							Computed: true,
+							Attributes: map[string]datasourceSchema.Attribute{
+								"type": datasourceSchema.StringAttribute{
+									Description: "Type of recurring schedule (OnceDaily, DaysPerWeek, DaysPerMonth, Annually)",
+									Computed:    true,
+								},
+								"unit": datasourceSchema.Int64Attribute{
+									Description: "The unit value for the schedule",
+									Computed:    true,
+								},
+								"end_type": datasourceSchema.StringAttribute{
+									Description: "When the recurring schedule should end (Never, OnDate, AfterOccurrences)",
+									Computed:    true,
+								},
+								"end_on_date": datasourceSchema.StringAttribute{
+									Description: "The date when the recurring schedule should end",
+									Computed:    true,
+								},
+								"end_after_occurrences": datasourceSchema.Int64Attribute{
+									Description: "Number of occurrences after which the schedule should end",
+									Computed:    true,
+								},
+								"monthly_schedule_type": datasourceSchema.StringAttribute{
+									Description: "Type of monthly schedule (DayOfMonth, DateOfMonth)",
+									Computed:    true,
+								},
+								"date_of_month": datasourceSchema.StringAttribute{
+									Description: "The date of the month for monthly schedules",
+									Computed:    true,
+								},
+								"day_number_of_month": datasourceSchema.StringAttribute{
+									Description: "The day number of the month for monthly schedules",
+									Computed:    true,
+								},
+								"days_of_week": datasourceSchema.ListAttribute{
+									Description: "List of days of the week for weekly schedules",
+									Computed:    true,
+									ElementType: types.StringType,
+								},
+								"day_of_week": datasourceSchema.StringAttribute{
+									Description: "The day of the week for monthly schedules",
+									Computed:    true,
+								},
+							},
+						},
+					},
+				},
+				Computed: true,
+			},
+		},
+	}
+}
+
+var _ EntitySchema = &ProjectDeploymentFreezeSchema{}


### PR DESCRIPTION
With the following Terraform configuration:
```hcl
resource "octopusdeploy_project" "freezetest" {
  space_id = octopusdeploy_space.project_freeze_test.id
  name = "Test Project"
  project_group_id = data.octopusdeploy_project_groups.default.project_groups[0].id
  lifecycle_id = data.octopusdeploy_lifecycles.default.lifecycles[0].id
}

resource "octopusdeploy_environment" "dev" {
  space_id = octopusdeploy_space.project_freeze_test.id
  name = "Dev"
}

resource "octopusdeploy_tenant" "tenant1" {
  space_id = octopusdeploy_space.project_freeze_test.id
  name = "Tenant 1"
}

resource "octopusdeploy_tenant_project" "tenant1freezetest" {
  space_id = octopusdeploy_space.project_freeze_test.id
  project_id = octopusdeploy_project.freezetest.id
  tenant_id = octopusdeploy_tenant.tenant1.id
  environment_ids = [octopusdeploy_environment.dev.id]
}

resource "octopusdeploy_project_deployment_freeze" "xmas" {
  owner_id = octopusdeploy_project.freezetest.id
  name = "Xmas"
  start = "2025-12-24T00:00:00+10:00"
  end = "2025-12-27T00:00:00+10:00"
  recurring_schedule = {
    type = "Annually"
    unit = 1
    end_type = "Never"
  }
  environment_ids = [octopusdeploy_environment.dev.id]
}

resource "octopusdeploy_deployment_freeze_tenant" "xmasfreezetenant1" {
  deploymentfreeze_id = octopusdeploy_project_deployment_freeze.xmas.id
  project_id = octopusdeploy_project.freezetest.id
  tenant_id = octopusdeploy_tenant.tenant1.id
  environment_id = octopusdeploy_environment.dev.id
}
```
Creates the following project deployment freeze in Octopus:
<img width="1305" alt="image" src="https://github.com/user-attachments/assets/9e0aaa8e-1005-453d-8691-966b2808afed" />
