### PR TITLE
Introduce primary_package attribute for new process step

### DIFF
--- a/docs/resources/process_child_step.md
+++ b/docs/resources/process_child_step.md
@@ -91,7 +91,7 @@ resource "octopusdeploy_process_child_step" "run_script" {
 
 - `channels` (Set of String) A set of channels associated with this step.
 - `condition` (String) When to run the step, can be 'Success' - run when previous child step succeed or variable expression - run when the expression evaluates to true
-- `container` (Attributes) When set used to run step inside a container on the Octopus Server. Octopus Server must support container execution. (see [below for nested schema](#nestedatt--container))
+- `container` (Attributes) When set, used to run step inside a container on the Octopus Server. Octopus Server must support container execution. (see [below for nested schema](#nestedatt--container))
 - `environments` (Set of String) A set of environments within which this step will run.
 - `excluded_environments` (Set of String) A set of environments that this step will be skipped in.
 - `execution_properties` (Map of String) A collection of step execution properties where the key is the property name and the value is its value.
@@ -100,6 +100,7 @@ resource "octopusdeploy_process_child_step" "run_script" {
 - `is_required` (Boolean) Indicates the required status of this step.
 - `notes` (String) The notes associated with this step.
 - `packages` (Attributes Map) Package references associated with this step where key is a name of the package reference (use empty name for primary package) (see [below for nested schema](#nestedatt--packages))
+- `primary_package` (Attributes) Primary package of the step (see [below for nested schema](#nestedatt--primary_package))
 - `slug` (String) The human-readable unique identifier for the step.
 - `space_id` (String) The space ID associated with this process_child_step.
 - `tenant_tags` (Set of String) A set of tenant tags associated with this step.
@@ -136,6 +137,24 @@ Optional:
 
 <a id="nestedatt--packages"></a>
 ### Nested Schema for `packages`
+
+Required:
+
+- `package_id` (String) Package ID or a variable-expression
+
+Optional:
+
+- `acquisition_location` (String) Whether to acquire this package on the server ('Server'), target ('ExecutionTarget') or not at all ('NotAcquired'). Can be an expression
+- `feed_id` (String) The feed ID associated with this package reference
+- `properties` (Map of String) A collection of properties associated with this package
+
+Read-Only:
+
+- `id` (String) The unique ID for this resource.
+
+
+<a id="nestedatt--primary_package"></a>
+### Nested Schema for `primary_package`
 
 Required:
 

--- a/docs/resources/process_step.md
+++ b/docs/resources/process_step.md
@@ -91,18 +91,12 @@ resource "octopusdeploy_process_step" "deploy_package" {
     "Octopus.Action.TargetRoles" = "role-one"
   }
   type = "Octopus.TentaclePackage"
-  packages = {
-    "": {
-      package_id: "my.package"
-      feed_id: "Feeds-1"
-    }
+  primary_package = {
+    package_id: "my.package"
+    feed_id: "Feeds-1"
   }
   execution_properties = {
     "Octopus.Action.RunOnServer" = "True"    
-    # Reference primary package in execution properties for legacy purposes
-    "Octopus.Action.Package.DownloadOnTentacle" = "False"
-    "Octopus.Action.Package.FeedId" = "Feeds-1"
-    "Octopus.Action.Package.PackageId" = "my.package"
   }
 }
 ```
@@ -120,7 +114,7 @@ resource "octopusdeploy_process_step" "deploy_package" {
 
 - `channels` (Set of String) A set of channels associated with this step.
 - `condition` (String) When to run the step, one of 'Success', 'Failure', 'Always' or 'Variable'
-- `container` (Attributes) When set used to run step inside a container on the Octopus Server. Octopus Server must support container execution. (see [below for nested schema](#nestedatt--container))
+- `container` (Attributes) When set, used to run step inside a container on the Octopus Server. Octopus Server must support container execution. (see [below for nested schema](#nestedatt--container))
 - `environments` (Set of String) A set of environments within which this step will run.
 - `excluded_environments` (Set of String) A set of environments that this step will be skipped in.
 - `execution_properties` (Map of String) A collection of step action properties where the key is the property name and the value is its value.
@@ -130,6 +124,7 @@ resource "octopusdeploy_process_step" "deploy_package" {
 - `notes` (String) The notes associated with this step.
 - `package_requirement` (String) Whether to run this step before or after package acquisition (if possible).
 - `packages` (Attributes Map) Package references associated with this step where key is a name of the package reference (use empty name for primary package) (see [below for nested schema](#nestedatt--packages))
+- `primary_package` (Attributes) Primary package of the step (see [below for nested schema](#nestedatt--primary_package))
 - `properties` (Map of String) A collection of process step properties where the key is the property name and the value is its value.
 - `slug` (String) The human-readable unique identifier for the step.
 - `space_id` (String) The space ID associated with this process_step.
@@ -168,6 +163,24 @@ Optional:
 
 <a id="nestedatt--packages"></a>
 ### Nested Schema for `packages`
+
+Required:
+
+- `package_id` (String) Package ID or a variable-expression
+
+Optional:
+
+- `acquisition_location` (String) Whether to acquire this package on the server ('Server'), target ('ExecutionTarget') or not at all ('NotAcquired'). Can be an expression
+- `feed_id` (String) The feed ID associated with this package reference
+- `properties` (Map of String) A collection of properties associated with this package
+
+Read-Only:
+
+- `id` (String) The unique ID for this resource.
+
+
+<a id="nestedatt--primary_package"></a>
+### Nested Schema for `primary_package`
 
 Required:
 

--- a/docs/resources/process_templated_child_step.md
+++ b/docs/resources/process_templated_child_step.md
@@ -137,7 +137,7 @@ resource "octopusdeploy_process_templated_child_step" "script" {
 
 - `channels` (Set of String) A set of channels associated with this step.
 - `condition` (String) When to run the step, can be 'Success' - run when previous child step succeed or variable expression - run when the expression evaluates to true
-- `container` (Attributes) When set used to run step inside a container on the Octopus Server. Octopus Server must support container execution. (see [below for nested schema](#nestedatt--container))
+- `container` (Attributes) When set, used to run step inside a container on the Octopus Server. Octopus Server must support container execution. (see [below for nested schema](#nestedatt--container))
 - `environments` (Set of String) A set of environments within which this step will run.
 - `excluded_environments` (Set of String) A set of environments that this step will be skipped in.
 - `execution_properties` (Map of String) Action properties where the key is the property name and the value is its value.

--- a/docs/resources/process_templated_step.md
+++ b/docs/resources/process_templated_step.md
@@ -117,7 +117,7 @@ resource "octopusdeploy_templated_process_step" "script" {
 
 - `channels` (Set of String) A set of channels associated with this step.
 - `condition` (String) When to run the step, one of 'Success', 'Failure', 'Always' or 'Variable'
-- `container` (Attributes) When set used to run step inside a container on the Octopus Server. Octopus Server must support container execution. (see [below for nested schema](#nestedatt--container))
+- `container` (Attributes) When set, used to run step inside a container on the Octopus Server. Octopus Server must support container execution. (see [below for nested schema](#nestedatt--container))
 - `environments` (Set of String) A set of environments within which this step will run.
 - `excluded_environments` (Set of String) A set of environments that this step will be skipped in.
 - `execution_properties` (Map of String) Action properties where the key is the property name and the value is its value.

--- a/examples/resources/octopusdeploy_process_step/resource.tf
+++ b/examples/resources/octopusdeploy_process_step/resource.tf
@@ -65,17 +65,11 @@ resource "octopusdeploy_process_step" "deploy_package" {
     "Octopus.Action.TargetRoles" = "role-one"
   }
   type = "Octopus.TentaclePackage"
-  packages = {
-    "": {
-      package_id: "my.package"
-      feed_id: "Feeds-1"
-    }
+  primary_package = {
+    package_id: "my.package"
+    feed_id: "Feeds-1"
   }
   execution_properties = {
     "Octopus.Action.RunOnServer" = "True"    
-    # Reference primary package in execution properties for legacy purposes
-    "Octopus.Action.Package.DownloadOnTentacle" = "False"
-    "Octopus.Action.Package.FeedId" = "Feeds-1"
-    "Octopus.Action.Package.PackageId" = "my.package"
   }
 }

--- a/octopusdeploy_framework/resource_process_child_step_mapping_test.go
+++ b/octopusdeploy_framework/resource_process_child_step_mapping_test.go
@@ -17,6 +17,16 @@ import (
 
 func TestAccMapProcessChildStepFromStateWithAllAttributes(t *testing.T) {
 	ctx := context.Background()
+	primaryPackage := &schemas.ProcessStepPackageReferenceResourceModel{
+		PackageID:           types.StringValue("Packages-0"),
+		FeedID:              types.StringValue("Feeds-0"),
+		AcquisitionLocation: types.StringValue("ExecutionTarget"),
+		Properties: types.MapValueMust(types.StringType, map[string]attr.Value{
+			"Extract": types.StringValue("True"),
+		}),
+	}
+	primaryPackage.ID = types.StringValue("00000000-0000-0000-0000-000000000044")
+
 	state := schemas.ProcessChildStepResourceModel{
 		SpaceID:            types.StringValue("Spaces-1"),
 		ProcessID:          types.StringValue("Processes-1"),
@@ -61,6 +71,7 @@ func TestAccMapProcessChildStepFromStateWithAllAttributes(t *testing.T) {
 				},
 			),
 		}),
+		PrimaryPackage: primaryPackage,
 		Packages: types.MapValueMust(schemas.ProcessStepPackageReferenceObjectType(), map[string]attr.Value{
 			"script-package": types.ObjectValueMust(
 				schemas.ProcessStepPackageReferenceAttributeTypes(),
@@ -117,6 +128,16 @@ func TestAccMapProcessChildStepFromStateWithAllAttributes(t *testing.T) {
 		},
 		Packages: []*packages.PackageReference{
 			{
+				ID:                  "00000000-0000-0000-0000-000000000044",
+				Name:                "", // Primary package
+				PackageID:           "Packages-0",
+				FeedID:              "Feeds-0",
+				AcquisitionLocation: "ExecutionTarget",
+				Properties: map[string]string{
+					"Extract": "True",
+				},
+			},
+			{
 				ID:                  "00000000-0000-0000-0000-000000000001",
 				Name:                "script-package",
 				PackageID:           "Package-1",
@@ -128,8 +149,11 @@ func TestAccMapProcessChildStepFromStateWithAllAttributes(t *testing.T) {
 			},
 		},
 		Properties: map[string]core.PropertyValue{
-			"Octopus.Action.RunOnServer":       core.NewPropertyValue("True", false),
-			"Octopus.Action.Script.ScriptBody": core.NewPropertyValue("Write-Host \"Step 1, Action 1\"", false),
+			"Octopus.Action.RunOnServer":                core.NewPropertyValue("True", false),
+			"Octopus.Action.Script.ScriptBody":          core.NewPropertyValue("Write-Host \"Step 1, Action 1\"", false),
+			"Octopus.Action.Package.FeedId":             core.NewPropertyValue("Feeds-0", false),
+			"Octopus.Action.Package.PackageId":          core.NewPropertyValue("Packages-0", false),
+			"Octopus.Action.Package.DownloadOnTentacle": core.NewPropertyValue("True", false),
 		},
 		Resource: *resources.NewResource(),
 	}
@@ -216,6 +240,16 @@ func TestAccMapProcessChildStepToStateWithAllAttributes(t *testing.T) {
 
 	assert.False(t, diags.HasError(), "Expected no errors in diagnostics")
 
+	expectedPrimaryPackage := &schemas.ProcessStepPackageReferenceResourceModel{
+		PackageID:           types.StringValue(primaryPackage.PackageID),
+		FeedID:              types.StringValue(primaryPackage.FeedID),
+		AcquisitionLocation: types.StringValue(primaryPackage.AcquisitionLocation),
+		Properties: types.MapValueMust(types.StringType, map[string]attr.Value{
+			"Octopus.Package.IsPrimary": types.StringValue("True"),
+		}),
+	}
+	expectedPrimaryPackage.ID = types.StringValue(primaryPackage.ID)
+
 	expectedState := schemas.ProcessChildStepResourceModel{
 		SpaceID:            types.StringValue(process.SpaceID),
 		ProcessID:          types.StringValue(process.ID),
@@ -261,19 +295,8 @@ func TestAccMapProcessChildStepToStateWithAllAttributes(t *testing.T) {
 				},
 			),
 		}),
+		PrimaryPackage: expectedPrimaryPackage,
 		Packages: types.MapValueMust(schemas.ProcessStepPackageReferenceObjectType(), map[string]attr.Value{
-			primaryPackage.Name: types.ObjectValueMust(
-				schemas.ProcessStepPackageReferenceAttributeTypes(),
-				map[string]attr.Value{
-					"id":                   types.StringValue(primaryPackage.ID),
-					"package_id":           types.StringValue(primaryPackage.PackageID),
-					"feed_id":              types.StringValue(primaryPackage.FeedID),
-					"acquisition_location": types.StringValue(primaryPackage.AcquisitionLocation),
-					"properties": types.MapValueMust(types.StringType, map[string]attr.Value{
-						"Octopus.Package.IsPrimary": types.StringValue("True"),
-					}),
-				},
-			),
 			additionalPackage.Name: types.ObjectValueMust(
 				schemas.ProcessStepPackageReferenceAttributeTypes(),
 				map[string]attr.Value{
@@ -375,6 +398,16 @@ func TestAccMapProcessChildStepToStateWithAllAttributesForRunbooks(t *testing.T)
 
 	assert.False(t, diags.HasError(), "Expected no errors in diagnostics")
 
+	expectedPrimaryPackage := &schemas.ProcessStepPackageReferenceResourceModel{
+		PackageID:           types.StringValue(primaryPackage.PackageID),
+		FeedID:              types.StringValue(primaryPackage.FeedID),
+		AcquisitionLocation: types.StringValue(primaryPackage.AcquisitionLocation),
+		Properties: types.MapValueMust(types.StringType, map[string]attr.Value{
+			"Octopus.Package.IsPrimary": types.StringValue("True"),
+		}),
+	}
+	expectedPrimaryPackage.ID = types.StringValue(primaryPackage.ID)
+
 	expectedState := schemas.ProcessChildStepResourceModel{
 		SpaceID:            types.StringValue(process.SpaceID),
 		ProcessID:          types.StringValue(process.ID),
@@ -420,19 +453,8 @@ func TestAccMapProcessChildStepToStateWithAllAttributesForRunbooks(t *testing.T)
 				},
 			),
 		}),
+		PrimaryPackage: expectedPrimaryPackage,
 		Packages: types.MapValueMust(schemas.ProcessStepPackageReferenceObjectType(), map[string]attr.Value{
-			primaryPackage.Name: types.ObjectValueMust(
-				schemas.ProcessStepPackageReferenceAttributeTypes(),
-				map[string]attr.Value{
-					"id":                   types.StringValue(primaryPackage.ID),
-					"package_id":           types.StringValue(primaryPackage.PackageID),
-					"feed_id":              types.StringValue(primaryPackage.FeedID),
-					"acquisition_location": types.StringValue(primaryPackage.AcquisitionLocation),
-					"properties": types.MapValueMust(types.StringType, map[string]attr.Value{
-						"Octopus.Package.IsPrimary": types.StringValue("True"),
-					}),
-				},
-			),
 			additionalPackage.Name: types.ObjectValueMust(
 				schemas.ProcessStepPackageReferenceAttributeTypes(),
 				map[string]attr.Value{

--- a/octopusdeploy_framework/resource_process_step.go
+++ b/octopusdeploy_framework/resource_process_step.go
@@ -606,7 +606,7 @@ func mapPackageReferencesToState(references []*packages.PackageReference) (*sche
 func mapActionExecutionPropertiesToState(properties map[string]core.PropertyValue) (types.Map, diag.Diagnostics) {
 	attributeValues := make(map[string]attr.Value)
 	for key, value := range properties {
-		if isReservedProperty(key) {
+		if schemas.IsReservedExecutionProperty(key) {
 			continue
 		}
 		attributeValues[key] = types.StringValue(value.Value)
@@ -618,16 +618,4 @@ func mapActionExecutionPropertiesToState(properties map[string]core.PropertyValu
 	}
 
 	return valuesMap, diags
-}
-
-// Properties which managed by other attributes
-var reservedExecutionProperties = map[string]struct{}{
-	"Octopus.Action.Package.FeedId":             {},
-	"Octopus.Action.Package.PackageId":          {},
-	"Octopus.Action.Package.DownloadOnTentacle": {},
-}
-
-func isReservedProperty(name string) bool {
-	_, exists := reservedExecutionProperties[name]
-	return exists
 }

--- a/octopusdeploy_framework/resource_process_step.go
+++ b/octopusdeploy_framework/resource_process_step.go
@@ -311,82 +311,28 @@ func mapProcessStepActionFromState(ctx context.Context, state *schemas.ProcessSt
 		return diags
 	}
 
-	action.GitDependencies, diags = mapProcessStepActionGitDependenciesFromState(ctx, state)
+	action.GitDependencies, diags = mapProcessStepActionGitDependenciesFromState(ctx, state.GitDependencies)
 	if diags.HasError() {
 		return diags
 	}
 
-	// Packages
-	var packagesMap map[string]types.Object
-	diags = state.Packages.ElementsAs(ctx, &packagesMap, false)
+	var primaryPackageProperties = map[string]core.PropertyValue{}
+	action.Packages, primaryPackageProperties, diags = mapProcessStepActionPackagesFromState(ctx, state.Packages, state.PrimaryPackage)
 	if diags.HasError() {
 		return diags
 	}
 
-	packageReferences := make([]*packages.PackageReference, 0)
-	for key, packageObject := range packagesMap {
-		if packageObject.IsNull() {
-			continue
-		}
-
-		var packageState schemas.ProcessStepPackageReferenceResourceModel
-		diags = packageObject.As(ctx, &packageState, basetypes.ObjectAsOptions{})
-		if diags.HasError() {
-			return diags
-		}
-
-		stateProperties := make(map[string]types.String, len(packageState.Properties.Elements()))
-		diags = packageState.Properties.ElementsAs(ctx, &stateProperties, false)
-		if diags.HasError() {
-			return diags
-		}
-
-		packageProperties := make(map[string]string, len(stateProperties))
-		for propertyKey, value := range stateProperties {
-			if value.IsNull() {
-				packageProperties[propertyKey] = ""
-			} else {
-				packageProperties[propertyKey] = value.ValueString()
-			}
-		}
-
-		packageReference := &packages.PackageReference{
-			ID:                  packageState.GetID(),
-			Name:                key,
-			PackageID:           packageState.PackageID.ValueString(),
-			FeedID:              packageState.FeedID.ValueString(),
-			AcquisitionLocation: packageState.AcquisitionLocation.ValueString(),
-			Properties:          packageProperties,
-		}
-		packageReferences = append(packageReferences, packageReference)
+	action.Properties, diags = mapActionExecutionPropertiesFromState(ctx, state.ExecutionProperties, primaryPackageProperties)
+	if diags.HasError() {
+		return diags
 	}
-
-	action.Packages = packageReferences
-
-	// Execution Properties
-	stateProperties := make(map[string]types.String, len(state.ExecutionProperties.Elements()))
-	propertiesDiags := state.ExecutionProperties.ElementsAs(ctx, &stateProperties, false)
-	if propertiesDiags.HasError() {
-		return propertiesDiags
-	}
-
-	properties := make(map[string]core.PropertyValue, len(stateProperties))
-	for key, value := range stateProperties {
-		if value.IsNull() {
-			properties[key] = core.NewPropertyValue("", false)
-		} else {
-			properties[key] = core.NewPropertyValue(value.ValueString(), false)
-		}
-	}
-
-	action.Properties = properties
 
 	return diag.Diagnostics{}
 }
 
-func mapProcessStepActionGitDependenciesFromState(ctx context.Context, state *schemas.ProcessStepResourceModel) ([]*gitdependencies.GitDependency, diag.Diagnostics) {
+func mapProcessStepActionGitDependenciesFromState(ctx context.Context, dependencies types.Map) ([]*gitdependencies.GitDependency, diag.Diagnostics) {
 	var dependenciesMap map[string]types.Object
-	diags := state.GitDependencies.ElementsAs(ctx, &dependenciesMap, false)
+	diags := dependencies.ElementsAs(ctx, &dependenciesMap, false)
 	if diags.HasError() {
 		return []*gitdependencies.GitDependency{}, diags
 	}
@@ -423,6 +369,111 @@ func mapProcessStepActionGitDependenciesFromState(ctx context.Context, state *sc
 	}
 
 	return gitDependencies, diags
+}
+
+func mapProcessStepActionPackagesFromState(ctx context.Context, statePackages types.Map, primaryPackage *schemas.ProcessStepPackageReferenceResourceModel) ([]*packages.PackageReference, map[string]core.PropertyValue, diag.Diagnostics) {
+	var packagesMap map[string]types.Object
+	diags := statePackages.ElementsAs(ctx, &packagesMap, false)
+	if diags.HasError() {
+		return []*packages.PackageReference{}, map[string]core.PropertyValue{}, diags
+	}
+
+	packageReferences := make([]*packages.PackageReference, 0)
+	primaryPackageProperties := make(map[string]core.PropertyValue)
+	if primaryPackage != nil {
+		primary, primaryDiags := mapPackageReferenceFromState(ctx, primaryPackage, "")
+		if primaryDiags.HasError() {
+			return []*packages.PackageReference{}, map[string]core.PropertyValue{}, primaryDiags
+		}
+
+		primaryPackageProperties["Octopus.Action.Package.PackageId"] = core.NewPropertyValue(primary.PackageID, false)
+		primaryPackageProperties["Octopus.Action.Package.FeedId"] = core.NewPropertyValue(primary.FeedID, false)
+		downloadOnTentacle := "False"
+		if primary.AcquisitionLocation == "ExecutionTarget" {
+			downloadOnTentacle = "True"
+		}
+		primaryPackageProperties["Octopus.Action.Package.DownloadOnTentacle"] = core.NewPropertyValue(downloadOnTentacle, false)
+
+		packageReferences = append(packageReferences, primary)
+	}
+
+	for key, packageObject := range packagesMap {
+		if packageObject.IsNull() {
+			continue
+		}
+
+		var packageState schemas.ProcessStepPackageReferenceResourceModel
+		diags = packageObject.As(ctx, &packageState, basetypes.ObjectAsOptions{})
+		if diags.HasError() {
+			return []*packages.PackageReference{}, map[string]core.PropertyValue{}, diags
+		}
+
+		var packageReference *packages.PackageReference
+		packageReference, diags = mapPackageReferenceFromState(ctx, &packageState, key)
+		if diags.HasError() {
+			return []*packages.PackageReference{}, map[string]core.PropertyValue{}, diags
+		}
+
+		packageReferences = append(packageReferences, packageReference)
+	}
+
+	return packageReferences, primaryPackageProperties, diag.Diagnostics{}
+}
+
+func mapPackageReferenceFromState(ctx context.Context, state *schemas.ProcessStepPackageReferenceResourceModel, key string) (*packages.PackageReference, diag.Diagnostics) {
+	packageProperties, diags := mapPackagePropertiesFromState(ctx, state)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	reference := &packages.PackageReference{
+		ID:                  state.GetID(),
+		Name:                key,
+		PackageID:           state.PackageID.ValueString(),
+		FeedID:              state.FeedID.ValueString(),
+		AcquisitionLocation: state.AcquisitionLocation.ValueString(),
+		Properties:          packageProperties,
+	}
+
+	return reference, diags
+}
+
+func mapPackagePropertiesFromState(ctx context.Context, state *schemas.ProcessStepPackageReferenceResourceModel) (map[string]string, diag.Diagnostics) {
+	stateProperties := make(map[string]types.String, len(state.Properties.Elements()))
+	diags := state.Properties.ElementsAs(ctx, &stateProperties, false)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	packageProperties := make(map[string]string, len(stateProperties))
+	for propertyKey, value := range stateProperties {
+		if value.IsNull() {
+			packageProperties[propertyKey] = ""
+		} else {
+			packageProperties[propertyKey] = value.ValueString()
+		}
+	}
+
+	return packageProperties, diags
+}
+
+func mapActionExecutionPropertiesFromState(ctx context.Context, executionProperties types.Map, computedProperties map[string]core.PropertyValue) (map[string]core.PropertyValue, diag.Diagnostics) {
+	stateProperties := make(map[string]types.String, len(executionProperties.Elements()))
+	diags := executionProperties.ElementsAs(ctx, &stateProperties, false)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	properties := make(map[string]core.PropertyValue)
+	for key, value := range computedProperties {
+		properties[key] = value
+	}
+
+	for key, value := range stateProperties {
+		properties[key] = util.ConvertToPropertyValue(value, false)
+	}
+
+	return properties, diags
 }
 
 func mapProcessStepToState(process processWrapper, step *deployments.DeploymentStep, state *schemas.ProcessStepResourceModel) diag.Diagnostics {
@@ -470,16 +521,12 @@ func mapProcessStepActionToState(action *deployments.DeploymentAction, state *sc
 	state.Channels = util.BuildStringSetOrEmpty(action.Channels)
 
 	state.GitDependencies = mapGitDependenciesToState(action.GitDependencies)
-	state.Packages = mapPackageReferencesToState(action.Packages)
+	state.PrimaryPackage, state.Packages = mapPackageReferencesToState(action.Packages)
 
-	stateProperties, diags := util.ConvertPropertiesToAttributeValuesMap(action.Properties)
-	if diags.HasError() {
-		return diags
-	}
+	diags := diag.Diagnostics{}
+	state.ExecutionProperties, diags = mapActionExecutionPropertiesToState(action.Properties)
 
-	state.ExecutionProperties = stateProperties
-
-	return diag.Diagnostics{}
+	return diags
 }
 
 func mapGitDependenciesToState(dependencies []*gitdependencies.GitDependency) types.Map {
@@ -517,14 +564,28 @@ func mapDeploymentActionContainerToState(container *deployments.DeploymentAction
 	}
 }
 
-func mapPackageReferencesToState(references []*packages.PackageReference) types.Map {
+func mapPackageReferencesToState(references []*packages.PackageReference) (*schemas.ProcessStepPackageReferenceResourceModel, types.Map) {
+	var primaryPackage *schemas.ProcessStepPackageReferenceResourceModel = nil
 	if references == nil {
-		return types.MapValueMust(schemas.ProcessStepPackageReferenceObjectType(), map[string]attr.Value{})
+		return primaryPackage, types.MapValueMust(schemas.ProcessStepPackageReferenceObjectType(), map[string]attr.Value{})
 	}
 
 	statePackages := make(map[string]attr.Value, len(references))
 	for _, packageReference := range references {
 		packageProperties := util.ConvertMapStringToMapAttrValue(packageReference.Properties)
+
+		// Primary package
+		if packageReference.Name == "" {
+			primaryPackage = &schemas.ProcessStepPackageReferenceResourceModel{
+				PackageID:           types.StringValue(packageReference.PackageID),
+				FeedID:              types.StringValue(packageReference.FeedID),
+				AcquisitionLocation: types.StringValue(packageReference.AcquisitionLocation),
+				Properties:          types.MapValueMust(types.StringType, packageProperties),
+			}
+			primaryPackage.ID = types.StringValue(packageReference.ID)
+			continue
+		}
+
 		statePackage := types.ObjectValueMust(
 			schemas.ProcessStepPackageReferenceAttributeTypes(),
 			map[string]attr.Value{
@@ -539,5 +600,34 @@ func mapPackageReferencesToState(references []*packages.PackageReference) types.
 		statePackages[packageReference.Name] = statePackage
 	}
 
-	return types.MapValueMust(schemas.ProcessStepPackageReferenceObjectType(), statePackages)
+	return primaryPackage, types.MapValueMust(schemas.ProcessStepPackageReferenceObjectType(), statePackages)
+}
+
+func mapActionExecutionPropertiesToState(properties map[string]core.PropertyValue) (types.Map, diag.Diagnostics) {
+	attributeValues := make(map[string]attr.Value)
+	for key, value := range properties {
+		if isReservedProperty(key) {
+			continue
+		}
+		attributeValues[key] = types.StringValue(value.Value)
+	}
+
+	valuesMap, diags := types.MapValue(types.StringType, attributeValues)
+	if diags.HasError() {
+		return types.MapNull(types.StringType), diags
+	}
+
+	return valuesMap, diags
+}
+
+// Properties which managed by other attributes
+var reservedExecutionProperties = map[string]struct{}{
+	"Octopus.Action.Package.FeedId":             {},
+	"Octopus.Action.Package.PackageId":          {},
+	"Octopus.Action.Package.DownloadOnTentacle": {},
+}
+
+func isReservedProperty(name string) bool {
+	_, exists := reservedExecutionProperties[name]
+	return exists
 }

--- a/octopusdeploy_framework/resource_process_templated_child_step.go
+++ b/octopusdeploy_framework/resource_process_templated_child_step.go
@@ -507,7 +507,7 @@ func mapProcessTemplatedChildStepActionToState(ctx context.Context, process proc
 	state.Channels = util.BuildStringSetOrEmpty(action.Channels)
 
 	state.GitDependencies = mapGitDependenciesToState(action.GitDependencies)
-	state.Packages = mapPackageReferencesToState(action.Packages)
+	_, state.Packages = mapPackageReferencesToState(action.Packages)
 
 	properties, diags := mapTemplatedActionPropertiesToState(ctx, template, action, state.Parameters, state.ExecutionProperties)
 	if diags.HasError() {

--- a/octopusdeploy_framework/resource_process_templated_step.go
+++ b/octopusdeploy_framework/resource_process_templated_step.go
@@ -534,7 +534,7 @@ func mapProcessTemplatedStepActionToState(ctx context.Context, action *deploymen
 	state.Channels = util.BuildStringSetOrEmpty(action.Channels)
 
 	state.GitDependencies = mapGitDependenciesToState(action.GitDependencies)
-	state.Packages = mapPackageReferencesToState(action.Packages)
+	_, state.Packages = mapPackageReferencesToState(action.Packages)
 
 	properties, diags := mapTemplatedActionPropertiesToState(ctx, template, action, state.Parameters, state.ExecutionProperties)
 	if diags.HasError() {

--- a/octopusdeploy_framework/schemas/process_child_step.go
+++ b/octopusdeploy_framework/schemas/process_child_step.go
@@ -103,6 +103,7 @@ func (p ProcessChildStepSchema) GetResourceSchema() resourceSchema.Schema {
 				Build(),
 			"container":        resourceActionContainerAttribute(),
 			"git_dependencies": resourceActionGitDependenciesAttribute(),
+			"primary_package":  resourceActionPrimaryPackageAttribute(),
 			"packages":         resourceActionPackageReferencesAttribute(),
 			"execution_properties": util.ResourceMap(types.StringType).
 				Description("A collection of step execution properties where the key is the property name and the value is its value.").
@@ -124,22 +125,23 @@ type ProcessChildStepResourceModel struct {
 	ParentID  types.String `tfsdk:"parent_id"`
 	Name      types.String `tfsdk:"name"`
 
-	Type                 types.String                     `tfsdk:"type"`
-	Slug                 types.String                     `tfsdk:"slug"`
-	IsDisabled           types.Bool                       `tfsdk:"is_disabled"`
-	IsRequired           types.Bool                       `tfsdk:"is_required"`
-	Condition            types.String                     `tfsdk:"condition"`
-	Notes                types.String                     `tfsdk:"notes"`
-	WorkerPoolID         types.String                     `tfsdk:"worker_pool_id"`
-	WorkerPoolVariable   types.String                     `tfsdk:"worker_pool_variable"`
-	TenantTags           types.Set                        `tfsdk:"tenant_tags"`
-	Environments         types.Set                        `tfsdk:"environments"`
-	ExcludedEnvironments types.Set                        `tfsdk:"excluded_environments"`
-	Channels             types.Set                        `tfsdk:"channels"`
-	Container            *ProcessStepActionContainerModel `tfsdk:"container"`
-	GitDependencies      types.Map                        `tfsdk:"git_dependencies"`
-	Packages             types.Map                        `tfsdk:"packages"`
-	ExecutionProperties  types.Map                        `tfsdk:"execution_properties"`
+	Type                 types.String                              `tfsdk:"type"`
+	Slug                 types.String                              `tfsdk:"slug"`
+	IsDisabled           types.Bool                                `tfsdk:"is_disabled"`
+	IsRequired           types.Bool                                `tfsdk:"is_required"`
+	Condition            types.String                              `tfsdk:"condition"`
+	Notes                types.String                              `tfsdk:"notes"`
+	WorkerPoolID         types.String                              `tfsdk:"worker_pool_id"`
+	WorkerPoolVariable   types.String                              `tfsdk:"worker_pool_variable"`
+	TenantTags           types.Set                                 `tfsdk:"tenant_tags"`
+	Environments         types.Set                                 `tfsdk:"environments"`
+	ExcludedEnvironments types.Set                                 `tfsdk:"excluded_environments"`
+	Channels             types.Set                                 `tfsdk:"channels"`
+	Container            *ProcessStepActionContainerModel          `tfsdk:"container"`
+	GitDependencies      types.Map                                 `tfsdk:"git_dependencies"`
+	PrimaryPackage       *ProcessStepPackageReferenceResourceModel `tfsdk:"primary_package"`
+	Packages             types.Map                                 `tfsdk:"packages"`
+	ExecutionProperties  types.Map                                 `tfsdk:"execution_properties"`
 
 	ResourceModel
 }

--- a/octopusdeploy_framework/schemas/process_child_step.go
+++ b/octopusdeploy_framework/schemas/process_child_step.go
@@ -110,6 +110,7 @@ func (p ProcessChildStepSchema) GetResourceSchema() resourceSchema.Schema {
 				Optional().
 				Computed().
 				DefaultEmpty().
+				Validators(warnAboutReservedExecutionProperties()).
 				Build(),
 		},
 	}

--- a/octopusdeploy_framework/schemas/process_step.go
+++ b/octopusdeploy_framework/schemas/process_step.go
@@ -124,6 +124,7 @@ func (p ProcessStepSchema) GetResourceSchema() resourceSchema.Schema {
 				Build(),
 			"container":        resourceActionContainerAttribute(),
 			"git_dependencies": resourceActionGitDependenciesAttribute(),
+			"primary_package":  resourceActionPrimaryPackageAttribute(),
 			"packages":         resourceActionPackageReferencesAttribute(),
 			"execution_properties": util.ResourceMap(types.StringType).
 				Description("A collection of step action properties where the key is the property name and the value is its value.").
@@ -148,21 +149,22 @@ type ProcessStepResourceModel struct {
 	Condition          types.String `tfsdk:"condition"`
 	Properties         types.Map    `tfsdk:"properties"`
 
-	Type                 types.String                     `tfsdk:"type"`
-	Slug                 types.String                     `tfsdk:"slug"`
-	IsDisabled           types.Bool                       `tfsdk:"is_disabled"`
-	IsRequired           types.Bool                       `tfsdk:"is_required"`
-	Notes                types.String                     `tfsdk:"notes"`
-	WorkerPoolID         types.String                     `tfsdk:"worker_pool_id"`
-	WorkerPoolVariable   types.String                     `tfsdk:"worker_pool_variable"`
-	TenantTags           types.Set                        `tfsdk:"tenant_tags"`
-	Environments         types.Set                        `tfsdk:"environments"`
-	ExcludedEnvironments types.Set                        `tfsdk:"excluded_environments"`
-	Channels             types.Set                        `tfsdk:"channels"`
-	Container            *ProcessStepActionContainerModel `tfsdk:"container"`
-	GitDependencies      types.Map                        `tfsdk:"git_dependencies"`
-	Packages             types.Map                        `tfsdk:"packages"`
-	ExecutionProperties  types.Map                        `tfsdk:"execution_properties"`
+	Type                 types.String                              `tfsdk:"type"`
+	Slug                 types.String                              `tfsdk:"slug"`
+	IsDisabled           types.Bool                                `tfsdk:"is_disabled"`
+	IsRequired           types.Bool                                `tfsdk:"is_required"`
+	Notes                types.String                              `tfsdk:"notes"`
+	WorkerPoolID         types.String                              `tfsdk:"worker_pool_id"`
+	WorkerPoolVariable   types.String                              `tfsdk:"worker_pool_variable"`
+	TenantTags           types.Set                                 `tfsdk:"tenant_tags"`
+	Environments         types.Set                                 `tfsdk:"environments"`
+	ExcludedEnvironments types.Set                                 `tfsdk:"excluded_environments"`
+	Channels             types.Set                                 `tfsdk:"channels"`
+	Container            *ProcessStepActionContainerModel          `tfsdk:"container"`
+	GitDependencies      types.Map                                 `tfsdk:"git_dependencies"`
+	PrimaryPackage       *ProcessStepPackageReferenceResourceModel `tfsdk:"primary_package"`
+	Packages             types.Map                                 `tfsdk:"packages"`
+	ExecutionProperties  types.Map                                 `tfsdk:"execution_properties"`
 
 	ResourceModel
 }
@@ -172,58 +174,9 @@ type ProcessStepActionContainerModel struct {
 	Image  types.String `tfsdk:"image"`
 }
 
-type ProcessStepPackageReferenceResourceModel struct {
-	PackageID           types.String `tfsdk:"package_id"`
-	FeedID              types.String `tfsdk:"feed_id"`
-	AcquisitionLocation types.String `tfsdk:"acquisition_location"`
-	Properties          types.Map    `tfsdk:"properties"`
-
-	ResourceModel
-}
-
-type ProcessStepGitDependencyResourceModel struct {
-	RepositoryUri     types.String `tfsdk:"repository_uri"`
-	DefaultBranch     types.String `tfsdk:"default_branch"`
-	GitCredentialType types.String `tfsdk:"git_credential_type"`
-	FilePathFilters   types.Set    `tfsdk:"file_path_filters"`
-	GitCredentialID   types.String `tfsdk:"git_credential_id"`
-}
-
-func ProcessStepPackageReferenceObjectType() types.ObjectType {
-	return types.ObjectType{
-		AttrTypes: ProcessStepPackageReferenceAttributeTypes(),
-	}
-}
-
-func ProcessStepPackageReferenceAttributeTypes() map[string]attr.Type {
-	return map[string]attr.Type{
-		"id":                   types.StringType,
-		"package_id":           types.StringType,
-		"feed_id":              types.StringType,
-		"acquisition_location": types.StringType,
-		"properties":           types.MapType{ElemType: types.StringType},
-	}
-}
-
-func ProcessStepGitDependencyObjectType() types.ObjectType {
-	return types.ObjectType{
-		AttrTypes: ProcessStepGitDependencyAttributeTypes(),
-	}
-}
-
-func ProcessStepGitDependencyAttributeTypes() map[string]attr.Type {
-	return map[string]attr.Type{
-		"repository_uri":      types.StringType,
-		"default_branch":      types.StringType,
-		"git_credential_type": types.StringType,
-		"file_path_filters":   types.SetType{ElemType: types.StringType},
-		"git_credential_id":   types.StringType,
-	}
-}
-
 func resourceActionContainerAttribute() resourceSchema.SingleNestedAttribute {
 	return resourceSchema.SingleNestedAttribute{
-		Description: "When set used to run step inside a container on the Octopus Server. Octopus Server must support container execution.",
+		Description: "When set, used to run step inside a container on the Octopus Server. Octopus Server must support container execution.",
 		Attributes: map[string]resourceSchema.Attribute{
 			"feed_id": util.ResourceString().
 				Description("Feed where the container will be pulled from.").
@@ -248,6 +201,107 @@ func resourceActionContainerAttribute() resourceSchema.SingleNestedAttribute {
 				},
 			),
 		),
+	}
+}
+
+func resourceActionPrimaryPackageAttribute() resourceSchema.SingleNestedAttribute {
+	return resourceSchema.SingleNestedAttribute{
+		Description: "Primary package of the step",
+		Attributes:  resourceActionPackageReferenceAttributes(),
+		Optional:    true,
+	}
+}
+
+type ProcessStepPackageReferenceResourceModel struct {
+	PackageID           types.String `tfsdk:"package_id"`
+	FeedID              types.String `tfsdk:"feed_id"`
+	AcquisitionLocation types.String `tfsdk:"acquisition_location"`
+	Properties          types.Map    `tfsdk:"properties"`
+
+	ResourceModel
+}
+
+func ProcessStepPackageReferenceObjectType() types.ObjectType {
+	return types.ObjectType{
+		AttrTypes: ProcessStepPackageReferenceAttributeTypes(),
+	}
+}
+
+func ProcessStepPackageReferenceAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"id":                   types.StringType,
+		"package_id":           types.StringType,
+		"feed_id":              types.StringType,
+		"acquisition_location": types.StringType,
+		"properties":           types.MapType{ElemType: types.StringType},
+	}
+}
+
+func resourceActionPackageReferencesAttribute() resourceSchema.MapNestedAttribute {
+	return resourceSchema.MapNestedAttribute{
+		Description:  "Package references associated with this step where key is a name of the package reference (use empty name for primary package)",
+		Optional:     true,
+		Computed:     true,
+		Default:      mapdefault.StaticValue(types.MapValueMust(ProcessStepPackageReferenceObjectType(), map[string]attr.Value{})),
+		NestedObject: resourceActionPackageReferenceNestedAttribute(),
+	}
+}
+
+func resourceActionPackageReferenceNestedAttribute() resourceSchema.NestedAttributeObject {
+	return resourceSchema.NestedAttributeObject{
+		Attributes: resourceActionPackageReferenceAttributes(),
+	}
+}
+
+func resourceActionPackageReferenceAttributes() map[string]resourceSchema.Attribute {
+	return map[string]resourceSchema.Attribute{
+		"id": GetIdResourceSchema(),
+		"package_id": util.ResourceString().
+			Description("Package ID or a variable-expression").
+			Required().
+			Build(),
+		"feed_id": util.ResourceString().
+			Description("The feed ID associated with this package reference").
+			Optional().
+			Computed().
+			Default("feeds-builtin").
+			Build(),
+		"acquisition_location": util.ResourceString().
+			Description("Whether to acquire this package on the server ('Server'), target ('ExecutionTarget') or not at all ('NotAcquired'). Can be an expression").
+			Optional().
+			Computed().
+			Default("Server").
+			Build(),
+		"properties": util.ResourceMap(types.StringType).
+			Description("A collection of properties associated with this package").
+			Optional().
+			Computed().
+			DefaultEmpty().
+			Build(),
+	}
+}
+
+type ProcessStepGitDependencyResourceModel struct {
+	RepositoryUri     types.String `tfsdk:"repository_uri"`
+	DefaultBranch     types.String `tfsdk:"default_branch"`
+	GitCredentialType types.String `tfsdk:"git_credential_type"`
+	FilePathFilters   types.Set    `tfsdk:"file_path_filters"`
+	GitCredentialID   types.String `tfsdk:"git_credential_id"`
+}
+
+func ProcessStepGitDependencyObjectType() types.ObjectType {
+	return types.ObjectType{
+		AttrTypes: ProcessStepGitDependencyAttributeTypes(),
+	}
+}
+
+func ProcessStepGitDependencyAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"repository_uri":      types.StringType,
+		"default_branch":      types.StringType,
+		"git_credential_type": types.StringType,
+		"file_path_filters":   types.SetType{ElemType: types.StringType},
+		"git_credential_id":   types.StringType,
 	}
 }
 
@@ -287,46 +341,6 @@ func resourceActionGitDependencyNestedAttribute() resourceSchema.NestedAttribute
 				Optional().
 				Computed().
 				Default("").
-				Build(),
-		},
-	}
-}
-
-func resourceActionPackageReferencesAttribute() resourceSchema.MapNestedAttribute {
-	return resourceSchema.MapNestedAttribute{
-		Description:  "Package references associated with this step where key is a name of the package reference (use empty name for primary package)",
-		Optional:     true,
-		Computed:     true,
-		Default:      mapdefault.StaticValue(types.MapValueMust(ProcessStepPackageReferenceObjectType(), map[string]attr.Value{})),
-		NestedObject: resourceActionPackageReferenceNestedAttribute(),
-	}
-}
-
-func resourceActionPackageReferenceNestedAttribute() resourceSchema.NestedAttributeObject {
-	return resourceSchema.NestedAttributeObject{
-		Attributes: map[string]resourceSchema.Attribute{
-			"id": GetIdResourceSchema(),
-			"package_id": util.ResourceString().
-				Description("Package ID or a variable-expression").
-				Required().
-				Build(),
-			"feed_id": util.ResourceString().
-				Description("The feed ID associated with this package reference").
-				Optional().
-				Computed().
-				Default("feeds-builtin").
-				Build(),
-			"acquisition_location": util.ResourceString().
-				Description("Whether to acquire this package on the server ('Server'), target ('ExecutionTarget') or not at all ('NotAcquired'). Can be an expression").
-				Optional().
-				Computed().
-				Default("Server").
-				Build(),
-			"properties": util.ResourceMap(types.StringType).
-				Description("A collection of properties associated with this package").
-				Optional().
-				Computed().
-				DefaultEmpty().
 				Build(),
 		},
 	}

--- a/octopusdeploy_framework/schemas/process_step.go
+++ b/octopusdeploy_framework/schemas/process_step.go
@@ -131,6 +131,7 @@ func (p ProcessStepSchema) GetResourceSchema() resourceSchema.Schema {
 				Optional().
 				Computed().
 				DefaultEmpty().
+				Validators(warnAboutReservedExecutionProperties()).
 				Build(),
 		},
 	}

--- a/octopusdeploy_framework/schemas/process_step_reserved_execution_properties_validator.go
+++ b/octopusdeploy_framework/schemas/process_step_reserved_execution_properties_validator.go
@@ -1,0 +1,62 @@
+package schemas
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type reservedExecutionPropertiesValidator struct{}
+
+func (v reservedExecutionPropertiesValidator) Description(ctx context.Context) string {
+	return "execution properties must not contain reserved properties"
+}
+
+func (v reservedExecutionPropertiesValidator) MarkdownDescription(ctx context.Context) string {
+	return "execution properties must not contain automatically generated properties or properties maintained by other attributes"
+}
+
+func (v reservedExecutionPropertiesValidator) ValidateMap(ctx context.Context, req validator.MapRequest, resp *validator.MapResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	properties := make(map[string]types.String, len(req.ConfigValue.Elements()))
+	diags := req.ConfigValue.ElementsAs(ctx, &properties, false)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
+	for key, _ := range properties {
+		if warning, reserved := reservedExecutionProperties[key]; reserved {
+			detail := fmt.Sprintf("This property managed automatically by the Octopus Deploy provider.\nAvoid configuring it manually as this can lead to discrepancies between planned and applied configurations, potentially causing unexpected behavior or drift.\n%s", warning.Suggestion)
+			resp.Diagnostics.AddAttributeWarning(
+				req.Path.AtMapKey(key),
+				fmt.Sprintf("Process step execution property %q is reserved", key),
+				detail,
+			)
+		}
+	}
+}
+
+func warnAboutReservedExecutionProperties() validator.Map {
+	return &reservedExecutionPropertiesValidator{}
+}
+
+type reservedExecutionPropertyWarning struct {
+	Suggestion string
+}
+
+// Properties which managed by other attributes
+var reservedExecutionProperties = map[string]reservedExecutionPropertyWarning{
+	"Octopus.Action.Package.FeedId":             {Suggestion: "Consider to use 'primary_package' attribute to configure it's value"},
+	"Octopus.Action.Package.PackageId":          {Suggestion: "Consider to use 'primary_package' attribute to configure it's value"},
+	"Octopus.Action.Package.DownloadOnTentacle": {Suggestion: "Consider to use 'primary_package' attribute to configure it's value"},
+}
+
+func IsReservedExecutionProperty(name string) bool {
+	_, exists := reservedExecutionProperties[name]
+	return exists
+}

--- a/octopusdeploy_framework/schemas/process_templated_child_step.go
+++ b/octopusdeploy_framework/schemas/process_templated_child_step.go
@@ -148,6 +148,7 @@ func (p ProcessTemplatedChildStepSchema) GetResourceSchema() resourceSchema.Sche
 				Optional().
 				Computed().
 				DefaultEmpty().
+				Validators(warnAboutReservedExecutionProperties()).
 				Build(),
 		},
 	}

--- a/octopusdeploy_framework/schemas/process_templated_step.go
+++ b/octopusdeploy_framework/schemas/process_templated_step.go
@@ -166,6 +166,7 @@ func (p ProcessTemplatedStepSchema) GetResourceSchema() resourceSchema.Schema {
 				Optional().
 				Computed().
 				DefaultEmpty().
+				Validators(warnAboutReservedExecutionProperties()).
 				Build(),
 		},
 	}


### PR DESCRIPTION
`primary_package` is special case in set of packages of process action. For package to be considered as primary package it's key should be an empty string `""`, Server will automatically add "legacy" properties to the set of action properties, which can lead to state conflicts between planned and applied terraform configurations

Primary package wraps this logic into dedicated attribute and make sure that automatically generated property will not cause state drift issues

```terraform
resource "octopusdeploy_process_step" "one" {
    process_id = octopusdeploy_process.app.id
    name = "One"
    condition = "Success"
    type = "Octopus.Script"
    is_required = true
    is_disabled = false
    execution_properties = {
        "Octopus.Action.Script.ScriptSource" = "Package"
        "Octopus.Action.Script.ScriptFileName" = "Console.exe"
        "Octopus.Action.EnabledFeatures" = "Octopus.Features.SubstituteInFiles"
        "Octopus.Action.SubstituteInFiles.Enabled"  = "True"
        "Octopus.Action.RunOnServer" = "True"
    }

    primary_package = {
      package_id = "math.console"
      feed_id = module.predefined.feeds.built_in
      acquisition_location = "Server"
    }
    
    packages = {
        "extra_package": {
            package_id = "extra.console"
            feed_id = module.predefined.feeds.built_in
            acquisition_location = "Server"
        }
    }
}
```