### PR TITLE
chore: updated docs command in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ build:
 
 .PHONY: docs
 docs:
-	tfplugindocs
+	go generate main.go
 
 .PHONY: release
 release:


### PR DESCRIPTION
Updated makefile to run the correct command for docs generation. The previous was producing unexpected changes

Context: https://octopusdeploy.slack.com/archives/C056NSRCRAL/p1744247970616289