### PR TITLE
Support runbooks for new process resource

### DIFF
--- a/docs/resources/process.md
+++ b/docs/resources/process.md
@@ -13,10 +13,17 @@ This resource manages execution processes in Octopus Deploy.
 ## Example Usage
 
 ```terraform
-# Steps moved into separate resources
+# Deployment process
 resource "octopusdeploy_process" "example" {
   space_id = "Spaces-1"
-  owner_id  = "Projects-21"
+  project_id  = "Projects-21"
+}
+
+# Runbook process
+resource "octopusdeploy_process" "example" {
+  space_id = "Spaces-1"
+  project_id  = "Projects-21"
+  runbook_id  = "Runbooks-42"
 }
 ```
 
@@ -25,10 +32,11 @@ resource "octopusdeploy_process" "example" {
 
 ### Required
 
-- `owner_id` (String) Id of the resource this process belongs to.
+- `project_id` (String) Id of the project this process belongs to.
 
 ### Optional
 
+- `runbook_id` (String) Id of the runbook this process belongs to. When not set this resource represents deployment process of the project
 - `space_id` (String) The space ID associated with this process.
 
 ### Read-Only

--- a/examples/resources/octopusdeploy_process/resource.tf
+++ b/examples/resources/octopusdeploy_process/resource.tf
@@ -1,5 +1,12 @@
-# Steps moved into separate resources
+# Deployment process
 resource "octopusdeploy_process" "example" {
   space_id = "Spaces-1"
-  owner_id  = "Projects-21"
+  project_id  = "Projects-21"
+}
+
+# Runbook process
+resource "octopusdeploy_process" "example" {
+  space_id = "Spaces-1"
+  project_id  = "Projects-21"
+  runbook_id  = "Runbooks-42"
 }

--- a/octopusdeploy_framework/process_wrapper.go
+++ b/octopusdeploy_framework/process_wrapper.go
@@ -1,0 +1,250 @@
+package octopusdeploy_framework
+
+import (
+	"fmt"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/deployments"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/runbookprocess"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/runbooks"
+	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"strings"
+)
+
+// A wrapper of deployment- or runbook processes.
+//
+// Provides common "abstraction" so both processes can be managed by the process resource
+type processWrapper interface { // Better name?
+	GetID() string
+	GetSpaceID() string
+	PopulateState(state *schemas.ProcessResourceModel)
+	AppendStep(step *deployments.DeploymentStep)
+	RemoveStep(stepId string)
+	ReplaceSteps(steps []*deployments.DeploymentStep)
+	// Update sends underlying process to the server via corresponding API endpoint
+	//
+	// Returns new instance with updated process, original process remains unchanged
+	Update(client *client.Client) (processWrapper, error)
+	FindStepByID(stepID string) (*deployments.DeploymentStep, bool)
+	FindStepByName(name string) (*deployments.DeploymentStep, bool)
+	GetSteps() []*deployments.DeploymentStep
+}
+
+func findDeploymentStepByID(steps []*deployments.DeploymentStep, stepID string) (*deployments.DeploymentStep, bool) {
+	for _, step := range steps {
+		if step.ID == stepID {
+			return step, true
+		}
+	}
+	return nil, false
+}
+
+func findDeploymentStepByName(steps []*deployments.DeploymentStep, name string) (*deployments.DeploymentStep, bool) {
+	for _, step := range steps {
+		if step.Name == name {
+			return step, true
+		}
+	}
+	return nil, false
+}
+
+// loadProcessWrapperForSteps determines projectId before loading deployment or runbook process.
+//
+// Returns wrapper of the process or error when process is not found or warning when corresponding project is version controlled.
+func loadProcessWrapperForSteps(client *client.Client, spaceId string, processId string) (processWrapper, diag.Diagnostics) {
+	switch kind, ownerId := deconstructProcessIdentifier(processId); kind {
+	case "deployment":
+		return loadProcessWrapper(client, spaceId, ownerId, processId)
+	case "runbook":
+		runbook, err := runbooks.GetByID(client, spaceId, ownerId)
+		if err != nil {
+			runbookNotFound := diag.NewErrorDiagnostic("Unable to load runbook for process", err.Error())
+			return nil, diag.Diagnostics{runbookNotFound}
+		}
+
+		return loadProcessWrapper(client, spaceId, runbook.ProjectID, processId)
+	default:
+		invalidIdentifier := diag.NewErrorDiagnostic("Unable to load process", fmt.Sprintf("Invalid process identifier '%s'", processId))
+		return nil, diag.Diagnostics{invalidIdentifier}
+	}
+}
+
+// loadProcessWrapper loads deployment or runbook process and returns a wrapper of the loaded process.
+//
+// Returns error when process is not found and warning when corresponding project is version controlled.
+func loadProcessWrapper(client *client.Client, spaceId string, projectId string, processId string) (processWrapper, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	// Load corresponding project to check if it's version controlled
+	project, projectError := projects.GetByID(client, spaceId, projectId)
+	if projectError != nil {
+		diags.AddError("Unable to load project for the process", projectError.Error())
+		return nil, diags
+	}
+
+	if project.PersistenceSettings != nil && project.PersistenceSettings.Type() == projects.PersistenceSettingsTypeVersionControlled {
+		diags.AddWarning("Process persisted under version control system", "Version controlled resources will not be modified via terraform")
+		return nil, diags
+	}
+
+	switch kind, _ := deconstructProcessIdentifier(processId); kind {
+	case "deployment":
+		process, processError := deployments.GetDeploymentProcessByID(client, spaceId, processId)
+		if processError != nil {
+			diags.AddError("Unable to load deployment process", processError.Error())
+			return nil, diags
+		}
+
+		return deploymentProcessWrapper{process}, diags
+	case "runbook":
+		process, runbookError := runbookprocess.GetByID(client, spaceId, processId)
+		if runbookError != nil {
+			diags.AddError("Unable to load runbook process", runbookError.Error())
+			return nil, diags
+		}
+
+		return runbookProcessWrapper{process}, diags
+	default:
+		diags.AddError("Unable to load process", fmt.Sprintf("Invalid process identifier '%s'", processId))
+		return nil, diags
+	}
+}
+
+// deconstructProcessIdentifier determines what kind of the process given identifier represents.
+//
+// Returns determined kind and extracted owner identifier.
+//
+// Relies on the fact that owner id is embedded in the processId
+func deconstructProcessIdentifier(processId string) (kind string, owner string) {
+	const deploymentPrefix = "deploymentprocess-"
+	if strings.HasPrefix(processId, deploymentPrefix) {
+		projectId := processId[len(deploymentPrefix):]
+		return "deployment", projectId
+	}
+
+	const runbookPrefix = "RunbookProcess-"
+	if strings.HasPrefix(processId, runbookPrefix) {
+		runbookId := processId[len(runbookPrefix):]
+		return "runbook", runbookId
+	}
+
+	return "unknown", ""
+}
+
+type deploymentProcessWrapper struct {
+	process *deployments.DeploymentProcess
+}
+
+func (w deploymentProcessWrapper) GetID() string {
+	return w.process.GetID()
+}
+
+func (w deploymentProcessWrapper) GetSpaceID() string {
+	return w.process.SpaceID
+}
+
+func (w deploymentProcessWrapper) PopulateState(state *schemas.ProcessResourceModel) {
+	state.ID = types.StringValue(w.process.ID)
+	state.SpaceID = types.StringValue(w.process.SpaceID)
+	state.ProjectID = types.StringValue(w.process.ProjectID)
+	state.RunbookID = types.StringNull()
+}
+
+func (w deploymentProcessWrapper) AppendStep(step *deployments.DeploymentStep) {
+	w.process.Steps = append(w.process.Steps, step)
+}
+
+func (w deploymentProcessWrapper) RemoveStep(stepId string) {
+	var filteredSteps []*deployments.DeploymentStep
+	for _, step := range w.process.Steps {
+		if stepId != step.GetID() {
+			filteredSteps = append(filteredSteps, step)
+		}
+	}
+	w.process.Steps = filteredSteps
+}
+
+func (w deploymentProcessWrapper) ReplaceSteps(steps []*deployments.DeploymentStep) {
+	w.process.Steps = steps
+}
+
+func (w deploymentProcessWrapper) Update(client *client.Client) (processWrapper, error) {
+	updated, err := deployments.UpdateDeploymentProcess(client, w.process)
+	if err != nil {
+		return nil, err
+	}
+
+	return deploymentProcessWrapper{updated}, nil
+}
+
+func (w deploymentProcessWrapper) FindStepByID(stepID string) (*deployments.DeploymentStep, bool) {
+	return findDeploymentStepByID(w.process.Steps, stepID)
+}
+
+func (w deploymentProcessWrapper) FindStepByName(name string) (*deployments.DeploymentStep, bool) {
+	return findDeploymentStepByName(w.process.Steps, name)
+}
+
+func (w deploymentProcessWrapper) GetSteps() []*deployments.DeploymentStep {
+	return w.process.Steps
+}
+
+type runbookProcessWrapper struct {
+	process *runbookprocess.RunbookProcess
+}
+
+func (w runbookProcessWrapper) GetID() string {
+	return w.process.GetID()
+}
+
+func (w runbookProcessWrapper) GetSpaceID() string {
+	return w.process.SpaceID
+}
+
+func (w runbookProcessWrapper) PopulateState(state *schemas.ProcessResourceModel) {
+	state.ID = types.StringValue(w.process.ID)
+	state.SpaceID = types.StringValue(w.process.SpaceID)
+	state.ProjectID = types.StringValue(w.process.ProjectID)
+	state.RunbookID = types.StringValue(w.process.RunbookID)
+}
+
+func (w runbookProcessWrapper) AppendStep(step *deployments.DeploymentStep) {
+	w.process.Steps = append(w.process.Steps, step)
+}
+
+func (w runbookProcessWrapper) RemoveStep(stepId string) {
+	var filteredSteps []*deployments.DeploymentStep
+	for _, step := range w.process.Steps {
+		if stepId != step.GetID() {
+			filteredSteps = append(filteredSteps, step)
+		}
+	}
+	w.process.Steps = filteredSteps
+}
+
+func (w runbookProcessWrapper) ReplaceSteps(steps []*deployments.DeploymentStep) {
+	w.process.Steps = steps
+}
+
+func (w runbookProcessWrapper) Update(client *client.Client) (processWrapper, error) {
+	updated, err := runbookprocess.Update(client, w.process)
+	if err != nil {
+		return nil, err
+	}
+
+	return runbookProcessWrapper{updated}, nil
+}
+
+func (w runbookProcessWrapper) FindStepByID(stepID string) (*deployments.DeploymentStep, bool) {
+	return findDeploymentStepByID(w.process.Steps, stepID)
+}
+
+func (w runbookProcessWrapper) FindStepByName(name string) (*deployments.DeploymentStep, bool) {
+	return findDeploymentStepByName(w.process.Steps, name)
+}
+
+func (w runbookProcessWrapper) GetSteps() []*deployments.DeploymentStep {
+	return w.process.Steps
+}

--- a/octopusdeploy_framework/resource_process.go
+++ b/octopusdeploy_framework/resource_process.go
@@ -2,22 +2,16 @@ package octopusdeploy_framework
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/client"
-	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/core"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/deployments"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"net/http"
-	"strings"
-
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/projects"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/runbookprocess"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/runbooks"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/util"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -33,7 +27,7 @@ func NewProcessResource() resource.Resource {
 	return &processResource{}
 }
 
-func (r *processResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+func (r *processResource) Metadata(_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = util.GetTypeName(schemas.ProcessResourceName)
 }
 
@@ -49,7 +43,7 @@ func (r *processResource) ImportState(ctx context.Context, request resource.Impo
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), request, response)
 }
 
-func (r *processResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+func (r *processResource) ModifyPlan(_ context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
 	if req.Plan.Raw.IsNull() {
 		resp.Diagnostics.AddWarning("Deleting process", "Applying this resource destruction will not delete process and it's steps")
 		return
@@ -64,29 +58,49 @@ func (r *processResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	spaceId := data.SpaceID.ValueString()
-	projectId := data.OwnerID.ValueString()
+	projectId := data.ProjectID.ValueString()
+	runbookId := data.RunbookID.ValueString()
 
 	tflog.Info(ctx, fmt.Sprintf("creating process for owner: %s", projectId))
 
-	// Empty process is created as part of project creation
-	project, err := projects.GetByID(r.Config.Client, spaceId, projectId)
-	if err != nil {
-		resp.Diagnostics.AddError("Error creating process, unable to find associated project", err.Error())
+	project, projectError := projects.GetByID(r.Config.Client, spaceId, projectId)
+	if projectError != nil {
+		resp.Diagnostics.AddError("Error creating process, unable to find associated project", projectError.Error())
 		return
 	}
 
 	if project.PersistenceSettings != nil && project.PersistenceSettings.Type() == projects.PersistenceSettingsTypeVersionControlled {
-		resp.Diagnostics.AddWarning("Cannot create process", "Project persisted under version control system. Process of version controlled project cannot be created")
+		resp.Diagnostics.AddError("Cannot create process for version controlled project", "Version controlled resources will not be modified via terraform")
 		return
 	}
 
-	process, err := deployments.GetDeploymentProcessByID(r.Config.Client, spaceId, project.DeploymentProcessID)
-	if err != nil {
-		resp.Diagnostics.AddError("Error creating process", err.Error())
-		return
+	// Empty process is created as part of the project or runbook creation
+	var process processWrapper
+	if runbookId != "" {
+		runbook, runbookError := runbooks.GetByID(r.Config.Client, spaceId, data.RunbookID.ValueString())
+		if runbookError != nil {
+			resp.Diagnostics.AddError("Error creating process, unable to find associated runbook", runbookError.Error())
+			return
+		}
+
+		runbookProcess, processError := runbookprocess.GetByID(r.Config.Client, spaceId, runbook.RunbookProcessID)
+		if processError != nil {
+			resp.Diagnostics.AddError("Error creating runbook process", processError.Error())
+			return
+		}
+
+		process = runbookProcessWrapper{runbookProcess}
+	} else {
+		deploymentProcess, processError := deployments.GetDeploymentProcessByID(r.Config.Client, spaceId, project.DeploymentProcessID)
+		if processError != nil {
+			resp.Diagnostics.AddError("Error creating deployment process", processError.Error())
+			return
+		}
+
+		process = deploymentProcessWrapper{deploymentProcess}
 	}
 
-	mapProcessToState(process, data)
+	process.PopulateState(data)
 
 	tflog.Info(ctx, fmt.Sprintf("process created (%s)", data.ID))
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -100,20 +114,20 @@ func (r *processResource) Read(ctx context.Context, req resource.ReadRequest, re
 	}
 
 	spaceId := data.SpaceID.ValueString()
-	projectId := data.OwnerID.ValueString()
+	projectId := data.ProjectID.ValueString()
 	processId := data.ID.ValueString()
 
 	tflog.Info(ctx, fmt.Sprintf("reading process (%s)", processId))
 
-	process, diags := loadProcess(r.Config.Client, spaceId, projectId, processId)
+	process, diags := loadProcessWrapper(r.Config.Client, spaceId, projectId, processId)
 	if len(diags) > 0 {
 		resp.Diagnostics.Append(diags...)
 		return
 	}
 
-	mapProcessToState(process, data)
+	process.PopulateState(data)
 
-	tflog.Info(ctx, fmt.Sprintf("process read (%s)", process.ID))
+	tflog.Info(ctx, fmt.Sprintf("process read (%s)", process.GetID()))
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -125,20 +139,19 @@ func (r *processResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	spaceId := data.SpaceID.ValueString()
-	projectId := data.OwnerID.ValueString()
+	projectId := data.ProjectID.ValueString()
 	processId := data.ID.ValueString()
 
 	tflog.Info(ctx, fmt.Sprintf("updating process (%s)", data.ID))
 
-	process, diags := loadProcess(r.Config.Client, spaceId, projectId, processId)
+	process, diags := loadProcessWrapper(r.Config.Client, spaceId, projectId, processId)
 	if len(diags) > 0 {
 		resp.Diagnostics.Append(diags...)
 		return
 	}
 
-	// Nothing to update, when owner_id is changed we want to replace this resource with process from another owner
-
-	mapProcessToState(process, data)
+	// Nothing to update, when projectId or runbookId are changed we want to replace this resource with process from another owner
+	process.PopulateState(data)
 
 	tflog.Info(ctx, fmt.Sprintf("process updated (%s)", process.GetID()))
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -152,69 +165,19 @@ func (r *processResource) Delete(ctx context.Context, req resource.DeleteRequest
 	}
 
 	spaceId := data.SpaceID.ValueString()
-	projectId := data.OwnerID.ValueString()
+	projectId := data.ProjectID.ValueString()
 	processId := data.ID.ValueString()
 
 	tflog.Info(ctx, fmt.Sprintf("deleting process (%s)", data.ID))
 
-	_, diags := loadProcess(r.Config.Client, spaceId, projectId, processId)
+	_, diags := loadProcessWrapper(r.Config.Client, spaceId, projectId, processId)
 	if len(diags) > 0 {
 		resp.Diagnostics.Append(diags...)
 		return
 	}
 
 	// Do nothing, because process can not be deleted from the project
-	resp.Diagnostics.AddWarning("Deleting process", "Destruction of this resource will not delete process from the project")
+	resp.Diagnostics.AddWarning("Deleting process", "Destruction of this resource will not remove the process from the system")
 
 	resp.State.RemoveResource(ctx)
-}
-
-func mapProcessToState(process *deployments.DeploymentProcess, state *schemas.ProcessResourceModel) {
-	state.ID = types.StringValue(process.ID)
-	state.SpaceID = types.StringValue(process.SpaceID)
-	state.OwnerID = types.StringValue(process.ProjectID)
-}
-
-func loadProcess(client *client.Client, spaceId string, projectId string, processId string) (*deployments.DeploymentProcess, diag.Diagnostics) {
-	process, processError := deployments.GetDeploymentProcessByID(client, spaceId, processId)
-	if processError == nil {
-		return process, diag.Diagnostics{}
-	}
-
-	processNotFound := diag.Diagnostics{}
-	processNotFound.AddError("unable to load process", processError.Error())
-
-	var apiError *core.APIError
-	if errors.As(processError, &apiError) && apiError.StatusCode == http.StatusNotFound {
-		// Try to load corresponding project to check if it's version controlled
-		project, err := projects.GetByID(client, spaceId, projectId)
-		if err != nil {
-			return nil, processNotFound // return original error when project cannot be loaded
-		}
-
-		if project.PersistenceSettings == nil {
-			return nil, processNotFound
-		}
-
-		if project.PersistenceSettings.Type() == projects.PersistenceSettingsTypeVersionControlled {
-			versionControlled := diag.Diagnostics{}
-			versionControlled.AddWarning("process persisted under version control system", "Version controlled resources will not be modified via terraform")
-			return nil, versionControlled
-		}
-	}
-
-	return nil, processNotFound
-}
-
-func loadProcessForSteps(client *client.Client, spaceId string, processId string) (*deployments.DeploymentProcess, diag.Diagnostics) {
-	projectId := ""
-
-	// Assumes that project id is part of the process identifier
-	// This approach allows us to avoid dependencies between resources and avoid adding "project_id" to all process resources
-	const prefix = "deploymentprocess-"
-	if strings.HasPrefix(processId, prefix) {
-		projectId = processId[len(prefix):]
-	}
-
-	return loadProcess(client, spaceId, projectId, processId)
 }

--- a/octopusdeploy_framework/resource_process.go
+++ b/octopusdeploy_framework/resource_process.go
@@ -83,6 +83,11 @@ func (r *processResource) Create(ctx context.Context, req resource.CreateRequest
 			return
 		}
 
+		if runbook.ProjectID != project.ID {
+			resp.Diagnostics.AddError("Error creating process", "Provided runbook does not belong to the given project")
+			return
+		}
+
 		runbookProcess, processError := runbookprocess.GetByID(r.Config.Client, spaceId, runbook.RunbookProcessID)
 		if processError != nil {
 			resp.Diagnostics.AddError("Error creating runbook process", processError.Error())

--- a/octopusdeploy_framework/resource_process_child_step_mapping_test.go
+++ b/octopusdeploy_framework/resource_process_child_step_mapping_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/gitdependencies"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/packages"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/runbookprocess"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -211,7 +212,166 @@ func TestAccMapProcessChildStepToStateWithAllAttributes(t *testing.T) {
 		SpaceID:   types.StringValue(process.SpaceID),
 		ProcessID: types.StringValue(process.ID),
 	}
-	diags := mapProcessChildStepActionToState(process, step, action, &state)
+	diags := mapProcessChildStepActionToState(deploymentProcessWrapper{process}, step, action, &state)
+
+	assert.False(t, diags.HasError(), "Expected no errors in diagnostics")
+
+	expectedState := schemas.ProcessChildStepResourceModel{
+		SpaceID:            types.StringValue(process.SpaceID),
+		ProcessID:          types.StringValue(process.ID),
+		Name:               types.StringValue(action.Name),
+		ParentID:           types.StringValue(step.ID),
+		Type:               types.StringValue(action.ActionType),
+		Slug:               types.StringValue(action.Slug),
+		IsRequired:         types.BoolValue(action.IsRequired),
+		IsDisabled:         types.BoolValue(action.IsDisabled),
+		Condition:          types.StringValue(action.Condition),
+		Notes:              types.StringValue(action.Notes),
+		WorkerPoolID:       types.StringValue(action.WorkerPool),
+		WorkerPoolVariable: types.StringValue(action.WorkerPoolVariable),
+		TenantTags: types.SetValueMust(types.StringType, []attr.Value{
+			types.StringValue("tag-1"),
+			types.StringValue("tag-2"),
+		}),
+		Environments: types.SetValueMust(types.StringType, []attr.Value{
+			types.StringValue("Environments-1"),
+			types.StringValue("Environments-2"),
+		}),
+		ExcludedEnvironments: types.SetValueMust(types.StringType, []attr.Value{
+			types.StringValue("Environments-13"),
+		}),
+		Channels: types.SetValueMust(types.StringType, []attr.Value{
+			types.StringValue("Channels-1"),
+		}),
+		Container: &schemas.ProcessStepActionContainerModel{
+			FeedID: types.StringValue("Feeds-1"),
+			Image:  types.StringValue("docker.io/library/dummy:latest"),
+		},
+		GitDependencies: types.MapValueMust(schemas.ProcessStepGitDependencyObjectType(), map[string]attr.Value{
+			gitDependency.Name: types.ObjectValueMust(
+				schemas.ProcessStepGitDependencyAttributeTypes(),
+				map[string]attr.Value{
+					"repository_uri":      types.StringValue(gitDependency.RepositoryUri),
+					"default_branch":      types.StringValue(gitDependency.DefaultBranch),
+					"git_credential_type": types.StringValue(gitDependency.GitCredentialType),
+					"git_credential_id":   types.StringValue(gitDependency.GitCredentialId),
+					"file_path_filters": types.SetValueMust(types.StringType, []attr.Value{
+						types.StringValue("directory-b"),
+					}),
+				},
+			),
+		}),
+		Packages: types.MapValueMust(schemas.ProcessStepPackageReferenceObjectType(), map[string]attr.Value{
+			primaryPackage.Name: types.ObjectValueMust(
+				schemas.ProcessStepPackageReferenceAttributeTypes(),
+				map[string]attr.Value{
+					"id":                   types.StringValue(primaryPackage.ID),
+					"package_id":           types.StringValue(primaryPackage.PackageID),
+					"feed_id":              types.StringValue(primaryPackage.FeedID),
+					"acquisition_location": types.StringValue(primaryPackage.AcquisitionLocation),
+					"properties": types.MapValueMust(types.StringType, map[string]attr.Value{
+						"Octopus.Package.IsPrimary": types.StringValue("True"),
+					}),
+				},
+			),
+			additionalPackage.Name: types.ObjectValueMust(
+				schemas.ProcessStepPackageReferenceAttributeTypes(),
+				map[string]attr.Value{
+					"id":                   types.StringValue(additionalPackage.ID),
+					"package_id":           types.StringValue(additionalPackage.PackageID),
+					"feed_id":              types.StringValue(additionalPackage.FeedID),
+					"acquisition_location": types.StringValue(additionalPackage.AcquisitionLocation),
+					"properties":           types.MapValueMust(types.StringType, map[string]attr.Value{}),
+				},
+			),
+		}),
+		ExecutionProperties: types.MapValueMust(types.StringType, map[string]attr.Value{
+			"Octopus.Action.RunOnServer":       types.StringValue("True"),
+			"Octopus.Action.Script.ScriptBody": types.StringValue("Write-Host \"Step 1, Action 1\""),
+		}),
+	}
+	expectedState.ID = types.StringValue(action.ID)
+
+	assert.Equal(t, expectedState, state)
+}
+
+func TestAccMapProcessChildStepToStateWithAllAttributesForRunbooks(t *testing.T) {
+	primaryPackage := &packages.PackageReference{
+		ID:                  "00000000-0000-0000-0000-000000000101",
+		Name:                "",
+		PackageID:           "Package-1",
+		FeedID:              "Feeds-1",
+		AcquisitionLocation: "ExecutionTarget",
+		Properties: map[string]string{
+			"Octopus.Package.IsPrimary": "True",
+		},
+	}
+	additionalPackage := &packages.PackageReference{
+		ID:                  "00000000-0000-0000-0000-000000000102",
+		Name:                "unique-name",
+		PackageID:           "Package-2",
+		FeedID:              "feeds-builtin",
+		AcquisitionLocation: "Server",
+	}
+	gitDependency := &gitdependencies.GitDependency{
+		Name:              "this-dependency",
+		RepositoryUri:     "git://test.repository.co.nz",
+		DefaultBranch:     "default",
+		GitCredentialType: "NotSpecified",
+		FilePathFilters:   []string{"directory-b"},
+		GitCredentialId:   "GitCredential-2",
+	}
+
+	action := deployments.NewDeploymentAction("Step One", "Octopus.Script")
+	action.SetID("00000000-0000-0000-0000-000000000011")
+	action.Name = "Child Step One"
+	action.Slug = "child-step-one"
+	action.ActionType = "Octopus.Script"
+	action.IsRequired = true
+	action.IsDisabled = false
+	action.Condition = "Success"
+	action.Notes = "Some notes"
+	action.WorkerPool = "WorkerPools-1"
+	action.WorkerPoolVariable = "#{Environment.WorkerPools.Default}"
+	action.TenantTags = []string{"tag-1", "tag-2"}
+	action.Environments = []string{"Environments-1", "Environments-2"}
+	action.ExcludedEnvironments = []string{"Environments-13"}
+	action.Channels = []string{"Channels-1"}
+	action.Container = &deployments.DeploymentActionContainer{
+		FeedID: "Feeds-1",
+		Image:  "docker.io/library/dummy:latest",
+	}
+	action.GitDependencies = []*gitdependencies.GitDependency{gitDependency}
+	action.Packages = []*packages.PackageReference{primaryPackage, additionalPackage}
+	action.Properties = map[string]core.PropertyValue{
+		"Octopus.Action.RunOnServer":       core.NewPropertyValue("True", false),
+		"Octopus.Action.Script.ScriptBody": core.NewPropertyValue("Write-Host \"Step 1, Action 1\"", false),
+	}
+
+	step := deployments.NewDeploymentStep("Step One")
+	step.SetID("00000000-0000-0000-0000-000000000001")
+	step.StartTrigger = "StartAfterPrevious"
+	step.PackageRequirement = "LetOctopusDecide"
+	step.Condition = "Success"
+	step.Properties = map[string]core.PropertyValue{
+		"Octopus.Action.MaxParallelism": core.NewPropertyValue("2", false),
+		"Octopus.Action.TargetRoles":    core.NewPropertyValue("agent-1,agent-2", false),
+	}
+	step.Actions = []*deployments.DeploymentAction{action}
+
+	process := &runbookprocess.RunbookProcess{
+		SpaceID:   "Spaces-1",
+		ProjectID: "Projects-1",
+		RunbookID: "Runbooks-1",
+		Steps:     []*deployments.DeploymentStep{step},
+	}
+	process.SetID("Processes-1")
+
+	state := schemas.ProcessChildStepResourceModel{
+		SpaceID:   types.StringValue(process.SpaceID),
+		ProcessID: types.StringValue(process.ID),
+	}
+	diags := mapProcessChildStepActionToState(runbookProcessWrapper{process}, step, action, &state)
 
 	assert.False(t, diags.HasError(), "Expected no errors in diagnostics")
 

--- a/octopusdeploy_framework/resource_process_child_step_test.go
+++ b/octopusdeploy_framework/resource_process_child_step_test.go
@@ -116,7 +116,7 @@ func newProcessChildStepTestDependenciesConfiguration(scenario string) processCh
 		}
 
 		resource "octopusdeploy_process" "%s" {
-		  owner_id  = octopusdeploy_project.%s.id
+		  project_id  = octopusdeploy_project.%s.id
 		}
 
 		resource "octopusdeploy_process_step" "%s" {
@@ -165,7 +165,7 @@ func testCheckResourceProcessChildStepExists() resource.TestCheckFunc {
 					return fmt.Errorf("expected process with id '%s' to exist: %s", processId, err)
 				}
 
-				step, stepExists := findStepFromProcessByID(process, stepId)
+				step, stepExists := deploymentProcessWrapper{process}.FindStepByID(stepId)
 				if !stepExists {
 					return fmt.Errorf("expected process (%s) to contain step (%s)", processId, stepId)
 				}

--- a/octopusdeploy_framework/resource_process_step_mapping_test.go
+++ b/octopusdeploy_framework/resource_process_step_mapping_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/gitdependencies"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/packages"
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/resources"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/runbookprocess"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -287,7 +288,170 @@ func TestAccMapProcessStepToStateWithAllAttributes(t *testing.T) {
 		SpaceID:   types.StringValue(process.SpaceID),
 		ProcessID: types.StringValue(process.ID),
 	}
-	diags := mapProcessStepToState(process, step, &state)
+	diags := mapProcessStepToState(deploymentProcessWrapper{process}, step, &state)
+
+	assert.False(t, diags.HasError(), "Expected no errors in diagnostics")
+
+	expectedState := schemas.ProcessStepResourceModel{
+		SpaceID:            types.StringValue("Spaces-1"),
+		ProcessID:          types.StringValue("Processes-1"),
+		Name:               types.StringValue("Step One"),
+		StartTrigger:       types.StringValue("StartAfterPrevious"),
+		PackageRequirement: types.StringValue("LetOctopusDecide"),
+		Condition:          types.StringValue("Success"),
+		Properties: types.MapValueMust(types.StringType, map[string]attr.Value{
+			"Octopus.Action.MaxParallelism": types.StringValue("2"),
+			"Octopus.Action.TargetRoles":    types.StringValue("agent-1,agent-2"),
+		}),
+		Type:               types.StringValue("Octopus.Script"),
+		Slug:               types.StringValue("step-one"),
+		IsRequired:         types.BoolValue(true),
+		IsDisabled:         types.BoolValue(false),
+		Notes:              types.StringValue(`Some notes`),
+		WorkerPoolID:       types.StringValue("WorkerPools-1"),
+		WorkerPoolVariable: types.StringValue("#{Environment.WorkerPools.Default}"),
+		TenantTags: types.SetValueMust(types.StringType, []attr.Value{
+			types.StringValue("tag-1"),
+			types.StringValue("tag-2"),
+		}),
+		Environments: types.SetValueMust(types.StringType, []attr.Value{
+			types.StringValue("Environments-1"),
+			types.StringValue("Environments-2"),
+		}),
+		ExcludedEnvironments: types.SetValueMust(types.StringType, []attr.Value{
+			types.StringValue("Environments-13"),
+		}),
+		Channels: types.SetValueMust(types.StringType, []attr.Value{
+			types.StringValue("Channels-1"),
+		}),
+		Container: &schemas.ProcessStepActionContainerModel{
+			FeedID: types.StringValue("Feeds-1"),
+			Image:  types.StringValue("docker.io/library/dummy:latest"),
+		},
+		GitDependencies: types.MapValueMust(schemas.ProcessStepGitDependencyObjectType(), map[string]attr.Value{
+			gitDependency.Name: types.ObjectValueMust(
+				schemas.ProcessStepGitDependencyAttributeTypes(),
+				map[string]attr.Value{
+					"repository_uri":      types.StringValue(gitDependency.RepositoryUri),
+					"default_branch":      types.StringValue(gitDependency.DefaultBranch),
+					"git_credential_type": types.StringValue(gitDependency.GitCredentialType),
+					"git_credential_id":   types.StringValue(gitDependency.GitCredentialId),
+					"file_path_filters": types.SetValueMust(types.StringType, []attr.Value{
+						types.StringValue("directory-b"),
+					}),
+				},
+			),
+		}),
+		Packages: types.MapValueMust(schemas.ProcessStepPackageReferenceObjectType(), map[string]attr.Value{
+			primaryPackage.Name: types.ObjectValueMust(
+				schemas.ProcessStepPackageReferenceAttributeTypes(),
+				map[string]attr.Value{
+					"id":                   types.StringValue(primaryPackage.ID),
+					"package_id":           types.StringValue(primaryPackage.PackageID),
+					"feed_id":              types.StringValue(primaryPackage.FeedID),
+					"acquisition_location": types.StringValue(primaryPackage.AcquisitionLocation),
+					"properties": types.MapValueMust(types.StringType, map[string]attr.Value{
+						"Octopus.Package.IsPrimary": types.StringValue("True"),
+					}),
+				},
+			),
+			additionalPackage.Name: types.ObjectValueMust(
+				schemas.ProcessStepPackageReferenceAttributeTypes(),
+				map[string]attr.Value{
+					"id":                   types.StringValue(additionalPackage.ID),
+					"package_id":           types.StringValue(additionalPackage.PackageID),
+					"feed_id":              types.StringValue(additionalPackage.FeedID),
+					"acquisition_location": types.StringValue(additionalPackage.AcquisitionLocation),
+					"properties":           types.MapValueMust(types.StringType, map[string]attr.Value{}),
+				},
+			),
+		}),
+		ExecutionProperties: types.MapValueMust(types.StringType, map[string]attr.Value{
+			"Octopus.Action.RunOnServer":       types.StringValue("True"),
+			"Octopus.Action.Script.ScriptBody": types.StringValue("Write-Host \"Step 1, Action 1\""),
+		}),
+	}
+	expectedState.ID = types.StringValue(step.ID)
+
+	assert.Equal(t, expectedState, state)
+}
+
+func TestAccMapProcessStepToStateWithAllAttributesForRunbook(t *testing.T) {
+	primaryPackage := &packages.PackageReference{
+		ID:                  "00000000-0000-0000-0000-000000000101",
+		Name:                "",
+		PackageID:           "Package-1",
+		FeedID:              "Feeds-1",
+		AcquisitionLocation: "ExecutionTarget",
+		Properties: map[string]string{
+			"Octopus.Package.IsPrimary": "True",
+		},
+	}
+	additionalPackage := &packages.PackageReference{
+		ID:                  "00000000-0000-0000-0000-000000000102",
+		Name:                "unique-name",
+		PackageID:           "Package-2",
+		FeedID:              "feeds-builtin",
+		AcquisitionLocation: "Server",
+	}
+	gitDependency := &gitdependencies.GitDependency{
+		Name:              "this-dependency",
+		RepositoryUri:     "git://test.repository.co.nz",
+		DefaultBranch:     "default",
+		GitCredentialType: "NotSpecified",
+		FilePathFilters:   []string{"directory-b"},
+		GitCredentialId:   "GitCredential-2",
+	}
+
+	action := deployments.NewDeploymentAction("Step One", "Octopus.Script")
+	action.SetID("00000000-0000-0000-0000-000000000011")
+	action.Name = "Step One"
+	action.Slug = "step-one"
+	action.ActionType = "Octopus.Script"
+	action.IsRequired = true
+	action.IsDisabled = false
+	action.Notes = "Some notes"
+	action.WorkerPool = "WorkerPools-1"
+	action.WorkerPoolVariable = "#{Environment.WorkerPools.Default}"
+	action.TenantTags = []string{"tag-1", "tag-2"}
+	action.Environments = []string{"Environments-1", "Environments-2"}
+	action.ExcludedEnvironments = []string{"Environments-13"}
+	action.Channels = []string{"Channels-1"}
+	action.Container = &deployments.DeploymentActionContainer{
+		FeedID: "Feeds-1",
+		Image:  "docker.io/library/dummy:latest",
+	}
+	action.GitDependencies = []*gitdependencies.GitDependency{gitDependency}
+	action.Packages = []*packages.PackageReference{primaryPackage, additionalPackage}
+	action.Properties = map[string]core.PropertyValue{
+		"Octopus.Action.RunOnServer":       core.NewPropertyValue("True", false),
+		"Octopus.Action.Script.ScriptBody": core.NewPropertyValue("Write-Host \"Step 1, Action 1\"", false),
+	}
+
+	step := deployments.NewDeploymentStep("Step One")
+	step.SetID("00000000-0000-0000-0000-000000000001")
+	step.StartTrigger = "StartAfterPrevious"
+	step.PackageRequirement = "LetOctopusDecide"
+	step.Condition = "Success"
+	step.Properties = map[string]core.PropertyValue{
+		"Octopus.Action.MaxParallelism": core.NewPropertyValue("2", false),
+		"Octopus.Action.TargetRoles":    core.NewPropertyValue("agent-1,agent-2", false),
+	}
+	step.Actions = []*deployments.DeploymentAction{action}
+
+	process := &runbookprocess.RunbookProcess{
+		SpaceID:   "Spaces-1",
+		ProjectID: "Projects-1",
+		RunbookID: "Runbooks-2",
+		Steps:     []*deployments.DeploymentStep{step},
+	}
+	process.SetID("Processes-1")
+
+	state := schemas.ProcessStepResourceModel{
+		SpaceID:   types.StringValue(process.SpaceID),
+		ProcessID: types.StringValue(process.ID),
+	}
+	diags := mapProcessStepToState(runbookProcessWrapper{process}, step, &state)
 
 	assert.False(t, diags.HasError(), "Expected no errors in diagnostics")
 

--- a/octopusdeploy_framework/resource_process_step_test.go
+++ b/octopusdeploy_framework/resource_process_step_test.go
@@ -110,7 +110,7 @@ func newProcessStepTestDependenciesConfiguration(scenario string) processStepTes
 		}
 
 		resource "octopusdeploy_process" "%s" {
-		  owner_id  = octopusdeploy_project.%s.id
+		  project_id  = octopusdeploy_project.%s.id
 		}
 		`,
 		projectGroup,
@@ -134,12 +134,13 @@ func testCheckResourceProcessStepExists() resource.TestCheckFunc {
 			if r.Type == "octopusdeploy_process_step" {
 				stepId := r.Primary.ID
 				processId := r.Primary.Attributes["process_id"]
-				process, err := deployments.GetDeploymentProcessByID(octoClient, octoClient.GetSpaceID(), processId)
-				if err != nil {
-					return fmt.Errorf("expected process with id '%s' to exist: %s", processId, err)
+				process, processError := deployments.GetDeploymentProcessByID(octoClient, octoClient.GetSpaceID(), processId)
+				if processError != nil {
+					return fmt.Errorf("expected process with id '%s' to exist: %s", processId, processError)
 				}
 
-				if _, exists := findStepFromProcessByID(process, stepId); !exists {
+				_, stepExists := deploymentProcessWrapper{process}.FindStepByID(stepId)
+				if !stepExists {
 					return fmt.Errorf("expected process (%s) to contain step (%s)", processId, stepId)
 				}
 			}

--- a/octopusdeploy_framework/resource_process_steps_order_mapping_test.go
+++ b/octopusdeploy_framework/resource_process_steps_order_mapping_test.go
@@ -2,6 +2,7 @@ package octopusdeploy_framework
 
 import (
 	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/deployments"
+	"github.com/OctopusDeploy/go-octopusdeploy/v2/pkg/runbookprocess"
 	"github.com/OctopusDeploy/terraform-provider-octopusdeploy/octopusdeploy_framework/schemas"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -37,7 +38,51 @@ func TestAccMapProcessStepsOrderingFromStateAddMissingStepToTheEnd(t *testing.T)
 		Steps: []*deployments.DeploymentStep{step4, step3, step2, step1},
 	}
 
-	diags := mapProcessStepsOrderFromState(&state, &process)
+	diags := mapProcessStepsOrderFromState(&state, deploymentProcessWrapper{&process})
+
+	orderedStepIds := make([]string, len(process.Steps))
+	for i, step := range process.Steps {
+		orderedStepIds[i] = step.ID
+	}
+	expectedStepIds := []string{"step-1", "step-2", "step-3", "step-4"}
+	assert.Equal(t, expectedStepIds, orderedStepIds, "Should put missing steps to the end of the order")
+
+	diagnostics := make([]diag.Severity, len(diags))
+	for i, d := range diags {
+		diagnostics[i] = d.Severity()
+	}
+	expectedDiagnostics := []diag.Severity{diag.SeverityWarning}
+	assert.Equal(t, expectedDiagnostics, diagnostics, "Expects to have warning diagnostics")
+}
+
+func TestAccMapProcessStepsOrderingFromStateAddMissingStepToTheEndForRunbook(t *testing.T) {
+	state := schemas.ProcessStepsOrderResourceModel{
+		SpaceID:   types.StringValue("Spaces-1"),
+		ProcessID: types.StringValue("Processes-1"),
+		Steps: types.ListValueMust(types.StringType, []attr.Value{
+			types.StringValue("step-1"),
+			types.StringValue("step-2"),
+			types.StringValue("step-3"),
+		}),
+	}
+
+	step1 := deployments.NewDeploymentStep("Step One")
+	step1.SetID("step-1")
+
+	step2 := deployments.NewDeploymentStep("Step Two")
+	step2.SetID("step-2")
+
+	step3 := deployments.NewDeploymentStep("Step Three")
+	step3.SetID("step-3")
+
+	step4 := deployments.NewDeploymentStep("Step Four")
+	step4.SetID("step-4")
+
+	process := runbookprocess.RunbookProcess{
+		Steps: []*deployments.DeploymentStep{step4, step3, step2, step1},
+	}
+
+	diags := mapProcessStepsOrderFromState(&state, runbookProcessWrapper{&process})
 
 	orderedStepIds := make([]string, len(process.Steps))
 	for i, step := range process.Steps {
@@ -78,7 +123,7 @@ func TestAccMapProcessStepsOrderingFromStateAddsErrorWhenStepIsNotPartOfTheProce
 		Steps: []*deployments.DeploymentStep{step4, step2, step1},
 	}
 
-	diags := mapProcessStepsOrderFromState(&state, &process)
+	diags := mapProcessStepsOrderFromState(&state, deploymentProcessWrapper{&process})
 
 	orderedStepIds := make([]string, len(process.Steps))
 	for i, step := range process.Steps {
@@ -119,7 +164,47 @@ func TestAccMapProcessStepsOrderingToStateTakesOnlyConfiguredAmountOfSteps(t *te
 		}),
 	}
 
-	mapProcessStepsOrderToState(process, &state)
+	mapProcessStepsOrderToState(deploymentProcessWrapper{process}, &state)
+
+	expectedState := schemas.ProcessStepsOrderResourceModel{
+		SpaceID:   types.StringValue(process.SpaceID),
+		ProcessID: types.StringValue(process.ID),
+		Steps: types.ListValueMust(types.StringType, []attr.Value{
+			types.StringValue(step1.ID),
+			types.StringValue(step2.ID),
+		}),
+	}
+	expectedState.ID = types.StringValue(process.ID)
+
+	assert.Equal(t, expectedState, state)
+}
+
+func TestAccMapProcessStepsOrderingToStateTakesOnlyConfiguredAmountOfStepsForRunbooks(t *testing.T) {
+	step1 := deployments.NewDeploymentStep("Step One")
+	step1.SetID("00000000-0000-0000-0000-000000000001")
+
+	step2 := deployments.NewDeploymentStep("Step Two")
+	step2.SetID("00000000-0000-0000-0000-000000000002")
+
+	step3 := deployments.NewDeploymentStep("Step Three")
+	step3.SetID("00000000-0000-0000-0000-000000000003")
+
+	process := &runbookprocess.RunbookProcess{
+		SpaceID:   "Spaces-1",
+		ProjectID: "Projects-1",
+		RunbookID: "Runbook-1",
+		Steps:     []*deployments.DeploymentStep{step1, step2, step3},
+	}
+	process.SetID("Processes-1")
+
+	state := schemas.ProcessStepsOrderResourceModel{
+		Steps: types.ListValueMust(types.StringType, []attr.Value{
+			types.StringValue(step3.ID),
+			types.StringValue(step2.ID),
+		}),
+	}
+
+	mapProcessStepsOrderToState(runbookProcessWrapper{process}, &state)
 
 	expectedState := schemas.ProcessStepsOrderResourceModel{
 		SpaceID:   types.StringValue(process.SpaceID),
@@ -159,7 +244,7 @@ func TestAccMapProcessStepsOrderingToStateWhenConfiguredStepsMoreThanProvided(t 
 		}),
 	}
 
-	mapProcessStepsOrderToState(process, &state)
+	mapProcessStepsOrderToState(deploymentProcessWrapper{process}, &state)
 
 	expectedState := schemas.ProcessStepsOrderResourceModel{
 		SpaceID:   types.StringValue(process.SpaceID),

--- a/octopusdeploy_framework/resource_process_steps_order_test.go
+++ b/octopusdeploy_framework/resource_process_steps_order_test.go
@@ -120,7 +120,7 @@ func newProcessStepsOrderTestDependenciesConfiguration(scenario string) processS
 		}
 
 		resource "octopusdeploy_process" "%s" {
-		  owner_id  = octopusdeploy_project.%s.id
+		  project_id  = octopusdeploy_project.%s.id
 		}
 
 		resource "octopusdeploy_process_step" "%s" {

--- a/octopusdeploy_framework/schemas/process.go
+++ b/octopusdeploy_framework/schemas/process.go
@@ -20,8 +20,14 @@ func (p ProcessSchema) GetResourceSchema() resourceSchema.Schema {
 		Attributes: map[string]resourceSchema.Attribute{
 			"id":       GetIdResourceSchema(),
 			"space_id": GetSpaceIdResourceSchema(ProcessResourceName),
-			"owner_id": util.ResourceString().Required().
-				Description("Id of the resource this process belongs to.").
+			"project_id": util.ResourceString().
+				Required().
+				Description("Id of the project this process belongs to.").
+				PlanModifiers(stringplanmodifier.RequiresReplace()).
+				Build(),
+			"runbook_id": util.ResourceString().
+				Optional().
+				Description("Id of the runbook this process belongs to. When not set this resource represents deployment process of the project").
 				PlanModifiers(stringplanmodifier.RequiresReplace()).
 				Build(),
 		},
@@ -33,8 +39,9 @@ func (p ProcessSchema) GetDatasourceSchema() datasourceSchema.Schema {
 }
 
 type ProcessResourceModel struct {
-	SpaceID types.String `tfsdk:"space_id"`
-	OwnerID types.String `tfsdk:"owner_id"`
+	SpaceID   types.String `tfsdk:"space_id"`
+	ProjectID types.String `tfsdk:"project_id"`
+	RunbookID types.String `tfsdk:"runbook_id"`
 
 	ResourceModel
 }


### PR DESCRIPTION
Adds support for runbooks in new `octopusdeploy_process` resource

Runbook process have similar data structure as deployment process, but using different API endpoints

```terraform
resource "octopusdeploy_process" "copy_database" {
  project_id = octopusdeploy_project.app.id
  runbook_id = octopusdeploy_runbook.copy_database.id
}
```

 

