### PR TITLE
Set project id when importing existing process

### DIFF
--- a/octopusdeploy_framework/process_wrapper.go
+++ b/octopusdeploy_framework/process_wrapper.go
@@ -19,6 +19,7 @@ import (
 type processWrapper interface { // Better name?
 	GetID() string
 	GetSpaceID() string
+	GetProjectID() string
 	PopulateState(state *schemas.ProcessResourceModel)
 	AppendStep(step *deployments.DeploymentStep)
 	RemoveStep(stepId string)
@@ -50,10 +51,10 @@ func findDeploymentStepByName(steps []*deployments.DeploymentStep, name string) 
 	return nil, false
 }
 
-// loadProcessWrapperForSteps determines projectId before loading deployment or runbook process.
+// loadProcessWrapperByProcessId determines projectId before loading deployment or runbook process.
 //
 // Returns wrapper of the process or error when process is not found or warning when corresponding project is version controlled.
-func loadProcessWrapperForSteps(client *client.Client, spaceId string, processId string) (processWrapper, diag.Diagnostics) {
+func loadProcessWrapperByProcessId(client *client.Client, spaceId string, processId string) (processWrapper, diag.Diagnostics) {
 	switch kind, ownerId := deconstructProcessIdentifier(processId); kind {
 	case "deployment":
 		return loadProcessWrapper(client, spaceId, ownerId, processId)
@@ -145,6 +146,10 @@ func (w deploymentProcessWrapper) GetSpaceID() string {
 	return w.process.SpaceID
 }
 
+func (w deploymentProcessWrapper) GetProjectID() string {
+	return w.process.ProjectID
+}
+
 func (w deploymentProcessWrapper) PopulateState(state *schemas.ProcessResourceModel) {
 	state.ID = types.StringValue(w.process.ID)
 	state.SpaceID = types.StringValue(w.process.SpaceID)
@@ -201,6 +206,10 @@ func (w runbookProcessWrapper) GetID() string {
 
 func (w runbookProcessWrapper) GetSpaceID() string {
 	return w.process.SpaceID
+}
+
+func (w runbookProcessWrapper) GetProjectID() string {
+	return w.process.ProjectID
 }
 
 func (w runbookProcessWrapper) PopulateState(state *schemas.ProcessResourceModel) {

--- a/octopusdeploy_framework/resource_process.go
+++ b/octopusdeploy_framework/resource_process.go
@@ -40,7 +40,14 @@ func (r *processResource) Configure(_ context.Context, req resource.ConfigureReq
 }
 
 func (r *processResource) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), request, response)
+	process, diags := loadProcessWrapperByProcessId(r.Config.Client, r.Config.SpaceID, request.ID)
+	if len(diags) > 0 {
+		response.Diagnostics.Append(diags...)
+		return
+	}
+
+	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("project_id"), process.GetProjectID())...)
+	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("id"), process.GetID())...)
 }
 
 func (r *processResource) ModifyPlan(_ context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {

--- a/octopusdeploy_framework/resource_process_child_step.go
+++ b/octopusdeploy_framework/resource_process_child_step.go
@@ -74,7 +74,7 @@ func (r *processChildStepResource) Create(ctx context.Context, req resource.Crea
 
 	tflog.Info(ctx, fmt.Sprintf("creating process child step: %s", data.Name.ValueString()))
 
-	process, diags := loadProcessWrapperForSteps(r.Config.Client, spaceId, processId)
+	process, diags := loadProcessWrapperByProcessId(r.Config.Client, spaceId, processId)
 	if len(diags) > 0 {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -137,7 +137,7 @@ func (r *processChildStepResource) Read(ctx context.Context, req resource.ReadRe
 	parentId := data.ParentID.ValueString()
 	actionId := data.ID.ValueString()
 
-	process, diags := loadProcessWrapperForSteps(r.Config.Client, spaceId, processId)
+	process, diags := loadProcessWrapperByProcessId(r.Config.Client, spaceId, processId)
 	if len(diags) > 0 {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -184,7 +184,7 @@ func (r *processChildStepResource) Update(ctx context.Context, req resource.Upda
 
 	tflog.Info(ctx, fmt.Sprintf("updating process child step (%s)", actionId))
 
-	process, diags := loadProcessWrapperForSteps(r.Config.Client, spaceId, processId)
+	process, diags := loadProcessWrapperByProcessId(r.Config.Client, spaceId, processId)
 	if len(diags) > 0 {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -253,7 +253,7 @@ func (r *processChildStepResource) Delete(ctx context.Context, req resource.Dele
 
 	tflog.Info(ctx, fmt.Sprintf("deleting process child step (%s)", data.ID))
 
-	process, diags := loadProcessWrapperForSteps(r.Config.Client, spaceId, processId)
+	process, diags := loadProcessWrapperByProcessId(r.Config.Client, spaceId, processId)
 	if len(diags) > 0 {
 		resp.Diagnostics.Append(diags...)
 		return

--- a/octopusdeploy_framework/resource_process_child_steps_order.go
+++ b/octopusdeploy_framework/resource_process_child_steps_order.go
@@ -59,7 +59,7 @@ func (r *processChildStepsOrderResource) ImportState(ctx context.Context, reques
 	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("parent_id"), parentStepId)...)
 	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("id"), parentStepId)...)
 
-	process, diags := loadProcessWrapperForSteps(r.Config.Client, r.Config.SpaceID, processId)
+	process, diags := loadProcessWrapperByProcessId(r.Config.Client, r.Config.SpaceID, processId)
 	if len(diags) > 0 {
 		response.Diagnostics.Append(diags...)
 		return
@@ -116,7 +116,7 @@ func (r *processChildStepsOrderResource) ModifyPlan(ctx context.Context, req res
 	parentId := state.ParentID.ValueString()
 
 	// Do the validation based on steps stored in Octopus Deploy
-	process, diags := loadProcessWrapperForSteps(r.Config.Client, spaceId, processId)
+	process, diags := loadProcessWrapperByProcessId(r.Config.Client, spaceId, processId)
 	if len(diags) > 0 {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -190,7 +190,7 @@ func (r *processChildStepsOrderResource) Create(ctx context.Context, req resourc
 
 	tflog.Info(ctx, fmt.Sprintf("creating process child steps order for parent %s", parentId))
 
-	process, diags := loadProcessWrapperForSteps(r.Config.Client, spaceId, processId)
+	process, diags := loadProcessWrapperByProcessId(r.Config.Client, spaceId, processId)
 	if len(diags) > 0 {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -239,7 +239,7 @@ func (r *processChildStepsOrderResource) Read(ctx context.Context, req resource.
 
 	tflog.Info(ctx, fmt.Sprintf("reading process child steps order (%s)", parentId))
 
-	process, diags := loadProcessWrapperForSteps(r.Config.Client, spaceId, processId)
+	process, diags := loadProcessWrapperByProcessId(r.Config.Client, spaceId, processId)
 	if len(diags) > 0 {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -273,7 +273,7 @@ func (r *processChildStepsOrderResource) Update(ctx context.Context, req resourc
 
 	tflog.Info(ctx, fmt.Sprintf("updating process child steps order (%s)", parentId))
 
-	process, diags := loadProcessWrapperForSteps(r.Config.Client, spaceId, processId)
+	process, diags := loadProcessWrapperByProcessId(r.Config.Client, spaceId, processId)
 	if len(diags) > 0 {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -325,7 +325,7 @@ func (r *processChildStepsOrderResource) Delete(ctx context.Context, req resourc
 
 	tflog.Info(ctx, fmt.Sprintf("deleting process steps order (%s)", processId))
 
-	process, diags := loadProcessWrapperForSteps(r.Config.Client, spaceId, processId)
+	process, diags := loadProcessWrapperByProcessId(r.Config.Client, spaceId, processId)
 	if len(diags) > 0 {
 		resp.Diagnostics.Append(diags...)
 		return

--- a/octopusdeploy_framework/resource_process_step.go
+++ b/octopusdeploy_framework/resource_process_step.go
@@ -72,7 +72,7 @@ func (r *processStepResource) Create(ctx context.Context, req resource.CreateReq
 
 	tflog.Info(ctx, fmt.Sprintf("creating process step: %s", data.Name.ValueString()))
 
-	process, diags := loadProcessWrapperForSteps(r.Config.Client, spaceId, processId)
+	process, diags := loadProcessWrapperByProcessId(r.Config.Client, spaceId, processId)
 	if len(diags) > 0 {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -123,7 +123,7 @@ func (r *processStepResource) Read(ctx context.Context, req resource.ReadRequest
 
 	tflog.Info(ctx, fmt.Sprintf("reading process step (%s)", data.ID))
 
-	process, diags := loadProcessWrapperForSteps(r.Config.Client, spaceId, processId)
+	process, diags := loadProcessWrapperByProcessId(r.Config.Client, spaceId, processId)
 	if len(diags) > 0 {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -161,7 +161,7 @@ func (r *processStepResource) Update(ctx context.Context, req resource.UpdateReq
 
 	tflog.Info(ctx, fmt.Sprintf("updating process step (%s)", stepId))
 
-	process, diags := loadProcessWrapperForSteps(r.Config.Client, spaceId, processId)
+	process, diags := loadProcessWrapperByProcessId(r.Config.Client, spaceId, processId)
 	if len(diags) > 0 {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -213,7 +213,7 @@ func (r *processStepResource) Delete(ctx context.Context, req resource.DeleteReq
 
 	tflog.Info(ctx, fmt.Sprintf("deleting process step (%s)", stepId))
 
-	process, diags := loadProcessWrapperForSteps(r.Config.Client, spaceId, processId)
+	process, diags := loadProcessWrapperByProcessId(r.Config.Client, spaceId, processId)
 	if len(diags) > 0 {
 		resp.Diagnostics.Append(diags...)
 		return

--- a/octopusdeploy_framework/resource_process_steps_order.go
+++ b/octopusdeploy_framework/resource_process_steps_order.go
@@ -43,7 +43,7 @@ func (r *processStepsOrderResource) Configure(_ context.Context, req resource.Co
 func (r *processStepsOrderResource) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
 	processId := request.ID
 
-	process, diags := loadProcessWrapperForSteps(r.Config.Client, r.Config.SpaceID, processId)
+	process, diags := loadProcessWrapperByProcessId(r.Config.Client, r.Config.SpaceID, processId)
 	if len(diags) > 0 {
 		response.Diagnostics.Append(diags...)
 		return
@@ -89,7 +89,7 @@ func (r *processStepsOrderResource) ModifyPlan(ctx context.Context, req resource
 	processId := state.ProcessID.ValueString()
 
 	// Do the validation based on steps stored in Octopus Deploy
-	process, diags := loadProcessWrapperForSteps(r.Config.Client, spaceId, processId)
+	process, diags := loadProcessWrapperByProcessId(r.Config.Client, spaceId, processId)
 	if len(diags) > 0 {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -156,7 +156,7 @@ func (r *processStepsOrderResource) Create(ctx context.Context, req resource.Cre
 
 	tflog.Info(ctx, fmt.Sprintf("creating process steps order: %s", processId))
 
-	process, diags := loadProcessWrapperForSteps(r.Config.Client, spaceId, processId)
+	process, diags := loadProcessWrapperByProcessId(r.Config.Client, spaceId, processId)
 	if len(diags) > 0 {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -191,7 +191,7 @@ func (r *processStepsOrderResource) Read(ctx context.Context, req resource.ReadR
 
 	spaceId := data.SpaceID.ValueString()
 	processId := data.ProcessID.ValueString()
-	process, diags := loadProcessWrapperForSteps(r.Config.Client, spaceId, processId)
+	process, diags := loadProcessWrapperByProcessId(r.Config.Client, spaceId, processId)
 	if len(diags) > 0 {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -218,7 +218,7 @@ func (r *processStepsOrderResource) Update(ctx context.Context, req resource.Upd
 
 	tflog.Info(ctx, fmt.Sprintf("updating process steps order (%s)", data.ProcessID))
 
-	process, diags := loadProcessWrapperForSteps(r.Config.Client, spaceId, processId)
+	process, diags := loadProcessWrapperByProcessId(r.Config.Client, spaceId, processId)
 	if len(diags) > 0 {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -257,7 +257,7 @@ func (r *processStepsOrderResource) Delete(ctx context.Context, req resource.Del
 
 	tflog.Info(ctx, fmt.Sprintf("deleting process steps order (%s)", processId))
 
-	_, diags := loadProcessWrapperForSteps(r.Config.Client, spaceId, processId)
+	_, diags := loadProcessWrapperByProcessId(r.Config.Client, spaceId, processId)
 	if len(diags) > 0 {
 		resp.Diagnostics.Append(diags...)
 		return


### PR DESCRIPTION
Importing of `octopusdeploy_process` resources is failing at this moment, because provider trying to load corresponding project before loading process to check if project is version controlled.

This PR sets project id to the state during import by using similar "loading" approach we use for process steps