### PR TITLE
Fix container registry resource "oidc_authentication" examples

### DIFF
--- a/docs/resources/azure_container_registry.md
+++ b/docs/resources/azure_container_registry.md
@@ -23,7 +23,7 @@ resource "octopusdeploy_azure_container_registry" "example" {
 resource "octopusdeploy_azure_container_register" "example_with_oidc" {
     name          = "Test Azure Container Registry (OK to Delete)"
     feed_uri      = "https://test-azure.azurecr.io"
-    oidc_authentication {
+    oidc_authentication = {
       client_id     = "client_id"
       tenant_id     = "tenant_id"
       audience      = "audience"

--- a/docs/resources/google_container_registry.md
+++ b/docs/resources/google_container_registry.md
@@ -24,7 +24,7 @@ resource "octopusdeploy_google_container_registry" "example_with_oidc" {
   name          = "Test Google Container Registry (OK to Delete)"
   feed_uri      = "https://google.docker.test"
   registry_path = "testing/test-image"
-  oidc_authentication {
+  oidc_authentication = {
     audience      = "audience"
     subject_keys = ["feed", "space"]
   }

--- a/examples/resources/octopusdeploy_azure_container_registry/resource.tf
+++ b/examples/resources/octopusdeploy_azure_container_registry/resource.tf
@@ -8,7 +8,7 @@ resource "octopusdeploy_azure_container_registry" "example" {
 resource "octopusdeploy_azure_container_register" "example_with_oidc" {
     name          = "Test Azure Container Registry (OK to Delete)"
     feed_uri      = "https://test-azure.azurecr.io"
-    oidc_authentication {
+    oidc_authentication = {
       client_id     = "client_id"
       tenant_id     = "tenant_id"
       audience      = "audience"

--- a/examples/resources/octopusdeploy_google_container_registry/resource.tf
+++ b/examples/resources/octopusdeploy_google_container_registry/resource.tf
@@ -9,7 +9,7 @@ resource "octopusdeploy_google_container_registry" "example_with_oidc" {
   name          = "Test Google Container Registry (OK to Delete)"
   feed_uri      = "https://google.docker.test"
   registry_path = "testing/test-image"
-  oidc_authentication {
+  oidc_authentication = {
     audience      = "audience"
     subject_keys = ["feed", "space"]
   }


### PR DESCRIPTION
# Overview

Usage examples for the new `oidc_authentication` attribute appear to incorrectly show it as a `SingleNestedBlock` type rather than a `SingleNestedAttribute` as described by the underlying resource schemas:

- [octopusdeploy_azure_container_registry](https://registry.terraform.io/providers/OctopusDeployLabs/octopusdeploy/latest/docs/resources/azure_container_registry#nestedatt--oidc_authentication)
- [octopusdeploy_google_container_registry](https://registry.terraform.io/providers/OctopusDeployLabs/octopusdeploy/latest/docs/resources/google_container_registry#nestedatt--oidc_authentication)

Interestingly, the usage examples for [octopusdeploy_aws_elastic_container_registry](https://registry.terraform.io/providers/OctopusDeployLabs/octopusdeploy/latest/docs/resources/aws_elastic_container_registry#oidc_authentication-2) appear to be true-to-schema.

# Reproduction

Minimal workspace that reproduces the schema errors upon `terraform validate` - though the current examples listed on registry pages also work:

```terraform
terraform {
  required_providers {
    octopusdeploy = {
      source  = "octopusdeploylabs/octopusdeploy"
      version = "= 0.43.2"
    }
  }
}

provider "octopusdeploy" {}

resource "octopusdeploy_azure_container_registry" "test" {
  name     = "test"
  feed_uri = "test"

  oidc_authentication {
    tenant_id = "00000000-0000-0000-0000-000000000000"
    client_id = "00000000-0000-0000-0000-000000000000"
    audience  = "api://AzureADTokenExchange"
    subject_keys = [
      "space",
      "feed"
    ]
  }
}

resource "octopusdeploy_google_container_registry" "test" {
  name     = "test"
  feed_uri = "test"

  oidc_authentication {
    audience = "test"
    subject_keys = [
      "space",
      "feed"
    ]
  }
}
```

Resultant validation errors:

![image](https://github.com/user-attachments/assets/eb3969fd-3684-49b1-97eb-527a2eff5d94)
