### PR TITLE
Update warning around this version of the provider no longer being maintained

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,10 +7,9 @@ description: |-
 
 # octopusdeploy Provider
 
-## Warning
+## ⚠️ Warning ⚠️
 
-> This provider has been moved under the namespace OctopusDeploy, the provider under OctopusDeployLabs is no longer maintained.
-> Please read *0. Moving to Octopus Deploy Namespace* under the guides subcategory to learn how to upgrade your provider while maintaining state.
+!> Since 1st June 2025, the Octopus Deploy Terraform Provider has moved to the [OctopusDeploy namespace](https://registry.terraform.io/providers/OctopusDeploy/octopusdeploy/latest/docs), and this version is no longer being maintained. If you were previously using this version of the provider, please read the guide for [Moving to Octopus Deploy Namespace](https://registry.terraform.io/providers/OctopusDeployLabs/octopusdeploy/latest/docs/guides/0-moving-to-cctopus-deploy-namespace) to learn how to upgrade your provider while maintaining state.
 
 ## Overview
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -7,10 +7,9 @@ description: |-
 
 # {{.ProviderShortName}} Provider
 
-## Warning
+## ⚠️ Warning ⚠️
 
-> This provider has been moved under the namespace OctopusDeploy, the provider under OctopusDeployLabs is no longer maintained.
-> Please read *0. Moving to Octopus Deploy Namespace* under the guides subcategory to learn how to upgrade your provider while maintaining state.
+!> Since 1st June 2025, the Octopus Deploy Terraform Provider has moved to the [OctopusDeploy namespace](https://registry.terraform.io/providers/OctopusDeploy/octopusdeploy/latest/docs), and this version is no longer being maintained. If you were previously using this version of the provider, please read the guide for [Moving to Octopus Deploy Namespace](https://registry.terraform.io/providers/OctopusDeployLabs/octopusdeploy/latest/docs/guides/0-moving-to-cctopus-deploy-namespace) to learn how to upgrade your provider while maintaining state.
 
 ## Overview
 


### PR DESCRIPTION
The warning wasn't super clear, and there weren't links off to the right place to be to help guide towards the new TFP.

This adds links to the new v1.0 TFP, the migration guide for keeping state. It updates the wording a little bit.

I've used `!>` which isn't standard markdown, but apparently it will create a warning block for us: https://developer.hashicorp.com/terraform/registry/providers/docs#callouts 

We'll see if it actually works, otherwise I'll try a different block in a follow up PR. 

[[sc-131719](https://app.shortcut.com/octopusdeploy/story/131719/sev-3-warning-message-visibility-on-the-octopuslabs-terraform-provider-could-be-improved-requested-by-britton-riggs)]